### PR TITLE
Handle JSON encoding errors in engine-mpd and show then in UI

### DIFF
--- a/www/engine-mpd.php
+++ b/www/engine-mpd.php
@@ -99,6 +99,11 @@ debugLog('engine-mpd: Metadata returned to client: Size=(' . sizeof($current) . 
 // TEST I don't think this is needed
 //header('Access-Control-Allow-Origin: *');
 
-echo json_encode($current);
+$current_json = json_encode($current);
+if ($current_json === FALSE) {
+  echo json_encode(array('error' => array('code' => json_last_error(), 'message' => json_last_error_msg())));
+} else {
+  echo $current_json;
+}
 
 closeMpdSock($sock);

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -343,8 +343,12 @@ function engineMpd() {
 			else {
 				debugLog('engineMpd: success branch: error=(' + MPD.json['error'] + '), module=(' + MPD.json['module'] + ')');
 
+				// JSON encoding errors
+				if (typeof(MPD.json['error']) == 'object') {
+					notify('mpderror', 'JSON encode error: ' + MPD.json['error']['message'] + ' (' + MPD.json['error']['code'] + ')');
+				}
 				// mpd bug may have been fixed in 0.20.20 ?
-				if (MPD.json['error'] == 'Not seekable') {					
+				else if (MPD.json['error'] == 'Not seekable') {
 					// nop
 				}
 				// MPD output --> Bluetooth but no actual BT connection


### PR DESCRIPTION
The engine-mpd.php will generate a error structure in case an error happens
while encoding/generating the JSON response data (e.g. due to invalid
values which can not be encoded, like NaN or Infinity values).

In the UI this case of error is now checked and handled to show an error
notify to the user. This includes the JSON error message and JSON error code
for easier debugging/fixing.

In some cases it could happen that the generated data which should be converted
to JSON contains some invalid values (as mentioned above). Usually this should not
happen, but if the user will see the error.
