### PR TITLE
Versioned resource files

### DIFF
--- a/var/local/www/header.php
+++ b/var/local/www/header.php
@@ -45,18 +45,19 @@
 
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0 user-scalable=no">
-	
-	<link href="css/bootstrap.min.css" rel="stylesheet">
-	<link href="cssw/bootstrap-select.css" rel="stylesheet">
-	<link href="cssw/flat-ui.css" rel="stylesheet">
-	<link href="css/fontawesome-moode.css" rel="stylesheet">
+
+<!-- versioned resources -->
+        <?php versioned_resource ('css/bootstrap.min.css'); ?>
+        <?php versioned_resource ('cssw/bootstrap-select.css'); ?>
+        <?php versioned_resource ('cssw/flat-ui.css'); ?>
+        <?php versioned_resource ('css/fontawesome-moode.css'); ?>
 	<?php if ($section == 'index') { ?>
-		<link href="css/jquery.countdown.css" rel="stylesheet">
+		<?php echo versioned_resource ('css/jquery.countdown.css'); ?>
 	<?php } ?>
-	<link href="css/jquery.pnotify.default.css" rel="stylesheet">
-	<link href="cssw/panels.css" rel="stylesheet">
-	<link href="css/moode.css" rel="stylesheet">
 	
+       <?php versioned_resource ('css/jquery.pnotify.default.css'); ?>
+       <?php versioned_resource ('cssw/panels.css'); ?>
+       <?php versioned_resource ('css/moode.css'); ?>
 	<!-- Apple -->
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<link rel="apple-touch-icon" sizes="180x180" href="/v5-apple-touch-icon.png">

--- a/var/local/www/header.php
+++ b/var/local/www/header.php
@@ -47,17 +47,18 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0 user-scalable=no">
 
 <!-- versioned resources -->
-        <?php versioned_resource ('css/bootstrap.min.css'); ?>
-        <?php versioned_resource ('cssw/bootstrap-select.css'); ?>
-        <?php versioned_resource ('cssw/flat-ui.css'); ?>
-        <?php versioned_resource ('css/fontawesome-moode.css'); ?>
-	<?php if ($section == 'index') { ?>
-		<?php echo versioned_resource ('css/jquery.countdown.css'); ?>
-	<?php } ?>
-	
-       <?php versioned_resource ('css/jquery.pnotify.default.css'); ?>
-       <?php versioned_resource ('cssw/panels.css'); ?>
-       <?php versioned_resource ('css/moode.css'); ?>
+	<?php
+	versioned_resource ('css/bootstrap.min.css');
+	versioned_resource ('cssw/bootstrap-select.css');
+	versioned_resource ('cssw/flat-ui.css');
+	versioned_resource ('css/fontawesome-moode.css');
+	if ($section == 'index') {
+		versioned_resource ('css/jquery.countdown.css');
+	}
+	versioned_resource ('css/jquery.pnotify.default.css');
+	versioned_resource ('cssw/panels.css');
+	versioned_resource ('css/moode.css');
+	?>
 	<!-- Apple -->
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<link rel="apple-touch-icon" sizes="180x180" href="/v5-apple-touch-icon.png">

--- a/www/footer.php
+++ b/www/footer.php
@@ -889,9 +889,7 @@ versioned_script('js/jquery.md5.js');
 	versioned_script('js/application.js');
 	versioned_script('js/jquery.pnotify.min.js');
 	versioned_script('js/scripts-configs.js');
