### PR TITLE
'Year' labels in Tag and Album views - re-basedlined for 6.4.2

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -291,7 +291,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	/* tag view */
 	.lib-entry {margin-right:0;}
 	.lib-entry-song {font-size:unset;}
-	.songyear {display:none;}
+	/*.songyear {display:none;}*/
 	/* folder view */
 	#folder-panel {padding-top:1.875em;height:calc(100vh - 1.875em);}
 	#database .btn {font-size:.9em;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -183,8 +183,8 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .pll2 {font-size:.9em;margin-bottom:.75em;color:var(--textvariant) !important}
 #albumsList li, #artistsList li, #genresList li {line-height:calc(1.45em + 1vmin);}
 #albumsList .lib-entry img {width:3rem;margin:.15em .25em .15em 0;}
-#albumsList .album-name {display:inline-flex;vertical-align:middle;max-width:calc(100% - 3rem - .25em);line-height:1.25em;}
-#albumsList .album-year {display:none;font-size:0.85em;color:var(--textvariant);}
+#albumsList .album-name {display:inline-block;vertical-align:middle;max-width:calc(100% - 3rem - .25em);line-height:1.25em;}
+#albumsList .album-year {display:inline-block;font-size:0.85em;color:var(--textvariant); vertical-align:top;}
 .database .active {font-size:inherit;font-weight:700;}
 .playlist .active .pll1 {color:var(--accentxts);font-weight:700;}
 .tab-content.visacc .playlist .active .pll1 {color:var(--adapttext);}
@@ -299,7 +299,8 @@ code, pre {background-color:inherit;color:inherit;border:none;font-size:.8em;}
 #lib-genre {top:calc(1.5em + 1px);height:calc(100% - 1.5em);border-right:1px solid var(--btnshade);-webkit-overflow-scrolling:touch;box-sizing:border-box;}
 #lib-artist {top:calc(1.5em + 1px);height:calc(100% - 1.5em);left:33.33%;margin-left:0px;-webkit-overflow-scrolling:touch;box-sizing:border-box;}
 #lib-album {top:calc(1.5em + 1px);height:calc(100% - 1.5em);left:66.66%;border-left:1px solid var(--btnshade);margin-left:0px;-webkit-overflow-scrolling:touch;box-sizing:border-box;}
