### PR TITLE
Fix menu breakage on iOS 13 / A12 processors

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -63,8 +63,6 @@ a.btn.btn-medium.btn-primary {font-size:16px;}
 .modal-footer .btn-primary{border-left:1px solid rgba(128,128,128,0.3);text-transform:capitalize;border-radius:0px;}
 .modal-footer .singleton {width:100%;}
 h6 {font-size: large;font-weight: 500;text-transform: capitalize;text-align: center;}
-.bootstrap-select .dropdown-menu {background-color:rgba(50,50,50,0.98);}
-.bootstrap-select .dropdown-menu li a {color:#eee;}
 .span5 {width:38%;}
 .span4 {padding:0;width:38%;}
 .span3 {width:24%;margin-left:0px;}
@@ -79,6 +77,7 @@ h6 {font-size: large;font-weight: 500;text-transform: capitalize;text-align: cen
 legend {border-bottom: 1px solid #999;}
 .modal {background-color: rgba(240,240,240,0.9);color: #333;}
 .modal-header, .modal-footer {background-color: transparent;}
+.modal-xs{min-width:230px;text-align:center;}
 .form-horizontal .control-group {margin-bottom:15px;}
 #togglebtns {padding-top:10px;}
 .modal-dropdown-text {color:#333;}
@@ -86,15 +85,22 @@ li.modal-dropdown-text:hover,
 li.modal-dropdown-text:focus {color:#eee;}
 .help-block, .help-inline {color:#333;}
 .help-block-modal {margin:0 !important;}
+
+/* dropdown menus */
+
+.dropdown-menu > li > a {line-height:2.75em;margin:0;padding:0 1em;background:none;color:var(--adapttext);font-size:1em;}
+.dropdown-menu {float:right;position:absolute;left:auto;border:none;list-style:none outside none;background-color:var(--adaptmbg);border:none;box-shadow:0px 4px 10px rgba(0, 0, 0, 0.4);border-radius:.5em;backdrop-filter:(10px);-webkit-backdrop-filter:blur(10px);z-index:1000;}
+.dropdown-menu.open {padding:0;margin:0;}
 .bootstrap-select .dropdown-menu {background-color:transparent;}
-.bootstrap-select.btn-group .dropdown-menu li > a {color:inherit;}
-.btn-group.open.bootstrap-select .btn.dropdown-toggle {background-color:rgba(128,128,128,0.2);border-radius:4px;}
-.dropdown-menu .custom-select.inner {background-color:transparent;}
-.dropdown-menu.open {background-color:rgba(240,240,240,0.9);backdrop-filter: blur(20px);-webkit-backdrop-filter: blur(20px);}
-.container2 .dropdown-menu.open {background-color:rgba(50,50,50,0.95);-webkit-overflow-scrolling:touch;}
-#players .btn, #configure .btn {background:rgba(64,64,64,0.08);}
-.modal-xs{min-width:230px;text-align:center;}
+.btn-group.open.bootstrap-select .btn.dropdown-toggle {background-color:rgba(128,128,128,0.3);box-shadow:none;border-radius:4px;}
+.bootstrap-select.btn-group .dropdown-menu.inner {background-color:rgba(240,240,240,0.95);color:#333;border-radius:.51rem .5rem;overflow:hidden;} /* weird border radius cos bug in chrome? */
+.bootstrap-select .dropdown-menu > li > a {color:inherit;padding:0 1em;}
+/*.bootstrap-select .dropdown-menu > li:first-child > a {padding-top:.5em !important;}
+.bootstrap-select .dropdown-menu > li:last-child > a {padding-bottom:.5em !important;}*/
+.container2 .dropdown-menu.inner {background-color:rgba(50,50,50,0.95) !important;color:#eee !important;-webkit-overflow-scrolling:touch;} /* config theme menu bg */
+
 .btn-group.bootstrap-select.bootstrap-select-mini {width:5.5rem;}
+#players .btn, #configure .btn {background:rgba(64,64,64,0.08);}
 #info-toggle-bgimage {position:absolute;margin-left:5px;}
 /* clock radio */
 .checkbox-grp {margin:.35em 0 .85em 0;}
@@ -107,20 +113,12 @@ li.modal-dropdown-text:focus {color:#eee;}
 #update-pkg-ol {font-family:courier new;}
 #update-pkg-ol li {line-height:1em;}
 
-@supports ((backdrop-filter: blur(10px)) or (-webkit-backdrop-filter: blur(10px))) {
-	.modal-dropdown-text {color:#333;}
-	li.modal-dropdown-text:hover,
-	li.modal-dropdown-text:focus {color:#eee;}
-	.modal-backdrop {background-color: rgba(48,48,48,0.2);backdrop-filter: blur(20px);-webkit-backdrop-filter: blur(20px);}
+@supports (-webkit-backdrop-filter: blur(10px)) {
+	.modal-backdrop {background-color: rgba(32,32,32,0.9);backdrop-filter: blur(10px);-webkit-backdrop-filter: blur(10px);}
 	.modal-backdrop.fade.in {opacity:1.0;}
-	.modal {background-color:rgba(240,240,240,0.7);color:#333;}
-	.modal.fade.in{opacity:1.0;}
-	.help-block, .help-inline {color:#333;}
-	.bootstrap-select .dropdown-menu {background-color:transparent;}
-	.bootstrap-select.btn-group .dropdown-menu li > a {color:inherit;}
-	.btn-group.open.bootstrap-select .btn.dropdown-toggle {background-color:rgba(128,128,128,0.2);border-radius:4px;}
-	.dropdown-menu .custom-select.inner {background-color:transparent;}
-	.dropdown-menu.open {background-color:rgba(240,240,240,0.1);backdrop-filter: blur(20px);-webkit-backdrop-filter: blur(20px);}
+	.modal {background-color:rgba(240,240,240,0.7);} /* bit more translucent */
+	.bootstrap-select.btn-group .dropdown-menu.inner {background-color:rgba(240,240,240,0.25);}
+	.container2 .bootstrap-select.btn-group .dropdown-menu.inner {background-color:rgba(50,50,50,0.25)} /* config theme menu bg */
 	#players .btn, #configure .btn {background:rgba(64,64,64,0.08);}
 }
 
@@ -235,7 +233,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#playbar-timeline {display:none;}
 	#playbar-div {display:block;}
 	#playbar-mtime {display:flex;position:relative;font-size:.9em;}
-	#menu-top .dropdown-menu {right:0;min-width:13rem;/*min-width:15rem;top:.25em;*/box-shadow:0px 4px 10px rgba(0, 0, 0, 0.1);border-radius:.5em;background-color:var(--adaptmbg);z-index:1000;padding-top:0;}
+	/*#menu-top .dropdown-menu {min-width:13rem;}*/
 	#menu-top .dropdown.open {background-color:transparent;border-radius:unset;box-shadow:none;backdrop-filter:none;padding-left:0}
 	/* playbar */
 	#playbar-title {text-align:left;top:0;margin-left:.75rem;width:calc(64vw - 6rem);height:auto;position:relative;transform:none;font-size:1rem;line-height:1.5rem;left:0;padding:0;}

--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -88,7 +88,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 
 /* dropdown menus */
 
-.dropdown-menu > li > a {line-height:2.75em;margin:0;padding:0 1em;background:none;color:var(--adapttext);font-size:1em;}
+.dropdown-menu > li > a {line-height:2.75em;margin:0;padding:0 .5em;background:none;color:var(--adapttext);font-size:1em;white-space:normal;}
 .dropdown-menu {float:right;position:absolute;left:auto;border:none;list-style:none outside none;background-color:var(--adaptmbg);border:none;box-shadow:0px 4px 10px rgba(0, 0, 0, 0.4);border-radius:.5em;backdrop-filter:(10px);-webkit-backdrop-filter:blur(10px);z-index:1000;}
 .dropdown-menu.open {padding:0;margin:0;}
 .bootstrap-select .dropdown-menu {background-color:transparent;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -137,19 +137,11 @@ html {background-color:inherit;}
 .btnlist.btnlist-top.btnlist-top-pl, .btnlist.btnlist-top.btnlist-top-lib {top:0px;top:env(safe-area-inset-top);width:35%;z-index:1004;height:2.5rem;margin-left:.4rem;}
 .btn.btn-primary.btn-small, .btn.btn-primary.btn-medium {background:rgba(128,128,128,0.2);margin-top:-4px;}
 #menu-top {height:2.75em;line-height:2.75em;padding-top:0;padding-top:env(safe-area-inset-top);height:0;z-index:1002;display:flex;}
-#menu-top .dropdown {display:flex;float:right;height:2.75em;top:0;top:calc(env(safe-area-inset-top) + 0);right:.5em;line-height:2.75em;margin:0;background:none;position:absolute;align-items:center;}
-#menu-top .dropdown-menu, #context-menus .dropdown-menu {float:right;position:absolute;left:auto;background:inherit;border:none;border-radius:5px;box-shadow:none;list-style:none outside none;margin:0;padding:0;}
-#menu-top .dropdown-menu {right:0;min-width:11rem;/*min-width:12.5rem;top:.25em;*/box-shadow:0px 4px 10px rgba(0, 0, 0, 0.1);border-radius:.5em 0 .5em .5em;background-color:var(--adaptmbg);z-index:1000;}
-.dropdown-menu .custom-select .inner {background-color:none;}
-#context-menus .dropdown-menu {/*border:1px solid rgba(128,128,128,0.2);*/padding:.5em 0;min-width:160px;box-shadow:0px 0px 3px rgba(0, 0, 0, 0.30);background:var(--adaptmbg);backdrop-filter: (10px);-webkit-backdrop-filter:blur(10px);}
-#menu-top .dropdown-menu > li > a, #context-menus .dropdown-menu > li > a {line-height:2.75em;margin:0;padding:0 .6em;background:none;color:var(--adapttext);font-size:1em;}
-#menu-top .dropdown-menu > li > a i, #context-menus .dropdown-menu > li > a i {width:1.75em;}
-#context-menus .dropdown-menu > li > a {border:none;}
-#menu-top .dropdown-menu > li:first-child > a, #context-menus .dropdown-menu > li:first-child > a {border-top:0px solid #000;}
-#menu-top .dropdown-menu > li > a:hover, #menu-top .dropdown-menu > li > a:focus, #menu-top .dropdown-menu > li.active > a, #context-menus .dropdown-menu > li > a:hover, #context-menus .dropdown-menu > li.active > a {background-color:var(--accentxta);}
-#menu-top .dropdown-menu a, #context-menus .dropdown-menu a {font-size:calc(.95em + 1vmin); text-decoration:none;}
+#menu-top .dropdown {top:0;top:calc(env(safe-area-inset-top) + 0);right:.5em;position:absolute;}
+#menu-top .dropdown-menu {right:0;}
+#menu-top .dropdown-menu > li > a i, #context-menus .dropdown-menu > li > a i {width:1.75em;display:inline-block;text-align:center;}
+.dropdown-menu > li > a:hover, .dropdown-menu > li > a:active, .dropdown-menu > li > a:focus {background-color:var(--accentxta);}
 #menu-top a:hover, #menu-top a:focus, #context-menus .dropdown-menu a:hover, #context-menus .dropdown-menu a:focus {text-decoration:none;outline:none;}
-#menu-top .dropdown i, #context-menus i {display:inline-block;text-align:center;}
 #menu-top #config-back i {font-size:1.35rem;position:relative;top:1px;}
 #menu-settings {font-size:1.5rem;font-weight:500;text-shadow:0px 0px 2px rgba(0, 0, 0, 0.2);color:var(--adapttext);position:relative;z-index:1001;}
 #menu-settings i {color:var(--accentxts);font-size:.65em;}
@@ -225,7 +217,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .btnlist-top-db, .btnlist-top-ra {position:relative;background-color:rgba(128,128,128,.1);;color:var(--adapttext);border-radius:.25em;border:1px solid var(--btnshade);width:calc(100vw - 2.5em);height:2.1rem;padding:0 !important;margin:0 auto;}
 #pl-filter, #lib-album-filter, #ra-filter {padding:0}
 #db-browse .dropdown {display:block;height:40px;line-height:40px;margin:0 20px 0 0;}
-#db-browse .dropdown-menu {background:transparent;border:none;border-radius:0px;box-shadow:none;list-style:none outside none;margin:0;min-width:100px;padding:0;border-top:1px solid #000;border-left:1px solid #000;border-right:1px solid #000;position:absolute;top:100%;z-index:1000;}
+#db-browse .dropdown-menu {background:transparent;border:none;border-radius:0px;box-shadow:none;list-style:none outside none;margin:0;/*min-width:100px;*/padding:0;border-top:1px solid #000;border-left:1px solid #000;border-right:1px solid #000;position:absolute;top:100%;z-index:1000;}
 #db-browse .dropdown-menu > li > a {line-height:40px;margin:0;padding:0 10px;background:#34495E;border-bottom:0px solid #000;color:#fff;}
 #db-browse .dropdown-menu > li > a:hover, #db-browse .dropdown-menu > li > a:focus, #db-browse .dropdown-menu > li.active > a {background-color:var(--accentxta);}
 .btnlist a {font-size:1em;text-decoration:none;color:inherit;}
@@ -425,7 +417,7 @@ input[type='range'].vslide2::-webkit-slider-thumb {background:#fff;background-im
 #menu-bottom ul {display:none;color:var(--adapttext);}
 #menu-bottom .btn.active {background-color:transparent;}
 #menu-bottom .btn {border:none;background-color:transparent;margin-bottom:.15rem;}
-#theme-name-menu {margin:0;padding:0;border-radius:.5rem;overflow:hidden;opacity:.95;}
+#theme-name-menu {margin:0;border-radius:.5rem;overflow:hidden;opacity:.95;}
 /* alphabet quick jump stuff */
 #index-genres {right:calc(66.66% + var(--sbw));top:calc(1.5rem + 3px);height:calc(100% - 1.5rem - 3px);}
 #index-artists {right:calc(33.33% + var(--sbw));top:calc(1.5rem + 3px);height:calc(100% - 1.5rem - 3px);}
@@ -491,15 +483,6 @@ input[type='range'].vslide2::-webkit-slider-thumb {background:#fff;background-im
 #top-columns.nogenre #lib-album-header, #top-columns.nogenre #lib-album {left:50%;width:50%;}
 /* For updater view modal */
 .updater-relnotes {list-style-type:none;margin-left:0;}
-
-@supports (backdrop-filter:blur(10px)) or (-webkit-backdrop-filter:blur(10px)) {
-    #menu-top .dropdown-menu, .dropdown-menu {
-		background-color:var(--adaptmbg);
-		/*background:linear-gradient(to bottom, var(--adaptmbg));*/
-		backdrop-filter:blur(10px);
-		-webkit-backdrop-filter:blur(10px);
-   }
-}
 
 /* https: //codepen.io/mallendeo/pen/eLIiG */
 .toggle {background-color:rgba(128,128,128,0.3);}

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -73,7 +73,7 @@ jQuery(document).ready(function($) { 'use strict';
 	themeBack = 'rgba(' + THEME.json[SESSION.json['themename']]['bg_color'] + ',' + SESSION.json['alphablend'] +')';
 	themeMcolor = str2hex(THEME.json[SESSION.json['themename']]['tx_color']);
 	if (SESSION.json['adaptive'] == "No") {document.body.style.setProperty('--adaptmbg', themeBack);}
-	blurrr == true ? themeOp = .55 : themeOp = .95;
+	blurrr == true ? themeOp = .7 : themeOp = .95;
 
 	/*themeMback = 'rgba(' + THEME.json[SESSION.json['themename']]['bg_color'] + ',' + themeOp +')';
 	tempcolor = splitColor($('.dropdown-menu').css('background-color'));*/


### PR DESCRIPTION
This works around a bug in webkit on iOS 13 that affects menus with blurred backgrounds where the blur coverage was missing for part of the menu.