### PR TITLE
Make moode context menu behave more like native menus

### DIFF
--- a/var/local/www/header.php
+++ b/var/local/www/header.php
@@ -100,6 +100,7 @@
 <body onorientationchange="javascript:location.reload(true); void 0;">
 	<!-- ALBUM COVER BACKDROP -->
 	<div aria-label="Album Cover Backdrop" id="cover-backdrop"></div>
+	<div id="context-backdrop"></div>
 
 	<!-- HEADER -->
 	<div id="menu-top" class="ui-header ui-bar-f ui-header-fixed slidedown" data-position="fixed" data-role="header" role="banner">

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -354,6 +354,7 @@ img.lib-coverart.active {box-shadow:0px 0px .2em .1em var(--accentxts);}
 #random-albumcover i {color:var(--adapttext);opacity:.3}
 .albumcover {max-height:2.75em;overflow:hidden;}
 #cover-backdrop {height:100vh;filter:blur(20px);overflow:hidden;position:fixed;top:0;left:0;transform:scale(1.2);}
+#context-backdrop {height:100vh;width:100vw;;overflow:hidden;position:fixed;top:0;left:0;z-index:9998;display:none;}
 /* radio list view */
 .database-radiolist {text-align:left;padding-left:2rem;}
 .database-radiolist li {width:90%;display:inline-block;margin:0;font-size:1rem;}

--- a/www/js/bootstrap-contextmenu.js
+++ b/www/js/bootstrap-contextmenu.js
@@ -74,7 +74,7 @@
 			$menu.attr('style', '')
 				.css(tp)
 				.addClass('open');
-
+				$('#context-backdrop').show();
 
 			return false;
 		}
@@ -107,6 +107,7 @@
 			$('html').on('click.context.data-api', function (e) {
 				if (!e.ctrlKey) {
 					$target.removeClass('open');
+					$('#context-backdrop').hide();
 				}
 			});
 		}
@@ -176,6 +177,7 @@
 				$('[data-toggle=context]').each(function() {
 					this.getMenu()
 						.removeClass('open');
+					$('#context-backdrop').hide();
 				});
 			}
 		}

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -2910,3 +2910,9 @@ $('#playbar-switch, #playbar-cover').click(function(e){
 		}
 	}
 });
+
+$('#context-backdrop').click(function(e){
+	$('#context-backdrop').hide();
+	$('.context-menu').removeClass('open');
+	$('.context-menu-lib').removeClass('open');
+})


### PR DESCRIPTION
This makes it so clicking off a context menu will dismiss the menu instead of acting on the click. This is how native context menus work and also lets us get rid of all the 'close' menu items.