### PR TITLE
MPD config option for auto_format and auto_resample of default device

### DIFF
--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -944,7 +944,7 @@ function parseCfgMpd($dbh) {
 	 	$array['audio_output_depth'] = $format[1];
 	 	$array['audio_output_chan'] = formatChan($format[2]);
 	}
-
+	
 	return $array;
 }
 
@@ -1603,7 +1603,7 @@ function updMpdConf($i2sdevice) {
 
 	// ALSA local (outputs 1 - 5)
 	$names = array (
-		"name \"ALSA default\"\n" . "device \"hw:" . $device . ",0\"\n",
+		"name \"ALSA default\"\n" . "device \"hw:" . $device . ",0\"\nauto_format \"" . $auto_format . "\"\nauto_resample \"" . $auto_resample . "\"\n",
 		"name \"ALSA crossfeed\"\n" . "device \"crossfeed\"\n",
 		"name \"ALSA parametric eq\"\n" . "device \"eqfa4p\"\n",
 		"name \"ALSA graphic eq\"\n" . "device \"alsaequal\"\n",

--- a/www/mpd-config.php
+++ b/www/mpd-config.php
@@ -63,6 +63,10 @@ if (isset($_POST['save']) && $_POST['save'] == '1') {
 	submitJob('mpdcfg', $queueargs, $title, $message, $duration);
 }
 
+if (isset($_POST['update_mpd_tweaks']))  {	
+	cfgdb_update('cfg_mpd', $dbh, 'mpd_tweaks', $_POST['conf']['mpd_tweaks']);
+}	
+
 // Load settings
 $result = cfgdb_read('cfg_mpd', $dbh);
 $mpdconf = array();
@@ -197,6 +201,15 @@ $_mpd_select['zeroconf_enabled'] .= "<option value=\"yes\" " . (($mpdconf['zeroc
 $_mpd_select['zeroconf_enabled'] .= "<option value=\"no\" " . (($mpdconf['zeroconf_enabled'] == 'no') ? "selected" : "") . ">No</option>\n";
 $_mpd_select['zeroconf_name'] = $mpdconf['zeroconf_name'];
 */
+
+// mpd-tweaks
+$_select['alsa_tweaks1'] .= "<input type=\"radio\" name=\"conf[mpd_tweaks]\" id=\"togglealsa_tweaks1\" value=\"1\" " . (($mpdconf['mpd_tweaks'] == 1) ? "checked=\"checked\"" : "") . ">\n";
+$_select['alsa_tweaks0'] .= "<input type=\"radio\" name=\"conf[mpd_tweaks]\" id=\"togglealsa_tweaks2\" value=\"0\" " . (($mpdconf['mpd_tweaks'] == 0) ? "checked=\"checked\"" : "") . ">\n";
+
+$_mpd_tweaks_unlock = ($mpdconf['mpd_tweaks_unlock'] == 0) ? "style=\"visibility:hidden;\"" : ""; // the prevents that the tweaks are even visible
+$_mpd_tweaks_visible_style = ($mpdconf['mpd_tweaks'] == 0 or $mpdconf['mpd_tweaks_unlock'] == 0) ? "style=\"visibility:hidden;\"" : ""; // help to hide or show mpd tweak settings
+$mpdconf[mpd_extra_params]=htmlspecialchars($mpdconf[mpd_extra_params]); // escape the mpd params string
+$mpdconf[mpd_dev_extra_params]=htmlspecialchars($mpdconf[mpd_dev_extra_params]); // escape the mpd params string
 
 waitWorker(1, 'mpd-config');
 

--- a/www/mpd-config.php
+++ b/www/mpd-config.php
@@ -177,17 +177,19 @@ $_mpd_select['period_time'] .= "<option value=\"512000000\" " . (($mpdconf['peri
 $_mpd_select['period_time'] .= "<option value=\"64000000\" " . (($mpdconf['period_time'] == '64000000') ? "selected" : "") . " >0.25X</option>\n";
 $_mpd_select['period_time'] .= "<option value=\"640000\" " . (($mpdconf['period_time'] == '640000') ? "selected" : "") . " >0.0025X</option>\n";
 $_mpd_select['period_time'] .= "<option value=\"64000\" " . (($mpdconf['period_time'] == '64000') ? "selected" : "") . " >0.00025X</option>\n";
-
+*/
 // ALSA auto-resample
 $_mpd_select['auto_resample'] .= "<option value=\"yes\" " . (($mpdconf['auto_resample'] == 'yes') ? "selected" : "") . " >Yes</option>\n";
 $_mpd_select['auto_resample'] .= "<option value=\"no\" " . (($mpdconf['auto_resample'] == 'no') ? "selected" : "") . " >No</option>\n";
+/*
 // ALSA auto-channels, r45b
 $_mpd_select['auto_channels'] .= "<option value=\"yes\" " . (($mpdconf['auto_channels'] == 'yes') ? "selected" : "") . " >Yes</option>\n";
 $_mpd_select['auto_channels'] .= "<option value=\"no\" " . (($mpdconf['auto_channels'] == 'no') ? "selected" : "") . " >No</option>\n";
+*/
 /// ALSA auto-format, r45b
 $_mpd_select['auto_format'] .= "<option value=\"yes\" " . (($mpdconf['auto_format'] == 'yes') ? "selected" : "") . " >Yes</option>\n";
 $_mpd_select['auto_format'] .= "<option value=\"no\" " . (($mpdconf['auto_format'] == 'no') ? "selected" : "") . " >No</option>\n";
-*/
+
 
 /* DEPRECATE
 // Zeroconf

--- a/www/templates/mpd-config.html
+++ b/www/templates/mpd-config.html
@@ -83,36 +83,7 @@
                 </div>
             </div>
 
-		    <div class="control-group">							
-                <label class="control-label" for="auto-resample">ALSA auto-resample</label>
-                <div class="controls">
-					<select id="auto-resample" name="conf[auto_resample]" class="input-large">
-						$_mpd_select[auto_resample]
-					</select>
-					<a aria-label="Help" class="info-toggle" data-cmd="info-auto-resample" href="#notarget"><i class="fas fa-info-circle"></i></a>
-					<span id="info-auto-resample" class="help-block-configs help-block-margin hide">
-						Setting this to "No" disables ALSA's software resampling. NOTE: This lets MPD do the resampling if the hardware does not support the required sample rate. Default: "Yes".
-					</span>
-                </div>
-            </div>
-
-			<div class="control-group">
-                <label class="control-label" for="auto-format">ALSA auto-format</label>
-                <div class="controls">
-					<select id="auto-format" name="conf[auto_format]" class="input-large">
-						$_mpd_select[auto_format]
-					</select>
-					<a aria-label="Help" class="info-toggle" data-cmd="info-auto-format" href="#notarget"><i class="fas fa-info-circle"></i></a>
-					<span id="info-auto-format" class="help-block-configs help-block-margin hide">
-						Setting this to "No" disables ALSA's sample format conversion. WARNING: If set to "No" and the hardware does not support the required sample format MPD will fail to open the audio output. Default: "Yes".
-					</span>
-					<!--
-					<span class="help-block-configs help-block-margin">
-	                    WARNING: Setting this to "No" is not compatible with Crossfeed, Parametric EQ or Graphic EQ.
-					</span>
-					-->
-                </div>
-            </div> 			
+ 			
 
             <!--div class="control-group">
                 <label class="control-label" for="gapless-mp3-playback">Gapless mp3 playback</label>
@@ -311,7 +282,76 @@
 	                    WARNING: Setting this to "No" is not compatible with Crossfeed, Parametric EQ or Graphic EQ.
 					</span>
                 </div>
-            </div--> 			
+            </div--> 		
+			<div class="control-group" $_mpd_tweaks_unlock>
+			    <legend>MPD Tweaks</legend>
+				<label class="control-label">Enable MPD Tweaks</label>
+				<div class="controls">
+					<div class="toggle">
+	                    <label class="toggle-radio" for="togglealsa_tweaks2">ON</label>
+						$_select[alsa_tweaks1]
+						<label class="toggle-radio" for="togglealsa_tweaks1">OFF</label>
+						$_select[alsa_tweaks0]					
+					</div>
+					<div style="display: inline-block; vertical-align: top; margin-top: 4px;">
+						<button class="btn btn-primary btn-small btn-submit" type="submit" name="update_mpd_tweaks" value="novalue">Set</button>
+						<a aria-label="Help" class="info-toggle" data-cmd="info-mpd-tweaks" href="#notarget"><i class="fas fa-info-circle"></i></a>
+					</div>
+					<span id="info-mpd-tweaks" class="help-block-configs help-block-margin2 hide">
+						Enable manualy tweaking of the MPD options. Only enable this option if you know what you doing! Tweaks can lead to unasable configuration.
+                    </span>
+					<span class="help-block-configs help-block-margin">
+	                    Enabling MPD tweaks  may lead to an unusable system!<br>
+					</span>
+				</div>
+			</div>
+
+			<div class="control-group" $_mpd_tweaks_visible_style>										    
+                <label class="control-label" for="auto-resample">Auto resample</label>
+                <div class="controls">
+					<select id="auto-resample" name="conf[auto_resample]" class="input-large">
+						$_mpd_select[auto_resample]
+					</select>
+					<a aria-label="Help" class="info-toggle" data-cmd="info-auto-resample" href="#notarget"><i class="fas fa-info-circle"></i></a>
+					<span id="info-auto-resample" class="help-block-configs help-block-margin hide">
+						Setting this to "No" disables MPD's software resampling for the default audio device. NOTE: This lets MPD do the resampling if the hardware does not support the required sample rate. Default: "Yes".
+					</span>
+                </div>
+            </div>
+
+			<div class="control-group" $_mpd_tweaks_visible_style>
+                <label class="control-label" for="auto-format">Auto format</label>
+                <div class="controls">
+					<select id="auto-format" name="conf[auto_format]" class="input-large" >
+						$_mpd_select[auto_format]
+					</select>
+					<a aria-label="Help" class="info-toggle" data-cmd="info-auto-format" href="#notarget"><i class="fas fa-info-circle"></i></a>
+					<span id="info-auto-format" class="help-block-configs help-block-margin hide">
+						Setting this to "No" disables MPD's sample format conversion for the default audio device. WARNING: If set to "No" and the hardware does not support the required sample format MPD will fail to open the audio output. Default: "Yes".
+					</span>					
+                </div>
+            </div>	
+
+		   <div class="control-group" $_mpd_tweaks_visible_style>  
+                <label class="control-label" for="mpd-extra-params">General parameters</label>
+                <div class="controls">				
+                    <input class="input-large" type="text" id="mpd-extra-params" name="conf[mpd_extra_params]" value="$mpdconf[mpd_extra_params]">
+					<span class="help-block-configs help-block-margin">
+						Provide additional general MPD parameters. See MPD.conf for more information. Multiple parameters are separated by a ";".
+					</span>
+                </div>
+            </div>
+
+		   <div class="control-group" $_mpd_tweaks_visible_style>  
+                <label class="control-label" for="mpd-dev-extra-params">Device parameters</label>
+                <div class="controls">				
+                    <input class="input-large" type="text" id="mpd-dev-extra-params" name="conf[mpd_dev_extra_params]" value="$mpdconf[mpd_dev_extra_params]">					
+					<span class="help-block-configs help-block-margin">
+						Provide additional MPD parameters to the default output device. See MPD.conf for more information. Multiple parameters are separated by a ";".
+					</span>					
+                </div>
+            </div>
+
 		</fieldset>		
     </form>
 </div>

--- a/www/templates/mpd-config.html
+++ b/www/templates/mpd-config.html
@@ -83,6 +83,37 @@
                 </div>
             </div>
 
+		    <div class="control-group">							
+                <label class="control-label" for="auto-resample">ALSA auto-resample</label>
+                <div class="controls">
+					<select id="auto-resample" name="conf[auto_resample]" class="input-large">
+						$_mpd_select[auto_resample]
+					</select>
+					<a aria-label="Help" class="info-toggle" data-cmd="info-auto-resample" href="#notarget"><i class="fas fa-info-circle"></i></a>
+					<span id="info-auto-resample" class="help-block-configs help-block-margin hide">
+						Setting this to "No" disables ALSA's software resampling. NOTE: This lets MPD do the resampling if the hardware does not support the required sample rate. Default: "Yes".
+					</span>
+                </div>
+            </div>
+
+			<div class="control-group">
+                <label class="control-label" for="auto-format">ALSA auto-format</label>
+                <div class="controls">
+					<select id="auto-format" name="conf[auto_format]" class="input-large">
+						$_mpd_select[auto_format]
+					</select>
+					<a aria-label="Help" class="info-toggle" data-cmd="info-auto-format" href="#notarget"><i class="fas fa-info-circle"></i></a>
+					<span id="info-auto-format" class="help-block-configs help-block-margin hide">
+						Setting this to "No" disables ALSA's sample format conversion. WARNING: If set to "No" and the hardware does not support the required sample format MPD will fail to open the audio output. Default: "Yes".
+					</span>
+					<!--
+					<span class="help-block-configs help-block-margin">
+	                    WARNING: Setting this to "No" is not compatible with Crossfeed, Parametric EQ or Graphic EQ.
+					</span>
+					-->
+                </div>
+            </div> 			
+
             <!--div class="control-group">
                 <label class="control-label" for="gapless-mp3-playback">Gapless mp3 playback</label>
                 <div class="controls">
@@ -239,7 +270,7 @@
                 </div>
             </div>
 
-			<div class="control-group">
+				<div class="control-group">			
 				<legend>ALSA auto-conversion</legend>
                 <label class="control-label" for="auto-resample">ALSA auto-resample</label>
                 <div class="controls">
@@ -264,7 +295,7 @@
 						Setting this to "No disables ALSA's channel conversion. WARNING: If set to "No" and the hardware does not support the required number of channels MPD will fail to open the audio output. Default: "Yes".
 					</span>
                 </div>
-            </div>
+            </div>			
 
 			<div class="control-group">
                 <label class="control-label" for="auto-format">ALSA auto-format</label>
@@ -280,7 +311,7 @@
 	                    WARNING: Setting this to "No" is not compatible with Crossfeed, Parametric EQ or Graphic EQ.
 					</span>
                 </div>
-            </div-->
+            </div--> 			
 		</fieldset>		
     </form>
 </div>


### PR DESCRIPTION
In the past the auto_format and auto_resample where marked DEPRECATE.  Not sure why, probally because it was not compatible with Alsa EQ, Crossfeed etc.

Since then, after modification MPD.conf, I always patch my MPD.conf to add auto_format and auto_resample again. It is required to make my DAC work correctly with 16bits format, which is a DDDAC 1794.

In this PR only de ALSA Default is affected. Did put the items under the Audio Device group, but maybe I should put under a tweak group on the bottom ?