### PR TITLE
Gpio buttons py23

### DIFF
--- a/www/command/gpio-buttons.py
+++ b/www/command/gpio-buttons.py
@@ -46,72 +46,128 @@ bounce_time = int(row['value'])
 # Configure the pins
 cursor.execute("SELECT * FROM cfg_gpio")
 for row in cursor:
-	#print(str(datetime.datetime.now())[:19] + ' row id=' + str(row['id']) + ', enabled=' + row['enabled'] + ', command=' + row['command'])
-	if str(row['id']) == '1' and row['enabled'] == '1':
-		sw_1_pin = int(row['pin'])
-		sw_1_cmd = row['command'].split(' ')
-		GPIO.setup(sw_1_pin,GPIO.IN, pull_up_down=GPIO.PUD_UP)
-		def sw_1_event(channel):
-			subprocess.call(sw_1_cmd)
-		GPIO.add_event_detect(sw_1_pin, GPIO.RISING, callback = sw_1_event, bouncetime = bounce_time)
-		print(str(datetime.datetime.now())[:19] + ' sw_1: pin=' + str(sw_1_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
-	elif str(row['id']) == '2' and row['enabled'] == '1':
-		sw_2_pin = int(row['pin'])
-		sw_2_cmd = row['command'].split(' ')
-		GPIO.setup(sw_2_pin,GPIO.IN, pull_up_down=GPIO.PUD_UP)
-		def sw_2_event(channel):
-			subprocess.call(sw_2_cmd)
-		GPIO.add_event_detect(sw_2_pin, GPIO.RISING, callback = sw_2_event, bouncetime = bounce_time)
-		print(str(datetime.datetime.now())[:19] + ' sw_2: pin=' + str(sw_2_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
-	elif str(row['id']) == '3' and row['enabled'] == '1':
-		sw_3_pin = int(row['pin'])
-		sw_3_cmd = row['command'].split(' ')
-		GPIO.setup(sw_3_pin,GPIO.IN, pull_up_down=GPIO.PUD_UP)
-		def sw_3_event(channel):
-			subprocess.call(sw_3_cmd)
-		GPIO.add_event_detect(sw_3_pin, GPIO.RISING, callback = sw_3_event, bouncetime = bounce_time)
-		print(str(datetime.datetime.now())[:19] + ' sw_3: pin=' + str(sw_3_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
-	elif str(row['id']) == '4' and row['enabled'] == '1':
-		sw_4_pin = int(row['pin'])
-		sw_4_cmd = row['command'].split(' ')
-		GPIO.setup(sw_4_pin,GPIO.IN, pull_up_down=GPIO.PUD_UP)
-		def sw_4_event(channel):
-			subprocess.call(sw_4_cmd)
-		GPIO.add_event_detect(sw_4_pin, GPIO.RISING, callback = sw_4_event, bouncetime = bounce_time)
-		print(str(datetime.datetime.now())[:19] + ' sw_4: pin=' + str(sw_4_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
-	elif str(row['id']) == '5' and row['enabled'] == '1':
-		sw_5_pin = int(row['pin'])
-		sw_5_cmd = row['command'].split(' ')
-		GPIO.setup(sw_5_pin,GPIO.IN, pull_up_down=GPIO.PUD_UP)
-		def sw_5_event(channel):
-			subprocess.call(sw_5_cmd)
-		GPIO.add_event_detect(sw_5_pin, GPIO.RISING, callback = sw_5_event, bouncetime = bounce_time)
-		print(str(datetime.datetime.now())[:19] + ' sw_5: pin=' + str(sw_5_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
-	elif str(row['id']) == '6' and row['enabled'] == '1':
-		sw_6_pin = int(row['pin'])
-		sw_6_cmd = row['command'].split(' ')
-		GPIO.setup(sw_6_pin,GPIO.IN, pull_up_down=GPIO.PUD_UP)
-		def sw_6_event(channel):
-			subprocess.call(sw_6_cmd)
-		GPIO.add_event_detect(sw_6_pin, GPIO.RISING, callback = sw_6_event, bouncetime = bounce_time)
-		print(str(datetime.datetime.now())[:19] + ' sw_6: pin=' + str(sw_6_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
-	elif str(row['id']) == '7' and row['enabled'] == '1':
-		sw_7_pin = int(row['pin'])
-		sw_7_cmd = row['command'].split(' ')
-		GPIO.setup(sw_7_pin,GPIO.IN, pull_up_down=GPIO.PUD_UP)
-		def sw_7_event(channel):
-			subprocess.call(sw_7_cmd)
-		GPIO.add_event_detect(sw_7_pin, GPIO.RISING, callback = sw_7_event, bouncetime = bounce_time)
-		print(str(datetime.datetime.now())[:19] + ' sw_7: pin=' + str(sw_7_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
-	elif str(row['id']) == '8' and row['enabled'] == '1':
-		sw_8_pin = int(row['pin'])
-		sw_8_cmd = row['command'].split(' ')
-		GPIO.setup(sw_8_pin,GPIO.IN, pull_up_down=GPIO.PUD_UP)
-		def sw_8_event(channel):
-			subprocess.call(sw_8_cmd)
-		GPIO.add_event_detect(sw_8_pin, GPIO.RISING, callback = sw_8_event, bouncetime = bounce_time)
-		print(str(datetime.datetime.now())[:19] + ' sw_8: pin=' + str(sw_8_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
+    #print(str(datetime.datetime.now())[:19] + ' row id=' + str(row['id']) + ', enabled=' + row['enabled'] + ', command=' + row['command'])
+    if str(row['id']) == '1' and row['enabled'] == '1':
+        sw_1_pin = int(row['pin'])
+        sw_1_cmd = row['command'].split(' ')
+        GPIO.setup(sw_1_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+        def sw_1_event(channel):
+            subprocess.call(sw_1_cmd)
+
+        GPIO.add_event_detect(sw_1_pin,
+                              GPIO.RISING,
+                              callback=sw_1_event,
+                              bouncetime=bounce_time)
+        print(str(datetime.datetime.now())[:19] + ' sw_1: pin=' +
+              str(sw_1_pin) + ', enabled=' + row['enabled'] +
+              ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
+    elif str(row['id']) == '2' and row['enabled'] == '1':
+        sw_2_pin = int(row['pin'])
+        sw_2_cmd = row['command'].split(' ')
+        GPIO.setup(sw_2_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+        def sw_2_event(channel):
+            subprocess.call(sw_2_cmd)
+
+        GPIO.add_event_detect(sw_2_pin,
+                              GPIO.RISING,
+                              callback=sw_2_event,
+                              bouncetime=bounce_time)
+        print(str(datetime.datetime.now())[:19] + ' sw_2: pin=' +
+              str(sw_2_pin) + ', enabled=' + row['enabled'] +
+              ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
+    elif str(row['id']) == '3' and row['enabled'] == '1':
+        sw_3_pin = int(row['pin'])
+        sw_3_cmd = row['command'].split(' ')
+        GPIO.setup(sw_3_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+        def sw_3_event(channel):
+            subprocess.call(sw_3_cmd)
+
+        GPIO.add_event_detect(sw_3_pin,
+                              GPIO.RISING,
+                              callback=sw_3_event,
+                              bouncetime=bounce_time)
+        print(str(datetime.datetime.now())[:19] + ' sw_3: pin=' +
+              str(sw_3_pin) + ', enabled=' + row['enabled'] +
+              ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
+    elif str(row['id']) == '4' and row['enabled'] == '1':
+        sw_4_pin = int(row['pin'])
+        sw_4_cmd = row['command'].split(' ')
+        GPIO.setup(sw_4_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+        def sw_4_event(channel):
+            subprocess.call(sw_4_cmd)
+
+        GPIO.add_event_detect(sw_4_pin,
+                              GPIO.RISING,
+                              callback=sw_4_event,
+                              bouncetime=bounce_time)
+        print(str(datetime.datetime.now())[:19] + ' sw_4: pin=' +
+              str(sw_4_pin) + ', enabled=' + row['enabled'] +
+              ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
+    elif str(row['id']) == '5' and row['enabled'] == '1':
+        sw_5_pin = int(row['pin'])
+        sw_5_cmd = row['command'].split(' ')
+        GPIO.setup(sw_5_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+        def sw_5_event(channel):
+            subprocess.call(sw_5_cmd)
+
+        GPIO.add_event_detect(sw_5_pin,
+                              GPIO.RISING,
+                              callback=sw_5_event,
+                              bouncetime=bounce_time)
+        print(str(datetime.datetime.now())[:19] + ' sw_5: pin=' +
+              str(sw_5_pin) + ', enabled=' + row['enabled'] +
+              ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
+    elif str(row['id']) == '6' and row['enabled'] == '1':
+        sw_6_pin = int(row['pin'])
+        sw_6_cmd = row['command'].split(' ')
+        GPIO.setup(sw_6_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+        def sw_6_event(channel):
+            subprocess.call(sw_6_cmd)
+
+        GPIO.add_event_detect(sw_6_pin,
+                              GPIO.RISING,
+                              callback=sw_6_event,
+                              bouncetime=bounce_time)
+        print(str(datetime.datetime.now())[:19] + ' sw_6: pin=' +
+              str(sw_6_pin) + ', enabled=' + row['enabled'] +
+              ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
+    elif str(row['id']) == '7' and row['enabled'] == '1':
+        sw_7_pin = int(row['pin'])
+        sw_7_cmd = row['command'].split(' ')
+        GPIO.setup(sw_7_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+        def sw_7_event(channel):
+            subprocess.call(sw_7_cmd)
+
+        GPIO.add_event_detect(sw_7_pin,
+                              GPIO.RISING,
+                              callback=sw_7_event,
+                              bouncetime=bounce_time)
+        print(str(datetime.datetime.now())[:19] + ' sw_7: pin=' +
+              str(sw_7_pin) + ', enabled=' + row['enabled'] +
+              ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
+    elif str(row['id']) == '8' and row['enabled'] == '1':
+        sw_8_pin = int(row['pin'])
+        sw_8_cmd = row['command'].split(' ')
+        GPIO.setup(sw_8_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+        def sw_8_event(channel):
+            subprocess.call(sw_8_cmd)
+
+        GPIO.add_event_detect(sw_8_pin,
+                              GPIO.RISING,
+                              callback=sw_8_event,
+                              bouncetime=bounce_time)
+        print(str(datetime.datetime.now())[:19] + ' sw_8: pin=' +
+              str(sw_8_pin) + ', enabled=' + row['enabled'] +
+              ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
 
 # Main
 while True:
-	time.sleep(1)
+    time.sleep(1)

--- a/www/command/gpio-buttons.py
+++ b/www/command/gpio-buttons.py
@@ -19,6 +19,7 @@
 #	2019-09-05 TC moOde 6.2.0
 #
 
+from __future__ import print_function, absolute_import
 import RPi.GPIO as GPIO
 import sys
 import time
@@ -40,12 +41,12 @@ cursor = db.cursor()
 cursor.execute("SELECT value FROM cfg_gpio WHERE param='bounce_time'")
 row = cursor.fetchone()
 bounce_time = int(row['value'])
-#print str(datetime.datetime.now())[:19] + ' bounce_time=' + str(bounce_time)
+#print(str(datetime.datetime.now())[:19] + ' bounce_time=' + str(bounce_time))
 
 # Configure the pins
 cursor.execute("SELECT * FROM cfg_gpio")
 for row in cursor:
-	#print str(datetime.datetime.now())[:19] + ' row id=' + str(row['id']) + ', enabled=' + row['enabled'] + ', command=' + row['command']
+	#print(str(datetime.datetime.now())[:19] + ' row id=' + str(row['id']) + ', enabled=' + row['enabled'] + ', command=' + row['command'])
 	if str(row['id']) == '1' and row['enabled'] == '1':
 		sw_1_pin = int(row['pin'])
 		sw_1_cmd = row['command'].split(' ')
@@ -53,7 +54,7 @@ for row in cursor:
 		def sw_1_event(channel):
 			subprocess.call(sw_1_cmd)
 		GPIO.add_event_detect(sw_1_pin, GPIO.RISING, callback = sw_1_event, bouncetime = bounce_time)
-		print str(datetime.datetime.now())[:19] + ' sw_1: pin=' + str(sw_1_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command']
+		print(str(datetime.datetime.now())[:19] + ' sw_1: pin=' + str(sw_1_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
 	elif str(row['id']) == '2' and row['enabled'] == '1':
 		sw_2_pin = int(row['pin'])
 		sw_2_cmd = row['command'].split(' ')
@@ -61,7 +62,7 @@ for row in cursor:
 		def sw_2_event(channel):
 			subprocess.call(sw_2_cmd)
 		GPIO.add_event_detect(sw_2_pin, GPIO.RISING, callback = sw_2_event, bouncetime = bounce_time)
-		print str(datetime.datetime.now())[:19] + ' sw_2: pin=' + str(sw_2_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command']
+		print(str(datetime.datetime.now())[:19] + ' sw_2: pin=' + str(sw_2_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
 	elif str(row['id']) == '3' and row['enabled'] == '1':
 		sw_3_pin = int(row['pin'])
 		sw_3_cmd = row['command'].split(' ')
@@ -69,7 +70,7 @@ for row in cursor:
 		def sw_3_event(channel):
 			subprocess.call(sw_3_cmd)
 		GPIO.add_event_detect(sw_3_pin, GPIO.RISING, callback = sw_3_event, bouncetime = bounce_time)
-		print str(datetime.datetime.now())[:19] + ' sw_3: pin=' + str(sw_3_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command']
+		print(str(datetime.datetime.now())[:19] + ' sw_3: pin=' + str(sw_3_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
 	elif str(row['id']) == '4' and row['enabled'] == '1':
 		sw_4_pin = int(row['pin'])
 		sw_4_cmd = row['command'].split(' ')
@@ -77,7 +78,7 @@ for row in cursor:
 		def sw_4_event(channel):
 			subprocess.call(sw_4_cmd)
 		GPIO.add_event_detect(sw_4_pin, GPIO.RISING, callback = sw_4_event, bouncetime = bounce_time)
-		print str(datetime.datetime.now())[:19] + ' sw_4: pin=' + str(sw_4_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command']
+		print(str(datetime.datetime.now())[:19] + ' sw_4: pin=' + str(sw_4_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
 	elif str(row['id']) == '5' and row['enabled'] == '1':
 		sw_5_pin = int(row['pin'])
 		sw_5_cmd = row['command'].split(' ')
@@ -85,7 +86,7 @@ for row in cursor:
 		def sw_5_event(channel):
 			subprocess.call(sw_5_cmd)
 		GPIO.add_event_detect(sw_5_pin, GPIO.RISING, callback = sw_5_event, bouncetime = bounce_time)
-		print str(datetime.datetime.now())[:19] + ' sw_5: pin=' + str(sw_5_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command']
+		print(str(datetime.datetime.now())[:19] + ' sw_5: pin=' + str(sw_5_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
 	elif str(row['id']) == '6' and row['enabled'] == '1':
 		sw_6_pin = int(row['pin'])
 		sw_6_cmd = row['command'].split(' ')
@@ -93,7 +94,7 @@ for row in cursor:
 		def sw_6_event(channel):
 			subprocess.call(sw_6_cmd)
 		GPIO.add_event_detect(sw_6_pin, GPIO.RISING, callback = sw_6_event, bouncetime = bounce_time)
-		print str(datetime.datetime.now())[:19] + ' sw_6: pin=' + str(sw_6_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command']
+		print(str(datetime.datetime.now())[:19] + ' sw_6: pin=' + str(sw_6_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
 	elif str(row['id']) == '7' and row['enabled'] == '1':
 		sw_7_pin = int(row['pin'])
 		sw_7_cmd = row['command'].split(' ')
@@ -101,7 +102,7 @@ for row in cursor:
 		def sw_7_event(channel):
 			subprocess.call(sw_7_cmd)
 		GPIO.add_event_detect(sw_7_pin, GPIO.RISING, callback = sw_7_event, bouncetime = bounce_time)
-		print str(datetime.datetime.now())[:19] + ' sw_7: pin=' + str(sw_7_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command']
+		print(str(datetime.datetime.now())[:19] + ' sw_7: pin=' + str(sw_7_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
 	elif str(row['id']) == '8' and row['enabled'] == '1':
 		sw_8_pin = int(row['pin'])
 		sw_8_cmd = row['command'].split(' ')
@@ -109,7 +110,7 @@ for row in cursor:
 		def sw_8_event(channel):
 			subprocess.call(sw_8_cmd)
 		GPIO.add_event_detect(sw_8_pin, GPIO.RISING, callback = sw_8_event, bouncetime = bounce_time)
-		print str(datetime.datetime.now())[:19] + ' sw_8: pin=' + str(sw_8_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command']
+		print(str(datetime.datetime.now())[:19] + ' sw_8: pin=' + str(sw_8_pin) + ', enabled=' + row['enabled'] + ', bounce_time=' + str(bounce_time) + ', cmd=' + row['command'])
 
 # Main
 while True:


### PR DESCRIPTION
edited gpio-buttons.py in two consecutive commits

commit 1: a few minor changes to make it compatible with both Python 2 and Python 3.
commit 2: minor but numerous adjustments to style per PEP8 using Google's **yapf** (Yet Another Python Formatter)

After making these changes, running **pylint** with default settings on gpio-buttons.py generates

- 21 "C" messages concerning Python convention issues. I would ignore these.

- 18 "W" messages concerning Python warnings. I believe these ought to be addressed at some point but the code apparently works as-is now. Two involve unused imports and 8 (once for each pin) involve an unused variable. Easily fixed. The remaining 8 (once for each pin) involve a subtle point which AFAICT isn't an issue in our specific usage.