### PR TITLE
Appearance option: Show covers in Tag view: Yes/No

### DIFF
--- a/www/footer.php
+++ b/www/footer.php
@@ -334,6 +334,28 @@
 		                    	Display additional metadata under the cover art on the Playback panel.<br>
 	                    </span>
 	                </div>
+                    
+   	                <label class="control-label" for="tagviewcovers-display">Show covers in Tag view</label>
+	                <div class="controls">
+   						<div class="btn-group bootstrap-select bootstrap-select-mini">
+							<button type="button" class="btn btn-inverse dropdown-toggle" data-toggle="dropdown">
+								<div id="tagviewcovers-display" class="filter-option pull-left">
+									<span></span> <!-- selection from dropdown gets placed here -->
+								</div>&nbsp;
+								<div class="caret"></div>
+							</button>
+							<div class="dropdown-menu open">
+								<ul class="dropdown-menu custom-select inner" role="menu">
+									<li class="modal-dropdown-text"><a href="#notarget" data-cmd="tagviewcovers-display-yn"><span class="text">Yes</span></a></li>
+									<li class="modal-dropdown-text"><a href="#notarget" data-cmd="tagviewcovers-display-yn"><span class="text">No</span></a></li>
+								</ul>
+							</div>
+						</div>
+						<a aria-label="Help" class="info-toggle" data-cmd="info-tagviewcovers-display" href="#notarget"><i class="fas fa-info-circle"></i></a>
+						<span id="info-tagviewcovers-display" class="help-block hide">
+		                    	Display cover art thumbnails in the Album column of the Tag view.<br>
+	                    </span>
+	                </div>                    
 
    	                <label class="control-label" for="play-history-enabled">Playback history</label>
 	                <div class="controls">

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -725,6 +725,13 @@ function renderUI() {
 	else {
 		$('#extratags, #ss-extratags').html('');
 	}
+    
+	if (SESSION.json['tagviewcovers'] == 'Yes') {
+        UI.tagViewCovers = true;
+    }
+    else {
+        UI.tagViewCovers = false;
+    }  
 
 	// default metadata
 	if (MPD.json['album']) {
@@ -1836,6 +1843,7 @@ $('.context-menu a').click(function(e) {
 		// general
 		$('#play-history-enabled span').text(SESSION.json['playhist']);
 		$('#extratag-display span').text(SESSION.json['xtagdisp']);
+		$('#tagviewcovers-display span').text(SESSION.json['tagviewcovers']);
 		$('#ashuffle-filter').val(SESSION.json['ashuffle_filter']);
 
 		// themes and backgrounds
@@ -2057,8 +2065,10 @@ $('.btn-appearance-update').click(function(e){
 	var scnSaverTimeoutChange = false;
 	var scnSaverStyleChange = false;
     var playHistoryChange = false;
+	var tagViewCoversChange = false;
 	// general
 	if (SESSION.json['xtagdisp'] != $('#extratag-display span').text()) {xtagdispChange = true;}
+	if (SESSION.json['tagviewcovers'] != $('#tagviewcovers-display span').text()) {tagViewCoversChange = true;}    
 	if (SESSION.json['scnsaver_timeout'] != screenSaverTimeout($('#scnsaver-timeout span').text(), 'value')) {scnSaverTimeoutChange = true;}
 	if (SESSION.json['scnsaver_style'] != $('#scnsaver-style span').text()) {scnSaverStyleChange = true;}
 	// theme and backgrounds
@@ -2075,6 +2085,7 @@ $('.btn-appearance-update').click(function(e){
 	// general
 	SESSION.json['playhist'] = $('#play-history-enabled span').text();
 	SESSION.json['xtagdisp'] = $('#extratag-display span').text();
+	SESSION.json['tagviewcovers'] = $('#tagviewcovers-display span').text();    
 	SESSION.json['ashuffle_filter'] = $('#ashuffle-filter').val().trim() == '' ? 'None' : $('#ashuffle-filter').val();
 	// theme and backgrounds
 	SESSION.json['themename'] = $('#theme-name span').text();
@@ -2092,6 +2103,7 @@ $('.btn-appearance-update').click(function(e){
 	var result = sendMoodeCmd('POST', 'updcfgsystem',
 		{'playhist': SESSION.json['playhist'],
 		 'xtagdisp': SESSION.json['xtagdisp'],
+		 'tagviewcovers': SESSION.json['tagviewcovers'],
 		 'ashuffle_filter': SESSION.json['ashuffle_filter'],
 		 'themename': SESSION.json['themename'],
 		 'accent_color': SESSION.json['accent_color'],
@@ -2141,7 +2153,7 @@ $('.btn-appearance-update').click(function(e){
 	}
 
 	// auto-reload page if indicated
-	if (xtagdispChange == true || scnSaverStyleChange == true || playHistoryChange == true || UI.bgImgChange == true) {
+	if (xtagdispChange == true || scnSaverStyleChange == true || playHistoryChange == true || UI.bgImgChange == true || tagViewCoversChange == true) {
 	    notify('updcustomize', 'Auto-refresh in 3 seconds');
 		setTimeout(function() {
 			location.reload(true);
@@ -2303,6 +2315,9 @@ $('body').on('click', '.dropdown-menu .custom-select a', function(e) {
 	else if ($(this).data('cmd') == 'extratag-display-yn') {
 		$('#extratag-display span').text($(this).text());
 	}
+	else if ($(this).data('cmd') == 'tagviewcovers-display-yn') {
+		$('#tagviewcovers-display span').text($(this).text());
+	}    
 	else if ($(this).data('cmd') == 'play-history-enabled-yn') {
 		$('#play-history-enabled span').text($(this).text());
 	}


### PR DESCRIPTION
Adds an option in the Appearance configuration panel to show/hide album cover thumbnails in Album column of the Tag View.  I believe this is one of the 'Issues' you were looking to implement Tim.

Requires entry in db table cfg_system "tagviewcovers" default: Yes