### PR TITLE
Correct the placement of the Cue Icon

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -454,6 +454,11 @@ li.modal-dropdown-text:focus {color:#eee;}
 .info-toggle {text-decoration:none;margin-left:5px;font-size:18px;}
 .quickhelp {margin-left:0;color:#333;font-size:1em;font-weight:500;}
 .set-button {margin: 0 4px 0 8px;} /* for system config page 'set' buttons */
+
+/* for icon placement in file browse panel */
+a.btn i.sx { float:left;}
+/* TODO - there are some icons that are placed by javascript style, but could be done using css */
+
 /* playback history log */
 #container-playhistory {padding-top:5px;padding-left: 5px;}
 ol.playhistory {margin-left:55px;}


### PR DESCRIPTION
Not sure what the sx tag for images relates to.  Think this might make more sense if all of the images for db browsing were tagged with db-browse, but that is currently inconsistent.  If this (or something similar) is appropriate, then a lot of the 'float:left' in the javascript can be removed.