### PR TITLE
Adding back button to library browser in the radio tab

### DIFF
--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -867,6 +867,21 @@ jQuery(document).ready(function($) { 'use strict';
 			mpdDbCmd('lsinfo_radio', $(this).parent().data('path'));
 		}
 	});
+    // radio folder back button                                
+    $('#ra-back').click(function(e) {
+        if (UI.radioPos > -1) {
+            --UI.radioPos;
+			var pathr = UI.pathr;
+			var cutpos = pathr.lastIndexOf('/');
+			if (cutpos !=-1) {
+				var pathr = pathr.slice(0,cutpos);
+			}
+			else {
+				pathr = '';
+			}
+            mpdDbCmd('lsinfo_radio', pathr);
+		}
+	});
 	$('#ra-home').click(function(e) {
 		UI.raFolderLevel[4] = 0;
 		UI.pathr = '';

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -328,6 +328,7 @@
 	<div id="radio-panel" class="tab-pane">
 		<div id="container-radio">
 		<div class="btnlist btnlist-top btnlist-top-ra">
+            <button id="ra-back" class="btn"><i class="far fa-arrow-left"></i></button>
 			<button aria-label="Home" id="ra-home" class="btn"><i class="fas fa-home"></i></button>
 			<button aria-label="Refresh" id="ra-refresh" class="btn"><i class="far fa-redo"></i></button>
 			<button aria-label="Toggle View" id="ra-toggle-view" class="btn"><i class="far fa-bars"></i></button>


### PR DESCRIPTION
Navigation backwards in the radio tab in the library is difficult with deeply organized station structures. This pull request should replicate the back arrow as seen in the playlists tab. It retains and updates the UI.radioPos and the pathr and should navigate back to -1 in the cutpos.

Finally the jQuery updates mpdDbCmd('lsinfo_radio', pathr);

Let me know if this fails.