### PR TITLE
ui updates 4

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -95,8 +95,8 @@ li.modal-dropdown-text:focus {color:#eee;}
 
 /* dropdown menus */
 
-.dropdown-menu > li > a {line-height:2.75em;margin:0;padding:0 .5em;background:none;color:var(--adapttext);font-size:1.1rem;white-space:nowrap;}
-.dropdown-menu {float:right;position:absolute;min-width:180px;left:auto;border:none;list-style:none outside none;background-color:var(--adaptmbg);border:none;box-shadow:0px 4px 10px rgba(0, 0, 0, 0.4);border-radius:.5em;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);z-index:1000;}
+.dropdown-menu > li > a {line-height:2.75em;margin:0;padding:0 .5em;background:none;color:var(--adapttext);font-size:1rem;white-space:nowrap;}
+.dropdown-menu {float:right;position:absolute;min-width:200px;left:auto;border:none;list-style:none outside none;background-color:var(--adaptmbg);box-shadow:0px 4px 10px rgba(0, 0, 0, 0.4);border-radius:.5em;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);z-index:1000;white-space:normal;}
 .dropdown-menu.open {padding:0;margin:0;}
 .bootstrap-select .dropdown-menu {background-color:transparent;}
 .btn-group.open.bootstrap-select .btn.dropdown-toggle {background-color:rgba(128,128,128,0.3);box-shadow:none;border-radius:4px;}
