### PR TITLE
Sort and show Albums chronologically under Artists sorted alphabetically

### DIFF
--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -2750,13 +2750,15 @@ $('#index-artists li').on('click', function(e) {
 });
 $('#index-albums li').on('click', function(e) {
     // .artist-name or .album-name
-    var selector = '.' + SESSION.json['library_album_grouping'].toLowerCase() + '-name'
-    listLook('albumsList li ' + selector, 'albums', $(this).text());
+    var selector = '.' + SESSION.json['library_album_grouping'].toLowerCase() + '-name';
+    var selector2 = selector.replace(/\/year/g, '');
+    listLook('albumsList li ' + selector2, 'albums', $(this).text());
 });
 $('#index-albumcovers li').on('click', function(e) {
     // .artist-name or .album-name
-    var selector = '.' + SESSION.json['library_album_grouping'].toLowerCase() + '-name'
-    listLook('albumcovers li ' + selector, 'albumcovers', $(this).text());
+    var selector = '.' + SESSION.json['library_album_grouping'].toLowerCase() + '-name';
+    var selector2 = selector.replace(/\/year/g, '');
+    listLook('albumcovers li ' + selector2, 'albumcovers', $(this).text());
 });
 $('#index-browse li').on('click', function(e) {
 	listLook('database li', 'db', $(this).text());

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -189,6 +189,14 @@ function groupLib(fullLib) {
                 return (collator.compare(a['year'], b['year']) || collator.compare(removeArticles(a['album']), removeArticles(b['album'])));
             });
         }
+        else if (SESSION.json['library_album_grouping'] == 'Artist/Year') {
+            allAlbums.sort(function(a, b) {
+                return (collator.compare(removeArticles(a['artist']), removeArticles(b['artist'])) || collator.compare(a['year'],b['year']));
+            });
+            allAlbumCovers.sort(function(a, b) {
+                return (collator.compare(removeArticles(a['artist']), removeArticles(b['artist'])) || collator.compare(a['year'],b['year']));
+            });
+        }        
 	}
     // Fallback to default ordering
 	catch (e) {
@@ -231,6 +239,18 @@ function groupLib(fullLib) {
             allAlbumCovers.sort(function(a, b) {
     			var x1 = a['year'], x2 = b['year'];
     			var y1 = removeArticles(a['album']).toLowerCase(), y2 = removeArticles(b['album']).toLowerCase();
+    			return x1 > x2 ? 1 : (x1 < x2 ? -1 : (y1 > y2 ? 1 : (y1 < y2 ? -1 : 0)));
+    		});
+        }
+        else if (SESSION.json['library_album_grouping'] == 'Artist/Year') {
+            allAlbums.sort(function(a, b) {
+    			var x1 = removeArticles(a['artist']).toLowerCase(), x2 = removeArticles(b['artist']).toLowerCase();
+    			var y1 = a['year'], y2 = b['year'];
+    			return x1 > x2 ? 1 : (x1 < x2 ? -1 : (y1 > y2 ? 1 : (y1 < y2 ? -1 : 0)));
+    		});
+            allAlbumCovers.sort(function(a, b) {
+    			var x1 = removeArticles(a['artist']).toLowerCase(), x2 = removeArticles(b['artist']).toLowerCase();
+    			var y1 = a['year'], y2 = b['year'];
     			return x1 > x2 ? 1 : (x1 < x2 ? -1 : (y1 > y2 ? 1 : (y1 < y2 ? -1 : 0)));
     		});
         }

--- a/www/lop-config.php
+++ b/www/lop-config.php
@@ -56,6 +56,7 @@ $_select['show_genres'] .= "<option value=\"Yes\" " . (($_SESSION['show_genres']
 $_select['show_genres'] .= "<option value=\"No\" " . (($_SESSION['show_genres'] == 'No') ? "selected" : "") . ">No</option>\n";
 // Album grouping
 $_select['library_album_grouping'] .= "<option value=\"Artist\" " . (($_SESSION['library_album_grouping'] == 'Artist') ? "selected" : "") . ">by Artist</option>\n";
+$_select['library_album_grouping'] .= "<option value=\"Artist/Year\" " . (($_SESSION['library_album_grouping'] == 'Artist/Year') ? "selected" : "") . ">by Artist/Year</option>\n";
 $_select['library_album_grouping'] .= "<option value=\"Album\" " . (($_SESSION['library_album_grouping'] == 'Album') ? "selected" : "") . ">by Album</option>\n";
 $_select['library_album_grouping'] .= "<option value=\"Year\" " . (($_SESSION['library_album_grouping'] == 'Year') ? "selected" : "") . ">by Year</option>\n";
 // Compilation identifier

--- a/www/templates/lop-config.html
+++ b/www/templates/lop-config.html
@@ -69,8 +69,15 @@
 					</select>
 					<a aria-label="Help" class="info-toggle" data-cmd="info_library_album_grouping" href="#notarget"><i class="fas fa-info-circle"></i></a>
 					<span id="info_library_album_grouping" class="help-block-configs help-block-margin hide">
-						This option determines how albums are grouped in Album view.<br>
-						NOTE: When grouping by Year if not all tracks in the album have the same Year the highest Year will be used.
+						This option determines how albums are grouped in both Tag and Album views.<br><br>
+                        Options are:<br>
+                        &nbsp;&nbsp;&nbsp; "by Artist"      - all artists, and the albums for each artist, will be sorted alphabetically,<br>
+                        &nbsp;&nbsp;&nbsp; "by Artist/Year" - all artists will be listed alphabetically and the albums for each artist will be sorted chronologically,<br>
+                        &nbsp;&nbsp;&nbsp; "by Album"       - all albums in the library will be listed alphabetically, irrespective of the artist,<br>
+                        &nbsp;&nbsp;&nbsp; "by Year"        - all albums in the library will be listed chronologically, irrespective of the artist.<br><br>
+                        NOTE:<br>
+                        &nbsp;&nbsp;&nbsp; When grouping by Year if not all tracks in the album have the same Year tag then the latest year will be used.<br>
+                        &nbsp;&nbsp;&nbsp; If no Year tag exists or if the Year tag is not a number then no year information will be shown for that album.
                     </span>
 				</div>
 			</div>


### PR DESCRIPTION
Adds 'Artist/Year' album-grouping option.
Sort and shows Albums chronologically under Artists sorted alphabetically in both the Album column of the Tag view, and in the Album view.
Permits correct operation of Alphabits quick-search bar in both views (selecting by Artist).