### PR TITLE
ui updates 2

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -42,7 +42,7 @@ a.btn.btn-medium.btn-primary {font-size:16px;}
 /* general */
 .modal-backdrop{position:fixed;top:0;right:0;bottom:0;left:0;z-index:10000;background-color:var(--modalbkdr);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);}
 .modal-backdrop.fade{opacity:0;}
-.modal-backdrop,.modal-backdrop.fade.in{opacity:.9;}
+.modal-backdrop,.modal-backdrop.fade.in{opacity:1;}
 .modal{position:fixed;top:0;top:env(safe-area-inset-top);left:50%;z-index:10001;width:40%;min-width:560px;font-size:1rem;opacity:.9;background-color:inherit;border:none;margin-left:0;border-radius:.4em;box-shadow:0 3px 7px rgba(0, 0, 0, 0.3);background-clip:padding-box;outline:none;transform:translate(-50%,0%);-webkit-overflow-scrolling:touch;} /* 6.4.1 no font size */
 .modal h4 {font-size:1.25em;}
 .modal-header{padding:1em 1em 1.5em 1em;border-bottom:none;}
@@ -252,12 +252,18 @@ li.modal-dropdown-text:focus {color:#eee;}
 	.playlist .pl-action, .playlist .db-action a {padding:.4em 1.25em 1em 0;}
 	.ui-pnotify {top:40% !important;}
 	#lib-albumcover {left:0;}
-	#albumsList li {max-width:calc(50vw - 1px) !important;}
-	#albumcovers .lib-entry, .database-radio li {width:45vw;font-size:.9em;padding-bottom:1em;margin:0 1vw;}
+	#albumsList li {max-width:calc(50vw - 1px) !important;min-width:33vw;}
+	#albumsList.limited span {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
+	#albumsList .album-name-art {max-width:calc(48vw - 1rem);}
+	#albumsList .album-name {max-width:44vw;}
+	#albumsList .artist-name-art, #albumsList .album-year {max-width:calc(35vw - 1rem);}
+	#albumsList.limited .album-name-art {max-width:calc(48vw - 3.6rem);}
+	#albumsList.limited .artist-name-art, #albumsList .album-year {max-width:calc(35vw - 3.6rem);}
+	#albumcovers.limited span {max-width:calc(var(--mthumbcols) - 4em);}
+	#albumcovers.limited .album-name {max-width:var(--mthumbcols);}
+	#albumcovers .lib-entry, .database-radio li {width:var(--mthumbcols);font-size:.9em;padding-bottom:1em;margin:0 1vw;}
 	#albumcovers .lib-entry {padding-bottom:.4em;}
-	#albumcovers .lib-entry img, .database-radio img {width:90%;max-height:calc(45vw * .9);margin:.75em 0 .5em 0;}
-	#albumcovers li.limited span {max-width:calc(45vw - 4em);}
-	#albumcovers li.limited .album-name {max-width:45vw;}
+	#albumcovers .lib-entry img, .database-radio img {width:90%;max-height:calc(var(--mthumbcols) * .9);margin:.75em 0 .5em 0;}
 	#ss-currentsong {font-size:1.5em;}
 	#ss-currentalbum, #ss-currentartist {font-size:1.25em;}
 	#ss-coverart-url img {width:65vh;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -47,6 +47,8 @@ html, body {background-attachment:fixed;background-size:cover;height:100%;color:
 	--pbfont:calc(0.45em + 1vmin);
 	--radiobadge:url('../images/radio-l.svg');
 	--defcover:'images/default-cover-v6-l.svg';
+	--thumbcols:18vw;
+	--mthumbcols:45vw;
 }
 
 .btn {-webkit-tap-highlight-color: rgba(0, 0, 0, 0);-webkit-user-select: none;-webkit-touch-callout: none;}
@@ -201,9 +203,9 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #albumsList .lib-entry img {width:3rem;margin:.3em .35em .3em .15em;}
 #albumsList .tag-cover-text {display:inline-block;vertical-align:middle;transform:translate(0, .5em);min-width:50%;max-width:calc(100% - 3.6rem)}
 #albumsList .album-name-art {display:block;vertical-align:middle;max-width:calc(100% - 1em);min-width:25vw;line-height:1.25em;overflow:hidden;white-space:normal;text-overflow:ellipsis;}
-#albumsList li.limited .album-name-art, #albumsList li.limited .artist-name-art {white-space:nowrap;}
+#albumsList.limited .album-name-art, #albumsList.limited .artist-name-art {white-space:nowrap;}
 #albumsList .album-name {display:inline-block;vertical-align:middle;max-width:calc(100% - 1em);min-width:25vw;line-height:normal;}
