### PR TITLE
Changed README.md to use relative URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ moOde provides a beautifully designed and responsive user interface, an extensiv
 
 Tim Curtis © 2014
 
-Release notes https://github.com/moode-player/moode/blob/develop/www/relnotes.txt<br>
-Setup guide: https://github.com/moode-player/moode/blob/develop/www/setup.txt<br>
-Contributors: https://github.com/moode-player/moode/blob/develop/www/CONTRIBS.html<br>
+[Release notes: ./www/relnotes.txt](./www/relnotes.txt)<br/>
+[Setup guide: ./www/setup.txt](./www/setup.txt)<br/>
+[Contributors: ./www/CONTRIBS.html](./www/CONTRIBS.html)<br/>
+
 
 ## Other Resources
-Raspberry Pi: https://github.com/raspberrypi<br>
-Raspbian: https://www.raspbian.org/RaspbianRepository<br>
-Moode OS Builder: https://github.com/moode-player/mosbuild<br>
-moodeaudio.org: http://moodeaudio.org<br>
+Raspberry Pi: https://github.com/raspberrypi<br/>
+Raspbian: https://www.raspbian.org/RaspbianRepository<br/>
+Moode OS Builder: https://github.com/moode-player/mosbuild<br/>
+moodeaudio.org: http://moodeaudio.org<br/>
 moOde Twitter feed: http://twitter.com/MoodeAudio


### PR DESCRIPTION
Using relative URLs allows the links to work correctly in different branches, as well as in forked repositories.

Also added a slash to the br tags, to make them self closing -not that it really matters in markdown...