### PR TITLE
b2 fixes

### DIFF
--- a/www/css/bootstrap.min.css
+++ b/www/css/bootstrap.min.css
@@ -473,8 +473,8 @@ button.btn.btn-mini,input[type="submit"].btn.btn-mini{/**padding-top:1px;*paddin
 .tabbable:after{clear:both;}
 .tab-content{overflow:auto;}
 .tabs-below>.nav-tabs,.tabs-right>.nav-tabs,.tabs-left>.nav-tabs{border-bottom:0;}
-.tab-content>.tab-pane,.pill-content>.pill-pane{display:none;}
-.tab-content>.active,.pill-content>.active{display:block;}
+.tab-content>.tab-pane,.pill-content>.pill-pane{visibility:hidden;}
+.tab-content>.active,.pill-content>.active{visibility:visible;}
 .tabs-below>.nav-tabs{border-top:1px solid #ddd;}
 .tabs-below>.nav-tabs>li{margin-top:-1px;margin-bottom:0;}
 .tabs-below>.nav-tabs>li>a{-webkit-border-radius:0 0 4px 4px;-moz-border-radius:0 0 4px 4px;border-radius:0 0 4px 4px;}.tabs-below>.nav-tabs>li>a:hover,.tabs-below>.nav-tabs>li>a:focus{border-bottom-color:transparent;border-top-color:#ddd;}

--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -256,7 +256,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#lib-albumcover {left:0;}
 	/* ellipsis madness */
 	#artistsList li, #genresList li, #albumsList li {max-width:calc(50vw - 2.3rem);min-width:33vw;}
-	#albumcovers .lib-entry, .database-radio .lib-entry {width:var(--mthumbcols);}
+	#albumcovers .lib-entry, .database-radio li {width:var(--mthumbcols);}
 	#albumcovers .lib-entry img, .database-radio img {max-height:calc(var(--mthumbcols) * .9);}
 
 	#ss-currentsong {font-size:1.5em;}
@@ -283,7 +283,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	/* playbar */
 	#playbar-div {display:block;}
 	#playbar-mtime {display:flex;position:relative;}
-	#playbar-title {text-align:left;top:0;margin-left:1.25rem;width:calc(72vw - 6rem);height:auto;position:relative;transform:none;font-size:1.3em;line-height:2.2em;left:0;padding:0;text-shadow:0 0 1px var(--btnbarback);}
+	#playbar-title {text-align:left;top:0;margin-left:1.25rem;width:53vw;height:auto;position:relative;transform:none;font-size:1.3em;line-height:2.2em;left:0;padding:0;text-shadow:0 0 1px var(--btnbarback);}
 	#playbar-controls {right:.25rem;transform:none;top:0;left:unset;opacity:1;}
 	#playbar-time, #playbar-total {line-height:1.5rem;}
 	#playbar-controls .btn {padding:.4em;font-size:2.5rem;-webkit-tap-highlight-color:transparent);}
@@ -476,11 +476,11 @@ li.modal-dropdown-text:focus {color:#eee;}
 @media (orientation: portrait) and (min-aspect-ratio: 600/1024) {
 	#playback-panel.newui #timezone {left:12.5%;top:59%;}
 	#playback-panel.newui #volzone {right:12.5%;top:59%;}
-	#playback-panel.newui #playback-cover {width:75vw;} /* 75% cover h/w */
+	#playback-panel.newui #playback-cover {width:75vw;}
 	#playback-panel.newui #coverart-url, #playback-panel.newui img.coverart {width:75vw;max-height:75vw;}
 	#playback-panel.newui #container-playlist, #playback-panel.cv #container-playlist {width:60%;height:55%;}
-	#albumcovers .lib-entry img, .database-radio img {max-height: calc(31vw * .9);}
-	#albumcovers li, .database-radio li {width:31vw;}
+	#playback-panel.newui#albumcovers .lib-entry img, #playback-panel.newui.database-radio img {max-height: calc(31vw * .9);}
+	#playback-panel.newui#albumcovers li, #playback-panel.newui.database-radio li {width:31vw;}
 	#playback-panel.newui #volcontrol, #playback-panel.newui #volcontrol-2, #playback-panel.newui #countdown {height:12.5rem;width:12.5rem;}
 }
 @media (orientation: portrait) and (min-aspect-ratio: 2/3) {

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -192,7 +192,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .playlist li, .database li, .database-radio li {display:block;position:relative;margin:0;cursor:pointer;text-align:left;padding-left:.75em;}
 /*.playlist li:before {display:block;float:left;width:2.5em;line-height:normal;text-align:right;counter-increment:item;content:counter(item) ' ';color:var(--textvariant);font-size:1em;letter-spacing:-1px;}*/
 .playlist li:before {float:left;width:2.9em;letter-spacing:-1px;text-align:right;line-height:normal;counter-increment:item;content:counter(item) ' ';color:var(--textvariant);font-size:1em;}
-.database-radio li {width:12.25em;text-align:center;font-size:.9em;margin:.25em .75em .75em .75em;display:inline-block;vertical-align:top;height:auto;padding:0 0 .5em 0;}
+.database-radio li {width:var(--thumbcols);text-align:center;font-size:.9em;margin:.25em .75em .75em .75em;display:inline-block;vertical-align:top;height:auto;padding:0 0 .5em 0;}
 .database li {margin-left:2px;margin-right:5px;padding:0 0 .5em 0;}
 .playlist li.active:before {color:var(--accentxts);opacity:1;}
 .database span, .database-radio span {display:block;font-weight:normal;color:inherit;opacity:.60;}
@@ -530,7 +530,7 @@ input[type='range'].vslide2::-webkit-slider-thumb {background:#fff;background-im
 #playback-switch div {/*background-color:var(--textvariant);*/background-color:transparent;height:.25rem;width:2rem;margin:1em auto;border-radius:1em;overflow:hidden;}
 #playbar {display:flex;align-items:center;height:4.8rem;position:absolute;bottom:0;width:100%;color:var(--adapttext);box-shadow: 0px -1px 3px rgba(0,0,0,0.1);} /* was 9.25vh*/
 /*#playbar-cover {height:4.8rem;width:4.8rem;margin-left:0;border-radius:0;overflow:hidden;position:relative;cursor:pointer;opacity:.75;}*/
-#playbar-cover {height:4.8rem;width:9.6rem;/*4.8*/position:absolute;-webkit-mask-image: linear-gradient(to right, rgba(0,0,0,.5), rgba(0,0,0,0) 100%);}
+#playbar-cover {height:4.8rem;width:4.8rem;/*4.8*/position:absolute;-webkit-mask-image: linear-gradient(to right, rgba(0,0,0,.5), rgba(0,0,0,0) 100%);}
 #playbar-title {width:calc(50vw - 8.5rem);/* Was 5.5rem */;height:auto;position:absolute;font-size:.9em;left:50%;top:50%;transform:translate(-50%, -50%);text-align:center;padding-bottom:1.75rem;line-height:1.5em;}
 #playbar-title a {padding:0;margin:0;display:unset;text-align:unset;font-size:.9rem;color:var(--adapttext) !important;}
 #playbar-title span {opacity:.55;}
@@ -539,7 +539,7 @@ input[type='range'].vslide2::-webkit-slider-thumb {background:#fff;background-im
 #playbar-currentsong {font-weight:600;}
 #playbar-time, #playbar-total {font-size:.9rem;}
 #playbar-controls {position:absolute;left:.5rem;top:50%;transform:translate(0, -50%);opacity:1;}
-#playbar-controls .btn {padding:.25em;font-size:1.8rem;margin:0 .25em;}
+#playbar-controls .btn {padding:.25rem;font-size:1.8rem;margin:0 .25rem;}
 #playbar-switch {position:absolute;height:100%;width:100%;left:0;top:0;text-align:center;font-size:.9em;cursor:pointer;}
 #playbar-switch div {display:none;background-color:var(--textvariant);height:.25rem;width:2rem;margin:.5em auto;border-radius:1em;overflow:hidden;}
 #playbar-toggles {position:absolute;display:flex;flex-wrap:wrap;right:.5rem;top:50%;transform:translate(0, -50%);}

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -126,7 +126,7 @@
 								<button aria-label="Repeat" class="btn btn-cmd btn-toggle repeat hide" data-cmd="repeat"><i class="fal fa-repeat"></i></button>
 								<button aria-label="Single" class="btn btn-cmd btn-toggle single hide" data-cmd="single"><i class="fal fa-redo"></i></button>
 								<button aria-label="Random Album" class="btn btn-cmd ralbum"><i class="fal fa-dot-circle"></i></button>
-								<button aria-label="Volume Up" class="btn volume-popup hide" data-toggle="modal"><i class="fal fa-volume-up"></i><div id="volpopbarw"><div id="mvol-bg"></div><div aria-label="Volume" id="mvol-progress"></div></div></button>
+								<button aria-label="Volume Up" class="btn volume-popup hide" data-toggle="modal"><i class="fal fa-volume-up"></i><div id="mvol-bar"><div id="mvol-bg"></div><div aria-label="Volume" id="mvol-progress"></div></div></button>
 								<button aria-label="Add To Favorites" class="btn btn-cmd addfav"><i class="fal fa-heart"></i></button>
 							</div>
 						</div>


### PR DESCRIPTION
#1 migrate missing bootstrap.min.css changes

#2 fix radio cover size to use var(--thumbcols)

#3 revert 2x width for playbar cover

#4 use rem for playbar button margin/padding.

#5 add configurable extra metadata, currently the string is a global, it'll need ui in the appearance panel (other options?) and either need a new session var or some fancy coding

#6 commented out (probably) unneeded screen saver things

#7 added countup & countdown support for the playbar progress in synctimers

#8 use radiocover/radiolist in setcv instead of just radio (oops)

#9 change id to match css for the mobile volume popup "progress" bar.