-#albumsList .artist-name-art, #albumsList .album-year {display:inline-block;font-size:0.85em;line-height:normal;color:var(--textvariant);vertical-align:top;max-width:calc(100% - 1em);line-height:1.25em;overflow:hidden;white-space:normal;text-overflow:ellipsis;}
+#albumsList .artist-name-art, #albumsList .album-year {display:inline-block;font-size:0.85em;line-height:normal;color:var(--textvariant);vertical-align:top;max-width:calc(25vw - 3.6em);line-height:1.25em;overflow:hidden;white-space:normal;text-overflow:ellipsis;}
 #albumsList .artist-name {display:none}
 #albumsList .album-year {margin-left:.5em;}
 
@@ -284,6 +286,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .ui-pnotify .alert,.ui-pnotify .alert h4 {color:#333;text-shadow:none;text-align:center;}
 .ui-pnotify .alert span {margin-top:4px;}
 .ui-pnotify .alert h4 {font-size:1em;font-weight:600;text-align:center;}
+.ui-pnotify-text {padding-top:1em;}
 .ui-pnotify-sticker {position:absolute;right:2.1em;}
 .ui-pnotify-closer {position:absolute;right:1em;}
 .btn-primary {text-transform:uppercase;font-weight:500;}
@@ -386,8 +389,8 @@ img.lib-coverart.active {box-shadow:0px 0px .2em .1em var(--accentxts);}
 #albumcovers .lib-entry .album-year {display:inline-block;margin:0 .15em;}
 .albumcover {max-height:2.75em;overflow:hidden;}
 #albumcovers li span {display:block;white-space:normal;}
-#albumcovers li.limited span {white-space:nowrap;max-height:1.5em;max-width:calc(18vw - 4em);overflow:hidden;text-overflow:ellipsis;}
-#albumcovers li.limited .album-name {max-width:18vw;}
+#albumcovers.limited span {white-space:nowrap;max-height:1.5em;max-width:calc(18vw - 4em);overflow:hidden;text-overflow:ellipsis;}
+#albumcovers.limited .album-name {max-width:18vw;}
 #lib-albumcover-header {display:none;position:absolute;top:env(safe-area-inset-top);width:100vw;transform: translate(-50%);left:50%;}
 #albumcoverheader {line-height:2.75rem !important;position:absolute !important;height:2.75rem;width:15%;left:75%;transform:translate(-50%);}
 #albumview-header-text {display:none;background:none;text-transform:unset;font-size:1.1rem;padding:0 3rem;}

--- a/www/js/jquery.knob.js
+++ b/www/js/jquery.knob.js
@@ -263,8 +263,8 @@
 
             // finalize canvas with computed width + pixel offset
             this.$c.attr({
-                width: this.w,
-                height: this.h
+                width: this.w + 4,
+                height: this.h + 4
             });
 
             // scaling
@@ -727,7 +727,7 @@
                 && (eat = eat + this.cursorExt);
             c.beginPath();
                 c.strokeStyle = this.o.bgColor;
-                c.arc(this.xy, this.xy, this.radius, this.endAngle, this.startAngle, true);
+                c.arc(this.xy + 2, this.xy + 2, this.radius, this.endAngle, this.startAngle, true);
             c.stroke();
 
             if (this.o.displayPrevious) {
@@ -739,7 +739,7 @@
 
                 c.beginPath();
                     c.strokeStyle = this.pColor;
-                    c.arc(this.xy, this.xy, this.radius, sa, ea, false);
+                    c.arc(this.xy + 2, this.xy + 2, this.radius, sa, ea, false);
                 c.stroke();
                 r = (this.cv == this.v);
             }
@@ -764,7 +764,7 @@
 				}
 				//c.shadowColor = r ? this.o.fgColor : this.fgColor ;
                 c.strokeStyle = r ? this.o.fgColor : this.fgColor ;