@@ -222,6 +222,8 @@ li.modal-dropdown-text:focus {color:#eee;}
 /* smaller portrait for small screens */
 @media (max-width:479px) and (orientation:portrait) {
 	/*body {font-size:calc(.75em + 1vmin);}*/
+	.dropdown-menu {min-width:180px;}
+	.dropdown-menu > li > a {font-size:1.12rem;}
 	#playback-panel, #content {position:relative;}
 	.modal-body{max-height:calc(100vh - 13.5rem - env(safe-area-inset-bottom));}
 	.modal-footer .btn {width:40%;}
@@ -252,18 +254,11 @@ li.modal-dropdown-text:focus {color:#eee;}
 	.playlist .pl-action, .playlist .db-action a {padding:.4em 1.25em 1em 0;}
 	.ui-pnotify {top:40% !important;}
 	#lib-albumcover {left:0;}
-	#albumsList li {max-width:calc(50vw - 1px) !important;min-width:33vw;}
-	#albumsList.limited span {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
-	#albumsList .album-name-art {max-width:calc(48vw - 1rem);}
-	#albumsList .album-name {max-width:44vw;}
-	#albumsList .artist-name-art, #albumsList .album-year {max-width:calc(35vw - 1rem);}
-	#albumsList.limited .album-name-art {max-width:calc(48vw - 3.6rem);}
-	#albumsList.limited .artist-name-art, #albumsList .album-year {max-width:calc(35vw - 3.6rem);}
-	#albumcovers.limited span {max-width:calc(var(--mthumbcols) - 4em);}
-	#albumcovers.limited .album-name {max-width:var(--mthumbcols);}
-	#albumcovers .lib-entry, .database-radio li {width:var(--mthumbcols);font-size:.9em;padding-bottom:1em;margin:0 1vw;}
-	#albumcovers .lib-entry {padding-bottom:.4em;}
-	#albumcovers .lib-entry img, .database-radio img {width:90%;max-height:calc(var(--mthumbcols) * .9);margin:.75em 0 .5em 0;}
+	/* ellipsis madness */
+	#artistsList li, #genresList li, #albumsList li {max-width:calc(50vw - 2.3rem);min-width:33vw;}
+	#albumcovers .lib-entry, .database-radio .lib-entry {width:var(--mthumbcols);}
+	#albumcovers .lib-entry img, .database-radio img {max-height:calc(var(--mthumbcols) * .9);}
+
 	#ss-currentsong {font-size:1.5em;}
 	#ss-currentalbum, #ss-currentartist {font-size:1.25em;}
 	#ss-coverart-url img {width:65vh;}
@@ -399,7 +394,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 
 /* large screens */
 @media (min-height: 1080px) {
-	.dropdown-menu {min-width:220px;}
+	.dropdown-menu, #context-menu-playback .dropdown-menu {min-width:13em;}
 	#ss-backdrop {filter: blur(40px);}
 	#ss-currentsong {font-size:1.5em;}
 	#ss-currentalbum, #ss-currentartist {font-size:1.25em;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -49,6 +49,7 @@ html, body {background-attachment:fixed;background-size:cover;height:100%;color:
 	--defcover:'images/default-cover-v6-l.svg';
 	--thumbcols:18vw;
 	--mthumbcols:45vw;
+	--coverback:'';
 }
 
 .btn {-webkit-tap-highlight-color: rgba(0, 0, 0, 0);-webkit-user-select: none;-webkit-touch-callout: none;}
@@ -202,12 +203,21 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #top-columns.nogenre #albumsList li, #top-columns.nogenre #artistsList li {max-width:calc(50vw - 2.3rem);}
 #albumsList .lib-entry img {width:3rem;margin:.3em .35em .3em .15em;}
 #albumsList .tag-cover-text {display:inline-block;vertical-align:middle;transform:translate(0, .5em);min-width:50%;max-width:calc(100% - 3.6rem)}
-#albumsList .album-name-art {display:block;vertical-align:middle;max-width:calc(100% - 1em);min-width:25vw;line-height:1.25em;overflow:hidden;white-space:normal;text-overflow:ellipsis;}
-#albumsList.limited .album-name-art, #albumsList.limited .artist-name-art {white-space:nowrap;}
-#albumsList .album-name {display:inline-block;vertical-align:middle;max-width:calc(100% - 1em);min-width:25vw;line-height:normal;}
-#albumsList .artist-name-art, #albumsList .album-year {display:inline-block;font-size:0.85em;line-height:normal;color:var(--textvariant);vertical-align:top;max-width:calc(25vw - 3.6em);line-height:1.25em;overflow:hidden;white-space:normal;text-overflow:ellipsis;}
+#library-panel .lib-entry span {max-width:100%;display:inline-block;}
+#top-columns .lib-entry {font-size: 1em;}
+#top-columns .album-name-art, #top-columns .album-name {display:block !important;vertical-align:middle;min-width:25vw;line-height:1.25em;}
+.artist-name-art, #albumsList .album-year {font-size:.85em;color:var(--textvariant);}
+
 #albumsList .artist-name {display:none}
+#albumsList .artist-name-art, #albumsList .album-year {vertical-align:top;line-height:normal;}
 #albumsList .album-year {margin-left:.5em;}
+#library-panel.limited .artist-name-art, #library-panel.limited #albumcovers .artist-name {max-width:67%;}
+#library-panel.limited .lib-entry, #library-panel.limited .lib-entry span {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
+
+/*#albumsList .album-name-art {display:block;vertical-align:middle;max-width:calc(100% - 1em);min-width:25vw;line-height:1.25em;white-space:normal;}
+#albumsList .album-name {display:inline-block;vertical-align:middle;max-width:calc(100% - 1em);min-width:25vw;line-height:normal;}
+#albumsList .artist-name-art, #albumsList .album-year {display:inline-block;font-size:0.85em;line-height:normal;color:var(--textvariant);vertical-align:top;white-space:normal;}
+#albumsList.limited .album-name-art, #albumsList.limited .artist-name-art {white-space:nowrap;max-width:calc(24vw - 3.6em);text-overflow:ellipsis;overflow:hidden;}*/
 
 .database .active {font-size:inherit;font-weight:700;}
 .playlist .active .pll1 {color:var(--accentxts);font-weight:700;}
@@ -270,12 +280,14 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .reconnectbtn {position:relative;top:45%;text-transform:uppercase;color:#999;z-index:9999;}
 .viewswitch {position:fixed;top:0;top:env(safe-area-inset-top);left:50%;background-color:transparent;color:inherit;display:none;z-index:1001;line-height:2.75rem;font-size:inherit;transform:translate(-50%, 0%);height:2.75rem;align-items:center;left:.75rem;transform:none;}
 .viewswearch {height:2.25rem;padding:1.5rem 0 1.5rem 1rem !important;}
-#viewswitch span {float:right;display:none;transform:translate(.6rem);}
+#viewswitch span {float:right;display:none;}
+#searchResetLib {padding:.25em;position:relative;top:50%;transform:translate(0, -50%);font-size:1.2rem;}
 #viewswitch a {color:inherit;}
 .viewswitch div {display:flex;color:var(--adapttext);}
 .viewswitch .btn {position:relative;width:100%;line-height:normal;font-size:1.1rem;padding:.75rem 1rem;background-color:transparent;text-align:left;color:var(--textvariant);}
 .viewswitch .btn.active {color:inherit;}
 .viewswitch .btn:hover {background-color:var(--accentxta);}
+#viewswitch-search:hover {background-color:inherit;}
 .viewswitch .btn i {padding:0 .5rem 0 0;}
 #current-tab {font-size:1.1rem;font-weight:600;height:2.75rem;line-height:2.75rem;}
 #current-tab i {font-size:.7rem;margin-left:2px;}
@@ -379,25 +391,18 @@ img.lib-coverart.active {box-shadow:0px 0px .2em .1em var(--accentxts);}
 /* album cover panel */
 #lib-albumcover {height:100%;width:100%;position:absolute;box-sizing:border-box;left:0%;top:2.75em;top:calc(env(safe-area-inset-top) + 2.75em);overflow:auto;overflow-x:hidden;-webkit-overflow-scrolling:touch;}
 #albumcovers {text-align:center;margin:0;padding-bottom:12em;}
-#albumcovers li, .database-radio li {width:18vw;text-align:center;font-size:.95em;margin:0 .6vw;display:inline-block;vertical-align:top;height:auto;padding:0 0 .25rem 0;}
-/*#albumcovers .lib-entry span {display:block;max-height:1.5em;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;}*/
-#albumcovers .lib-entry img, .database-radio img {width:90%;max-height:calc(18vw * .9);margin:.5rem 0;box-shadow:0px 0px .25em rgba(0,0,0,0.3);border-radius:.1em;}
-#albumcovers .lib-entry {width:18vw;line-height:normal;padding:0 0 .2em 0;}
-#albumcovers .artyear	{color:var(--textvariant);font-weight:500;}
-#albumcovers .lib-entry .artist-name {display:inline-block;margin:0 .15em;}
-#albumcovers .lib-entry .album-name {color:inherit;font-weight:600;}
-#albumcovers .lib-entry .album-year {display:inline-block;margin:0 .15em;}
-.albumcover {max-height:2.75em;overflow:hidden;}
-#albumcovers li span {display:block;white-space:normal;}
-#albumcovers.limited span {white-space:nowrap;max-height:1.5em;max-width:calc(18vw - 4em);overflow:hidden;text-overflow:ellipsis;}
-#albumcovers.limited .album-name {max-width:18vw;}
+
+#albumcovers .lib-entry, .database-radio .lib-entry {width:var(--thumbcols);text-align:center;display:inline-block;vertical-align:top;height:auto;font-size:.95em;padding-bottom:.4em;margin:0 1vw;}
+#albumcovers .lib-entry img, .database-radio img {width:90%;max-height:calc(var(--thumbcols) * .9);margin:.75em 0 .5em 0;}
+#albumcovers .album-name {display:block !important;}
+#albumcovers .artyear {color:var(--textvariant);font-weight:500;}
+#albumcovers .artist-name, #albumcovers .album-year {margin:0 .15em;}
+
 #lib-albumcover-header {display:none;position:absolute;top:env(safe-area-inset-top);width:100vw;transform: translate(-50%);left:50%;}
 #albumcoverheader {line-height:2.75rem !important;position:absolute !important;height:2.75rem;width:15%;left:75%;transform:translate(-50%);}
 #albumview-header-text {display:none;background:none;text-transform:unset;font-size:1.1rem;padding:0 3rem;}
 #albumcoverheader .recently-added {margin:0;float:unset;padding:0;position:unset;opacity:1;}
 #albumcoverheader .recently-added i, #random-albumcover i {font-size:.9rem;opacity:0;} /* opacity hide for now */
-#cover-backdrop {filter:blur(20px);position:fixed;top:0;left:0;background-position:center center;height:100vh;width:100vw;background-size:cover;z-index:0;}
-#context-backdrop {height:100vh;width:100vw;;overflow:hidden;position:fixed;top:0;left:0;z-index:9998;display:none;}
 /*#random-albumcover {margin-top:-1.5em;float:right;position:relative;padding:.25em .5em 0em .5em;}
 #random-albumcover i {color:var(--adapttext);opacity:.3}
 .albumcover {max-height:2.75em;overflow:hidden;}*/
@@ -482,7 +487,7 @@ input[type='range'].vslide2::-webkit-slider-thumb {background:#fff;background-im
 .alphabits ul li {display:table-row !important;font-size:.8em;text-align:center !important;text-transform:uppercase;opacity:.75;line-height:normal;}
 
 /* playback ellipsis context menu */
-#context-menu-playback .dropdown-menu {min-width:12em;white-space:nowrap;}
+#context-menu-playback .dropdown-menu {min-width:200px;white-space:nowrap;}
 #menu-check-consume, #menu-check-repeat, #menu-check-single {display:none;float:right;color:var(--adapttext);line-height:2.75em;position:absolute;right:.5em;}
 
 /* active/inactive css element manip */
@@ -737,4 +742,5 @@ input[type='range'].vslide2::-moz-range-track {height:10em;width:2px;border-radi
 /*#albumcovers li.active span {max-height:unset;white-space:normal;}
 #albumcovers li:hover span {max-height:unset;white-space:normal;}*/
 
-#cover-backdrop {height:100vh;filter:blur(20px);overflow:hidden;position:fixed;top:0;left:0;transform:scale(1.2);}
+#cover-backdrop {height:100vh;width:100vw;background-size:cover;background-position:center center;z-index:0;filter:blur(20px);overflow:hidden;position:fixed;top:0;left:0;transform:scale(1.2);}
+#context-backdrop {height:100vh;width:100vw;;overflow:hidden;position:fixed;top:0;left:0;z-index:9998;display:none;}

--- a/www/footer.php
+++ b/www/footer.php
@@ -258,7 +258,14 @@
 										<div class="caret"></div>
 									</button>
 									<div class="dropdown-menu open">
-										<ul id="cover-blur-list" class="dropdown-menu custom-select inner" role="menu"></ul>
+										<ul id="cover-blur-list" class="dropdown-menu custom-select inner" role="menu">
+											<li class="modal-dropdown-text"><a href="#notarget" data-cmd="cover-blur-sel"><span class="text">0px</span></a></li>
+											<li class="modal-dropdown-text"><a href="#notarget" data-cmd="cover-blur-sel"><span class="text">5px</span></a></li>
+											<li class="modal-dropdown-text"><a href="#notarget" data-cmd="cover-blur-sel"><span class="text">10px</span></a></li>
+											<li class="modal-dropdown-text"><a href="#notarget" data-cmd="cover-blur-sel"><span class="text">15px</span></a></li>
+											<li class="modal-dropdown-text"><a href="#notarget" data-cmd="cover-blur-sel"><span class="text">20px</span></a></li>
+											<li class="modal-dropdown-text"><a href="#notarget" data-cmd="cover-blur-sel"><span class="text">30px</span></a></li>
+										</ul>
 									</div>
 								</div>
 								<a aria-label="Help" class="info-toggle" data-cmd="info-cover-blur" href="#notarget"><i class="fas fa-info-circle"></i></a>
@@ -277,7 +284,13 @@
 										<div class="caret"></div>
 									</button>
 									<div class="dropdown-menu open">
-										<ul id="cover-scale-list" class="dropdown-menu custom-select inner" role="menu"></ul>
+										<ul id="cover-scale-list" class="dropdown-menu custom-select inner" role="menu">
+											<li class="modal-dropdown-text"><a href="#notarget" data-cmd="cover-scale-sel">1.0</a></li>
+											<li class="modal-dropdown-text"><a href="#notarget" data-cmd="cover-scale-sel">1.25</a></li>
+											<li class="modal-dropdown-text"><a href="#notarget" data-cmd="cover-scale-sel">1.5</a></li>
+											<li class="modal-dropdown-text"><a href="#notarget" data-cmd="cover-scale-sel">1.75</a></li>
+											<li class="modal-dropdown-text"><a href="#notarget" data-cmd="cover-scale-sel">2.0</a></li>
+										</ul>
 									</div>
 								</div>
 								<a aria-label="Help" class="info-toggle" data-cmd="info-cover-scale" href="#notarget"><i class="fas fa-info-circle"></i></a>

--- a/www/js/jquery.knob.js
+++ b/www/js/jquery.knob.js
@@ -263,8 +263,8 @@
 
             // finalize canvas with computed width + pixel offset
             this.$c.attr({
-                width: this.w + 4,
-                height: this.h + 4
+                width: this.w + 2,
+                height: this.h + 2
             });
 
             // scaling

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -488,12 +488,11 @@ function inpSrcIndicator(cmd, msgText) {
 
 // show/hide screen saver
 function screenSaver(cmd) {
-    /*TEST*/console.log('6');
 	if ($('#inpsrc-indicator').css('display') == 'block') {
 		return;  // exit if input source is active
 	}
 	else if (cmd.slice(-1) == '1') {
-		/*NOTE*/$('#folder-panel, #library-panel, #radio-panel').addClass('hidden');
+		$('#folder-panel, #library-panel, #radio-panel').addClass('hidden');
 		$('#playback-panel').show();
 		setCV();
 		$('#menu-bottom, #menu-top').hide();
@@ -2941,7 +2940,6 @@ function setAlbumViewHeaderText() {
 
 // switch to library / playbar panel
 $("#coverart-url, #playback-switch").click(function(e){
-    /*TEST*/console.log('4');
 	if ($('#playback-panel').hasClass('cv')) {
 		e.stopImmediatePropagation();
 		$('.togglepl').click(); // or whatever show queue is
@@ -3002,7 +3000,6 @@ $('#playbar-switch, #playbar-cover').click(function(e){
 		$(window).scrollTop(0);
 	}
 	else {
-        /*TEST*/console.log('5');
 		currentView = 'playback,' + currentView;
 		var result = sendMoodeCmd('POST', 'updcfgsystem', {'current_view': currentView}, true); // async
 		syncTimers();
@@ -3079,7 +3076,6 @@ function syncTimers() {
 
 // active/inactive for buttons and panels
 function makeActive (vswitch, panel, view) {
-    /*TEST*/console.log('8');
     //const startTime = performance.now();
 	if (UI.mobile) {
 		$('#playback-controls').css('display', '');
@@ -3203,12 +3199,10 @@ function setFontSize() {
 
 // toggle cv class and use dark theme type colors for menus
 function setCV() {
-    /*TEST*/console.log('1', $('#playback-panel').hasClass('cv'));
 	$('#playback-panel').toggleClass('cv');
 	window.dispatchEvent(new Event('resize')); // resize for knobs
 
 	if ($('#playback-panel').hasClass('cv')) {
-        /*TEST*/console.log('2');
 		$('.playbackknob, .volumeknob').trigger('configure',{"thickness":'.11'});
 		$('#library-panel, #radio-panel, #folder-panel').removeClass('active');
 		tempBack = adaptBack;
@@ -3220,18 +3214,15 @@ function setCV() {
 		$('#playback-panel').addClass('active');
 	}
     else {
-        /*TEST*/console.log('3', currentView);
 		$('.playbackknob, .volumeknob').trigger('configure',{"thickness":'.13'});
 		$('#menu-top').show();
 		adaptBack = tempBack;
 		adaptMcolor = tempColor;
 		adaptMback = tempMback;
 		$('#playback-cover').css('display', '');
-
 		if (currentView.indexOf('playback') == -1) {
-			$('#playback-panel').removeClass('active');
-			$('#menu-bottom, #viewswitch').show();
-
+				$('#playback-panel').removeClass('active');
+				$('#menu-bottom, #viewswitch').show();
 			switch (currentView) {
 				case 'album':
 					$('#library-panel').addClass('active');
@@ -3247,9 +3238,6 @@ function setCV() {
 					break;
 			}
 		}
-        else {
-            // Placeholder
-        }
 	}
 	setColors();
 }

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -534,7 +534,7 @@ var renderAlbums = function() {
 			LIB.albumClicked = true;
 	}
 	if (SESSION.json["library_ellipsis_limited_text"] == "Yes") {
-		$('#albumsList, #albumcovers').addClass('limited');
+		$('#library-panel').addClass('limited');
 	}
 
 	// Headers clicked

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -1074,6 +1074,20 @@ jQuery(document).ready(function($) { 'use strict';
 		}
 	});
 
+	$('#searchResetLib').click(function(e) {
+		e.preventDefault();
+		GLOBAL.searchLib = '';
+		scopeR('Lib');
+		LIB.filters.albums.length = 0;
+		UI.libPos.fill(-2);
+		storeLibPos(UI.libPos);
+	    clickedLibItem(undefined, undefined, LIB.filters.albums, renderAlbums);
+		$("#searchResetLib").hide();
+		showSearchResetLib = false;
+		document.getElementById("lib-album-filter").focus();
+		return false;
+	});
+
 	// playback history search
 	$('#ph-filter').keyup(function(e){
 		if (!showSearchResetPh) {


### PR DESCRIPTION
#1 add missing menu lists to footer.php (blur & scale)

#2 knob padding adjustment in jquery-knobs

#3 test adding thumb size as css var, regular as well as mobile now, e.g. --thumbcols is 18vw which is 5 columns, setting it to 10vw is 7

#4 change to adding limited class to #library-panel, all .lib-entry items are now supported.

#5 redid ellipsis css & simplified css a bit for tag & cover view in general

#6 messed with context-menu width a bit to try to work around dumb apple bug, 1080p+ uses em width, maybe adjust or special case iPad sizes.

#7 added back lib search reset click handler, embiggened the button size, fixed the position, made it not dismiss the menu and refocused the input