-#lib-album span {display:none;vertical-align:middle;}
+/*#lib-album span {display:none;vertical-align:middle;}*/
+#albumsList .artist-name {display:none;}
 #lib-file {overflow-y:scroll;overflow-x:hidden;margin:1px 0 0 0;height:100%;width:100%;-webkit-overflow-scrolling:touch;}
 #lib-coverart-meta-area {width:20vw;line-height:normal;padding:0;float:left;position:fixed;}
 #lib-coverart-img {margin:.5em .25em 0 .5em;}

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -424,6 +424,9 @@ var renderAlbums = function() {
 	var output = '';
 	var output2 = '';
 	var tmp = '';
+	var tmpSub = '';   // For subtitles in Tag View
+	var tmpYear1 = ''; // For display of Year in Album View before Album title
+	var tmpYear2 = ''; // For display of Year in Album View	after Artist
 	var defCover = "this.src='images/default-cover-v6.svg'";
 
 	for (var i = 0; i < filteredAlbums.length; i++) {
@@ -435,41 +438,56 @@ var renderAlbums = function() {
 		else {
 			tmp = '';
 		}
-
-        var album_year = filteredAlbums[i].year;
-        var album_year2 = filteredAlbumCovers[i].year;
-
-        // TEST
+    
+		// Tag view - list subtitle options
+		switch (SESSION.json['taglist_sub']) {
+			case "Year":
+				tmpSub = '<br><span class="artist-name">' + filteredAlbums[i].artist + '</span><span class="album-year">' + filteredAlbums[i].year + '</span>';
+				break;
+			case "Artist":
+        		tmpSub = '<br><span class="artist-name">' + filteredAlbums[i].artist + '</span><span class="album-year">' + filteredAlbums[i].artist + '</span>';
+				break;
+			case "Artist (Year)":
+				tmpSub = '<br><span class="artist-name">' + filteredAlbums[i].artist + '</span><span class="album-year">' + filteredAlbums[i].artist + ' (' + filteredAlbums[i].year + ') </span>';
+				break;
+			default: tmpSub = '<span class="artist-name">' + filteredAlbums[i].artist + '</span>';  // Allows quick-jump filter to work when 'none' is selected
+		}
+		
+		// Album view - 'Year' display options
+		switch (SESSION.json['show_year_av']) {
+			case "Before Album":
+				tmpYear1 = '<span class="album-year">' + filteredAlbumCovers[i].year + '&nbsp;-&nbsp;</span>';
+				tmpYear2 = '</span>';
+				break;
+			case "After Artist":
+				tmpYear1 = '';
+				tmpYear2 = ' (' + filteredAlbumCovers[i].year + ')</span>';
+				break;
+			default:
+				tmpYear1 = '';
+				tmpYear2 = '';				
+		}
+                   
+        //TEST
         //UI.tagViewCovers = false;
         //
-		if (UI.tagViewCovers) {
-			output += '<li><div class="lib-entry'
-				+ tmp
-				+ '">' + '<img class="lazy-tagview" data-original="' + filteredAlbums[i].imgurl + '"><div class="album-name">' + filteredAlbums[i].album + '<br><span class="album-year">' + album_year + '</span><span class="artist-name">' + filteredAlbums[i].artist + '</span></div></div></li>';
-			output2 += '<li><div class="lib-entry'
-				+ tmp
-				+ '">' + '<img class="lazy-albumview" data-original="' + filteredAlbumCovers[i].imgurl + '"><div class="cover-menu" data-toggle="context" data-target="#context-menu-lib-all"></div><div class="albumcover">' + '<span class="album-year">' + album_year2 + '</span>' + '<span class="album-name">' + filteredAlbumCovers[i].album + '</span></div><span class="artist-name">' + filteredAlbumCovers[i].artist + '</span></div></li>';
+ 		if (UI.tagViewCovers) {
+			output += '<li><div class="lib-entry' + tmp + '">' 
+              + '<img class="lazy-tagview" data-original="' + filteredAlbums[i].imgurl + '"><div class="album-name">' + filteredAlbums[i].album 
+				+ tmpSub + '</div></div></li>';
 		}
 		else {
-			output += '<li><div class="lib-entry'
-				+ tmp
-				//+ '">' + filteredAlbums[i].album + '<span>' + ' - ' + filteredAlbums[i].artist + ', ' + album_year + '</span></div></li>';
-                + '">' + '<div class="album-name">' + filteredAlbums[i].album + '<br><span class="album-year">' + album_year + '</span><span class="artist-name">' + filteredAlbums[i].artist + '</span></div></div></li>';
-			output2 += '<li><div class="lib-entry'
-				+ tmp
-				+ '">' + '<img class="lazy-albumview" data-original="' + filteredAlbumCovers[i].imgurl + '"><div class="cover-menu" data-toggle="context" data-target="#context-menu-lib-all"></div><div class="albumcover">' + '<span class="album-year">' + album_year2 + '</span>' + '<span class="album-name">' + filteredAlbumCovers[i].album + '</span></div><span class="artist-name">' + filteredAlbumCovers[i].artist + '</span></div></li>';
-		}
+			output += '<li><div class="lib-entry' + tmp + '">'
+              + '<div class="album-name">' + filteredAlbums[i].album + tmpSub + '</div></div></li>';
+        }
+		
+            output2 += '<li><div class="lib-entry' + tmp + '">' 
+              + '<img class="lazy-albumview" data-original="' + filteredAlbumCovers[i].imgurl + '"><div class="cover-menu" data-toggle="context" data-target="#context-menu-lib-all"></div><div class="albumcover">' + tmpYear1 + '<span class="album-name">' + filteredAlbumCovers[i].album + '</span></div><span class="artist-name">' + filteredAlbumCovers[i].artist + tmpYear2 + '</div></li>';		
 	}
 
     // Output the lists
 	$('#albumsList').html(output);
 	$('#albumcovers').html(output2);
-
-    // Control whether to display album year
-    if (SESSION.json['library_album_grouping'] == 'Year') {
-        $('#albumsList .lib-entry .album-year').css('display', 'contents');
-        $('#albumcovers .lib-entry .album-year').css('display', 'block');
-    }
 
 	// Headers clicked
 	if (UI.libPos[0] == -2) {

--- a/www/lop-config.php
+++ b/www/lop-config.php
@@ -58,6 +58,15 @@ $_select['show_genres'] .= "<option value=\"No\" " . (($_SESSION['show_genres'] 
 $_select['library_album_grouping'] .= "<option value=\"Artist\" " . (($_SESSION['library_album_grouping'] == 'Artist') ? "selected" : "") . ">by Artist</option>\n";
 $_select['library_album_grouping'] .= "<option value=\"Album\" " . (($_SESSION['library_album_grouping'] == 'Album') ? "selected" : "") . ">by Album</option>\n";
 $_select['library_album_grouping'] .= "<option value=\"Year\" " . (($_SESSION['library_album_grouping'] == 'Year') ? "selected" : "") . ">by Year</option>\n";
+// Show Subtitle in Album List in Tag view
+$_select['taglist_sub'] .= "<option value=\"None\" " . (($_SESSION['taglist_sub'] == 'None') ? "selected" : "") . ">None</option>\n";
+$_select['taglist_sub'] .= "<option value=\"Artist\" " . (($_SESSION['taglist_sub'] == 'Artist') ? "selected" : "") . ">Artist</option>\n";
+$_select['taglist_sub'] .= "<option value=\"Year\" " . (($_SESSION['taglist_sub'] == 'Year') ? "selected" : "") . ">Year</option>\n";
+$_select['taglist_sub'] .= "<option value=\"Artist (Year)\" " . (($_SESSION['taglist_sub'] == 'Artist (Year)') ? "selected" : "") . ">Artist (Year)</option>\n";
+// Show Year label in Album view
+$_select['show_year_av'] .= "<option value=\"None\" " . (($_SESSION['show_year_av'] == 'None') ? "selected" : "") . ">None</option>\n";
+$_select['show_year_av'] .= "<option value=\"Before Album\" " . (($_SESSION['show_year_av'] == 'Before Album') ? "selected" : "") . ">Before Album</option>\n";
+$_select['show_year_av'] .= "<option value=\"After Artist\" " . (($_SESSION['show_year_av'] == 'After Artist') ? "selected" : "") . ">After Artist</option>\n";
 // Compilation identifier
 $_select['library_comp_id'] = $_SESSION['library_comp_id'];
 // Recently added

--- a/www/templates/lop-config.html
+++ b/www/templates/lop-config.html
@@ -69,11 +69,37 @@
 					</select>
 					<a aria-label="Help" class="info-toggle" data-cmd="info_library_album_grouping" href="#notarget"><i class="fas fa-info-circle"></i></a>
 					<span id="info_library_album_grouping" class="help-block-configs help-block-margin hide">
-						This option determines how albums are grouped in Album view.<br>
+						This option determines how albums are grouped in both Tag and Album views.<br>
 						NOTE: When grouping by Year if not all tracks in the album have the same Year the highest Year will be used.
                     </span>
 				</div>
 			</div>
+			
+			<div class="control-group">
+				<label class="control-label" for="taglist_sub">Subtitle in Tag View</label>
+				<div class="controls">
+					<select id="taglist_sub" class="input-large" name="config[taglist_sub]">
+						$_select[taglist_sub]
+					</select>
+					<a aria-label="Help" class="info-toggle" data-cmd="info_taglist_sub" href="#notarget"><i class="fas fa-info-circle"></i></a>
+					<span id="info_taglist_sub" class="help-block-configs help-block-margin hide">
+						Show 'Artist', 'Year', 'Artist (Year)' or nothing as a subtitle below each album in the Tag view.
+                    </span>
+				</div>
+			</div>	
+			
+			<div class="control-group">
+				<label class="control-label" for="show_year_av">Show Year in Album view</label>
+				<div class="controls">
+					<select id="show_year_av" class="input-large" name="config[show_year_av]">
+						$_select[show_year_av]
+					</select>
+					<a aria-label="Help" class="info-toggle" data-cmd="info_show_year_av" href="#notarget"><i class="fas fa-info-circle"></i></a>
+					<span id="info_show_year_av" class="help-block-configs help-block-margin hide">
+						Show and position, or hide, 'Year' details in the Album view.
+                    </span>
+				</div>
+			</div>				
 
 			<div class="control-group">
 				<label class="control-label" for="library_comp_id">Compilation identifier</label>


### PR DESCRIPTION
Updated so as not to break the 'quick search' function for those experimenting with UI.tagViewCovers = false.

Note:
Requires two records in the cfg_system table of the db:

taglist_sub (subtitles in Tag list). Default: 'Artist (Year)'
Options are 'None', 'Artist', 'Year' and 'Artist (Year)'

show_year_av (show year in album view). Default: 'After Artist'
Options are 'None', 'Before Album' and 'After Artist'