-                c.arc(this.xy, this.xy, this.radius, sat, eat, false);
+                c.arc(this.xy + 2, this.xy + 2, this.radius, sat, eat, false);
             c.stroke();
         };
 

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -1618,7 +1618,7 @@ function setVolume(level, event) {
 function customScroll(list, itemNum, speed) {
 	//console.log('list=' + list + ', itemNum=(' + itemNum + '), speed=(' + speed + ')');
 	var listSelector, scrollSelector, chDivisor, centerHeight, scrollTop, itemHeight, scrollCalc, scrollOffset, itemPos;
-	speed = typeof(speed) === 'undefined' ? 500 : speed;
+	speed = typeof(speed) === 'undefined' ? 200 : speed;
 
 	if (list == 'db') {
 		listSelector = '#database';
@@ -2697,7 +2697,8 @@ function btnbarfix(temp1,temp2) {
 	tempcolor = rgbaToRgb(.6, '.7', temprgba, temprgb); // textvariant
 	document.body.style.setProperty('--btnshade3', tempcolor);
 	document.body.style.setProperty('--btnshade4', getYIQ(temp1) > 127 ? 'rgba(32,32,32,0.10)' : 'rgba(208,208,208,0.17)');
-	document.body.style.setProperty('--modalbkdr', rgbaToRgb(.95, '.95', temprgba, temprgb));
+	$('#content').hasClass('visacc') ? op = .95 : op = .9;
+	document.body.style.setProperty('--modalbkdr', rgbaToRgb(.95, op, temprgba, temprgb));
 	if ($('#content').hasClass('visacc')) {
 		(currentView.indexOf('playback') == -1 || SESSION.json['adaptive'] == 'No') ? UI.accenta = themeMcolor : UI.accenta = adaptMcolor;
 	} else {

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -498,7 +498,6 @@ var renderAlbums = function() {
 	var tagViewYear = '';   // For display of Artist (Year) in Tag View
 	var albumViewYear = '';  // For display of Artist (Year) in Album View
 	var defCover = "this.src='images/default-cover-v6.svg'";
-	SESSION.json["library_ellipsis_limited_text"] == "Yes" ? liClass = 'lib-entry limited' : liClass = 'lib-entry';
 
     // Clear search filter and results
 	$('#lib-album-filter').val('');
@@ -510,16 +509,16 @@ var renderAlbums = function() {
         filteredAlbumCovers[i].year ? albumViewYear = ' (' + filteredAlbumCovers[i].year + ')' : albumViewYear = '';
 
 		if (SESSION.json['library_tagview_covers'] == 'Yes') {
-			output += '<li class="' + liClass + '">'
+			output += '<li class="lib-entry">'
              + '<img class="lazy-tagview" data-original="' + filteredAlbums[i].imgurl + '">'
              + '<div class="tag-cover-text"><span class="album-name-art">' + filteredAlbums[i].album
              + '</span><span class="artist-name-art">' + filteredAlbums[i].artist + '</span><span class="album-year">' + tagViewYear + '</span></div></li>'		}
 		else {
-			output += '<li class="' + liClass + '"><span class="album-name">' + filteredAlbums[i].album
+			output += '<li class="lib-entry"><span class="album-name">' + filteredAlbums[i].album
              + '</span><span class="artist-name">' + filteredAlbums[i].artist + tagViewYear + '</span></li>'
         }
 
-		output2 += '<li class="' + liClass + '">'
+		output2 += '<li class="lib-entry">'
             + '<img class="lazy-albumview" data-original="' + filteredAlbumCovers[i].imgurl + '">'
             + '<div class="cover-menu" data-toggle="context" data-target="#context-menu-lib-all"></div>'
             + '<span class="album-name">' + filteredAlbumCovers[i].album + '</span>'
@@ -533,6 +532,9 @@ var renderAlbums = function() {
 	if (filteredAlbums.length == 1) {
 		    $('#albumsList li').addClass('active');
 			LIB.albumClicked = true;
+	}
+	if (SESSION.json["library_ellipsis_limited_text"] == "Yes") {
+		$('#albumsList, #albumcovers').addClass('limited');
 	}
 
 	// Headers clicked

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -204,7 +204,6 @@
 						<div id="lib-album-header">
 							<li id="albumheader">
 								<div id="tagview-header-text" class="lib-heading">Albums</div>
-								<div aria-label="Recently Added" class="recently-added"><i class="far fa-filter"></i></div>
 								<div aria-label="Random Album" id="random-album"><i class="far fa-dot-circle"></i></div>
 							</li>
 						</div>


### PR DESCRIPTION
#1 take 2 ellipsis madness

#2 test using a css var for li width with eye towards a possible pref to set number of columns.

#3 change modal backdrop opacity to 1 in css since it already has an opacity, set the lower value in the computed color instead (in btnbarfix)

#4 add some padding-top to the alert second text line which I noticed because of the appearance library stuff but iirc we can just reload the library rather than refresh, and around half of the options don't need to even do that.

#5 take 2 knob fix wrt bloom

#6 remove filter icon from tag view album header

#7 last minute but seems ok, add limited class to the ul instead of the individual li elements, this way we save a bunch of memory and we can switch on the fly when I get around to making library options not always auto-refresh.