-}
-
-?>
+} ?>
 
 <!-- DISPLAY MESSAGES -->
 <?php if (isset($_SESSION['notify']) && $_SESSION['notify'] != '') {

--- a/www/footer.php
+++ b/www/footer.php
@@ -855,37 +855,43 @@
 </div>
 
 <!-- FRAMEWORK LIBS -->
-<script src="js/jquery-1.8.2.min.js"></script>
-<script src="js/jquery-ui-1.10.0.custom.min.js"></script>
-<script src="js/jquery.countdown.js"></script>
-<script src="js/jquery.scrollTo.min.js"></script>
-<script src="js/bootstrap.min.js"></script>
-<script src="js/bootstrap-select.min.js"></script>
+<?php
+versioned_script('js/jquery-1.8.2.min.js');
+versioned_script('js/jquery-ui-1.10.0.custom.min.js');
+versioned_script('js/jquery.countdown.js');
+versioned_script('js/jquery.scrollTo.min.js');
+versioned_script('js/bootstrap.min.js');
+versioned_script('js/bootstrap-select.min.js');
+?>
 <!-- MOODE LIBS -->
-<script src="js/jquery.adaptive-backgrounds.js"></script>
-<script src="js/notify.js"></script>
-<script src="js/playerlib.js"></script>
-<script src="js/links.js"></script>
-<script src="js/jquery.touchSwipe.min.js"></script>
-<script src="js/jquery.lazyload.js"></script>
-<script src="js/jquery.md5.js"></script>
+<?php
+versioned_script('js/jquery.adaptive-backgrounds.js');
+versioned_script('js/notify.js');
+versioned_script('js/playerlib.js');
+versioned_script('js/links.js');
+versioned_script('js/jquery.touchSwipe.min.js');
+versioned_script('js/jquery.lazyload.js');
+versioned_script('js/jquery.md5.js');
+?>
 
 <!-- LIBS FOR PANELS OR CONFIGS -->
-<?php if ($section == 'index') { ?>
-	<script src="jsw/jquery.knob.js"></script>
-	<script src="js/bootstrap-contextmenu.js"></script>
-	<script src="js/jquery.pnotify.min.js"></script>
-	<script src="js/scripts-panels.js"></script>
-<?php } else { ?>
-	<script src="js/custom_checkbox_and_radio.js"></script>
-	<script src="js/custom_radio.js"></script>
-	<script src="js/jquery.tagsinput.js"></script>
-	<script src="js/jquery.placeholder.js"></script>
-	<script src="js/i18n/_messages.en.js" type="text/javascript"></script>
-	<script src="js/application.js"></script>
-	<script src="js/jquery.pnotify.min.js"></script>
-	<script src="js/scripts-configs.js"></script>
-<?php } ?>
+<?php if ($section == 'index') {
+	versioned_script('jsw/jquery.knob.js');
+	versioned_script('js/bootstrap-contextmenu.js');
+	versioned_script('js/jquery.pnotify.min.js');
+	versioned_script('js/scripts-panels.js');
+} else {
+	versioned_script('js/custom_checkbox_and_radio.js');
+	versioned_script('js/custom_radio.js');
+	versioned_script('js/jquery.tagsinput.js');
+	versioned_script('js/jquery.placeholder.js');
+	versioned_script('js/i18n/_messages.en.js', 'text/javascript');
+	versioned_script('js/application.js');
+	versioned_script('js/jquery.pnotify.min.js');
+	versioned_script('js/scripts-configs.js');
+}
+
+?>
 
 <!-- DISPLAY MESSAGES -->
 <?php if (isset($_SESSION['notify']) && $_SESSION['notify'] != '') {

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -247,6 +247,27 @@ if (phpVer() == '5.3') {
 	}
 }
 
+// Helper functions for html generation
+
+function versioned_resource ($file, $type='stylesheet') {
+	// could get this from master config, or by hashing each file. Hard coded as proof of concept.
+	$resourcetag = '4.4.x';
+	$version_indicator = '?v=';
+	$tagged_link = '<link href="' . $file . $version_indicator . $resourcetag . '"  rel="' . $type .'">';
+	echo $tagged_link . "\n";
+}
+function versioned_script ($file, $type='') {
+	// could get this from master config, or by hashing each file. Hard coded as proof of concept.
+	$resourcetag = '4.4.x';
+	$version_indicator = '?v=';
+	$tagged_src = '<script src="' . $file . $version_indicator . $resourcetag . '"';
+	if ($type != '' ) {
+		$tagged_src .= ' type="' . $type . '"';
+	}
+	$tagged_src .= '></script>';
+	echo $tagged_src . "\n";
+}
+
 // socket routines for engine-cmd.php
 function sendEngCmd ($cmd) {
 	//workerLog('sendCmd(): Reading in portfile');


### PR DESCRIPTION
Hi Tim,

I had an issue after changing a system from 4.0b12 to 4.4 with a clean/new install.  Browser would not display pages until I cleared the browser cache.  After solving the problem by clearing the cache, I notice that someone in the forums had the same issue.

Attached fix provides **a** way of adding some versioning data to the .css and .js files, so that they will be treated as static, but updated with new releases.

I'm not a PHP person... so there might be better recipes for doing this...   The function code was added into playerlib.php. Not sure if that is the best spot for it, but that file is included at the top level, so was the most straight forward. (Is there another file for html helper code?). 

Also, the functions have hard-coded version strings that have to be maintained individually (uggg!). Best approach would be to pull version from config DB.  Rather than wait until I figure out how to pull that data, I thought I'd get this PR submitted, so it could be considered for the upcoming release. 

It may need some rework to be properly integrated. But figure I would through this out for consideration since the bug it fixes is related to consequences of upgrade.

Change, as coded, does produce pages that are as expected. (Unchanged, except for the addition of a version tag to the .css and .js resources in header.php and footer.php respectively). Once in place, a browser that was previously choking on opening the site (because it still had resource files cached) was able to cleanly load the site.

~paul