### PR TITLE
Extend zero duration handling for floats

### DIFF
--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -707,7 +707,7 @@ function parseStatus($resp) {
 			$array['time'] = '0';
 		}
 		// radio, upnp
-		elseif (!isset($array['duration'])) {
+		elseif (!isset($array['duration']) || $array['duration'] == 0) {
 			$percent = '0';
 			$array['elapsed'] = $time[0];
 			$array['time'] = $time[1];


### PR DESCRIPTION
In some cases the duration will be set to 0.00 (float) value which results
in a infinity float for the duration fields.

The check for the zero duration will be extended to not only check if the
field is present, instead it will also check if the value is zero.

In some cases, especially when playing a stream, the duration was set to
0.0 which was producing JavaScript errors and the UI was not usable anymore.
