### PR TITLE
b2-fixes-mk3

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -384,6 +384,9 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#currentsong, #currentalbum {padding-top:.75em;font-size:1.1em;}
 }
 
+@media (max-height: 640px) {
+	img.coverart {width:45vh;}
+}
 /* iPhone5 portrait */
 @media (max-height: 568px) and (max-width: 320px) {
 	#extratags {display:none;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -143,7 +143,7 @@ html {background-color:inherit;}
 #countdown-display {position:absolute;top:46%;left:50%;margin-right:0px;margin-bottom:0px;transform:translate(-50%, -50%);font-size:1.9rem;font-weight:500;cursor:pointer;}
 #total {position:absolute;top:60%;left:50%;transform:translate(-50%);margin-left:.4em;/*font-family:monospace;*/}
 .total-radio {background-image:var(--radiobadge);background-position:center center;background-repeat:no-repeat;width:22%;height:20px;margin-left:0 !important;}
-#playbtns, #playbtns .btn-group {font-size:1em;margin:.5em 0;}
+#playbtns, #playbtns .btn-group {font-size:1em;}
 #playbtns .btn {font-size:2rem;padding:1rem;}
 #togglebtns {padding-top:2rem;}
 #togglebtns .btn-group {font-size:1em;white-space:normal;width:100%;}
@@ -211,7 +211,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #top-columns .album-name-art {line-height:1.25em;}
 #albumsList .lib-entry span.artist-name {display:none}
 #albumsList .artist-name-art, #albumsList .album-year {vertical-align:top;line-height:normal;font-size:.85em;color:var(--textvariant);}
-#albumsList .album-year {margin-left:0;}
+#albumsList .album-year {margin-left:0;margin-left:.3em;}
 #library-panel.limited .artist-name-art, #library-panel.limited #albumcovers .artist-name {max-width:67%;}
 #library-panel.limited .lib-entry, #library-panel.limited .lib-entry span {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
 
@@ -627,7 +627,7 @@ input[type='range'].vslide2::-moz-range-track {height:10em;width:2px;border-radi
 
 /* newui */
 #playback-panel.newui #songsand, #playback-panel.cv #songsang {position:absolute;width:100vw;left:50%;transform:translate(-50%);}
-#playback-panel.newui #container-playlist, #playback-panel.cv #container-playlist {width:44%;height:75%;margin-top:-.5rem} /* transform instead of margin-top for ios */
+#playback-panel.newui #container-playlist, #playback-panel.cv #container-playlist {/*width:44%;*/height:75%;margin:-.5rem 0 0 3%;} /* transform instead of margin-top for ios */
 #playback-panel.newui #timezone {position:absolute;width:30%;height:34vw;left:0;}
 #playback-panel.newui #volzone {position:absolute;width:30%;height:34vw;right:0;}
 #playback-panel.newui #volbtns button {margin:.4em 0;font-size:1.75rem;}

--- a/www/js/jquery.knob.js
+++ b/www/js/jquery.knob.js
@@ -535,6 +535,12 @@
         };
 
         this.xy2val = function (x, y) {
+
+			if (this.$div.parent().hasClass('volume-step-limiter')) {
+				if (SESSION.json['mpdmixer'] == 'disabled') {return false;}
+				if (SESSION.json['volmute'] == '1') {volMuteSwitch();}
+			}
+			
             var a, ret;
 
             a = Math.atan2(

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -566,16 +566,16 @@ function disableVolKnob() {
 	}
 	else {
 		$('.repeat').hide();
-		$('#ssvolume').attr('data-readOnly', 'true');
-		$('#volumedn, #volumeup, #ssvolup, #ssvoldn').prop('disabled', true);
+		//$('#ssvolume').attr('data-readOnly', 'true');
+		$('#volumedn, #volumeup').prop('disabled', true);
 	}
 
 	$('.volume-popup').hide();
 	//$('#playbar-consume').show();
 
-	$('.volume-display, #ssvolume, #volumeup, #volumedn').css('opacity', '.3');
-	$('.volume-display div, #ssvolume, #inpsrc-preamp-volume').text('0dB');
-	$('.volume-display, #ssvolume').css('cursor', 'unset');
+	$('.volume-display, #volumeup, #volumedn').css('opacity', '.3');
+	$('.volume-display div, #inpsrc-preamp-volume').text('0dB');
+	$('.volume-display').css('cursor', 'unset');
 }
 
 // when last item in laylist finishes just update a few things, called from engineCmd()
@@ -621,7 +621,7 @@ function renderUIVol() {
 
 		// update volume knob, ss volume
 		$('#volume').val(SESSION.json['volknob']).trigger('change');
-		$('.volume-display div, #ssvolume, #inpsrc-preamp-volume').text(SESSION.json['volknob']);
+		$('.volume-display div, #inpsrc-preamp-volume').text(SESSION.json['volknob']);
 
 		// update mobile volume
 		$('#volume-2').val(SESSION.json['volknob']).trigger('change');
@@ -629,8 +629,8 @@ function renderUIVol() {
 
 	   	// update mute and ss mute state
 		if (SESSION.json['volmute'] == '1') {
-			$('.volume-display').css('opacity', '.3');
-			$('.volume-display div, #ssvolume, #inpsrc-preamp-volume').text('mute');
+			//$('.volume-display').css('opacity', '.3');
+			$('.volume-display div, #inpsrc-preamp-volume').text('mute');
 		}
 		else {
 			$('.volume-display').css('opacity', '');
@@ -671,18 +671,18 @@ function renderUI() {
 	else {
 		// update volume knob, ss volume
 		$('#volume').val(SESSION.json['volknob']).trigger('change');
-		$('.volume-display div, #ssvolume, #inpsrc-preamp-volume').text(SESSION.json['volknob']);
+		$('.volume-display div, #inpsrc-preamp-volume').text(SESSION.json['volknob']);
 		$('#volume-2').val(SESSION.json['volknob']).trigger('change');
 		$('#mvol-progress').css('width', SESSION.json['volknob'] + '%');
 
 	   	// update mute state
 		if (SESSION.json['volmute'] == '1') {
-			$('.volume-display').css('opacity', '.3');
-			$('.volume-display div, #ssvolume, #inpsrc-preamp-volume').text('mute');
+			//$('.volume-display').css('opacity', '.3');
+			$('.volume-display div, #inpsrc-preamp-volume').text('mute');
 		}
 		else {
 			$('.volume-display').css('opacity', '');
-			$('.volume-display div, #ssvolume').text(SESSION.json['volknob']);
+			$('.volume-display div').text(SESSION.json['volknob']);
 		}
 	}
 
@@ -3174,9 +3174,15 @@ function scopeR () {
 	UI.mobile ? view = '' : view = 'Browse by ';
 	if (currentView == 'radiocovers' || currentView == 'radiolist') {
 		view += 'Radio Stations';
+		if (GLOBAL.searchRadio) {
+			view = GLOBAL.searchRadio;
+		}
 	}
 	else if (currentView == 'folder') {
 		view += 'Folders';
+		if (GLOBAL.searchFolder) {
+			view = GLOBAL.searchFolder;
+		}
 	}
 	else if (currentView == 'album' || currentView == 'tag') {
 		if (GLOBAL.searchLib && GLOBAL.musicScope == 'all') {
@@ -3192,19 +3198,12 @@ function scopeR () {
 				$('.view-all span').show();
 		        LIB.recentlyAddedClicked = false;
 			}
+			if (LIB.filters.artists.length) {
+				view = 'Albums by ' + LIB.filters.artists[0];
+			}
 		}
 	}
-	if (GLOBAL.searchFolder) {
-		view = GLOBAL.searchFolder;
-	}
-	if (GLOBAL.searchRadio) {
-		view = GLOBAL.searchRadio;
-	}
-	if (LIB.filters.artists.length) {
-		$('#menu-header').text('Albums by ' + LIB.filters.artists[0]);
-	} else {
-		$('#menu-header').text(view);
-	}
+	$('#menu-header').text(view);
 }
 
 function lazyLode(container) {
@@ -3293,4 +3292,19 @@ function setCV() {
 		}
 	}
 	setColors();
+}
+
+function volMuteSwitch() {
+    if (SESSION.json['volmute'] == '0') {
+		SESSION.json['volmute'] = '1' // toggle to mute
+		var newVol = 0;
+		var volEvent = 'mute';
+    }
+	else {
+		SESSION.json['volmute'] = '0' // toggle to unmute
+		var newVol = SESSION.json['volknob'];
+		var volEvent = 'unmute';
+    }
+	var result = sendMoodeCmd('POST', 'updcfgsystem', {'volmute': SESSION.json['volmute']});
+	setVolume(newVol, volEvent);
 }

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -505,8 +505,8 @@ var renderAlbums = function() {
 
 	for (var i = 0; i < filteredAlbums.length; i++) {
 
-        filteredAlbums[i].year ? tagViewYear = ' (' + filteredAlbums[i].year + ')' : tagViewYear = '';
-        filteredAlbumCovers[i].year ? albumViewYear = ' (' + filteredAlbumCovers[i].year + ')' : albumViewYear = '';
+        filteredAlbums[i].year ? tagViewYear = '(' + filteredAlbums[i].year + ')' : tagViewYear = '';
+        filteredAlbumCovers[i].year ? albumViewYear = '(' + filteredAlbumCovers[i].year + ')' : albumViewYear = '';
 
 		if (SESSION.json['library_tagview_covers'] == 'Yes') {
 			output += '<li class="lib-entry">'
@@ -756,6 +756,7 @@ $('#artistsList').on('click', '.lib-entry', function(e) {
 	if (UI.mobile) {
 		$('#top-columns').animate({left: '-50%'}, 200);
 	}
+	scopeR();
 });
 
 // Click album

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -373,24 +373,11 @@ jQuery(document).ready(function($) { 'use strict';
 	});
 
 	// mute toggle
-	$('.volume-display, #ssvolume').click(function(e) {
+	$('.volume-display').click(function(e) {
 		if (SESSION.json['mpdmixer'] == 'disabled') {
 			return false;
 		}
-
-        if (SESSION.json['volmute'] == '0') {
-			SESSION.json['volmute'] = '1' // toggle to mute
-			var newVol = 0;
-			var volEvent = 'mute';
-        }
-		else {
-			SESSION.json['volmute'] = '0' // toggle to unmute
-			var newVol = SESSION.json['volknob'];
-			var volEvent = 'unmute';
-        }
-
-		var result = sendMoodeCmd('POST', 'updcfgsystem', {'volmute': SESSION.json['volmute']});
-		setVolume(newVol, volEvent);
+		volMuteSwitch();
 	});
 
 	// volume control popup (for mobile and playbar)
@@ -476,12 +463,14 @@ jQuery(document).ready(function($) { 'use strict';
 		return false;
 	});
 	$('#volumeup,#volumeup-2').click(function(e) {
+		SESSION.json['volmute'] == '1' ? volMuteSwitch() : '';
 		var curVol = parseInt(SESSION.json['volknob']);
 		var newVol = curVol < 100 ? curVol + 1 : 100;
 		setVolume(newVol, '');
 		return false
 	});
 	$('#volumedn,#volumedn-2').click(function(e) {
+		SESSION.json['volmute'] == '1' ? volMuteSwitch() : '';
 		var curVol = parseInt(SESSION.json['volknob']);
 		var newVol = curVol > 0 ? curVol - 1 : 0;
 		setVolume(newVol, '');


### PR DESCRIPTION
#1 modify cover size on shorter big screen mobile devices (e.g. Galaxy 5).

#2 adjust play control buttons a bit (goes with above to provide more space between cover, controls and text).

#3 revert coverview playlist to normal size to prevent it from possibly overlapping the knob(s).

#4 prevent knob changing if volume is disabled.

#5 disable mute if knob track is touched and then act on touch.

#6 ditto volume buttons.

#7 remove some deprecated ssvolume references I noticed.

#8 fix menu header to display "Albums by [artist name]" when an artist is clicked.

#9 fix missing space in ellipsis limited tag view between artist name and album year.