### PR TITLE
Chrome on Windows 10 display issues in 5.3.1 (may have started with 5.2)

### DIFF
--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -3738,7 +3738,7 @@ function getCSSRule(ruleName) {
 	for (var i = 0; i < document.styleSheets.length; i++) {
 		var styleSheet = document.styleSheets[i];
 
-		if (styleSheet.href.indexOf('flat-ui.css') != -1 ) {
+		if (styleSheet.href && styleSheet.href.indexOf('flat-ui.css') != -1 ) {
 			var cssRules = styleSheet.cssRules;
 			for (var j = 0; j < cssRules.length; j++) {
 				var cssRule = cssRules[j];


### PR DESCRIPTION
Chrome throws console error, and display is mostly blank when there is a stylesheet without href.

There is a bit of playerlib.js that iterates over stylesheets. At that point Chrome throws a console error, and most of the display is blank/unusable. Not sure why there is a stylesheet without href, but this code provides a defensive measure against that case.

Firefox did not have an issue.