### PR TITLE
playbar-cv

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -122,7 +122,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 .modal .modal-dropdown-text {color:inherit;}
 .modal .bootstrap-select .btn, #appearance-modal input {border: 1px solid var(--textvariant);}
 .modal .modal-footer {border-top: none;text-align:center;}
-.modal-footer .btn {border-radius:5rem;background-color:var(--btnshade4);margin:.2em 1em;width:25%;color:inherit;}
+.modal-footer .btn {border-radius:5rem;background-color:var(--btnshade4);margin:.2em 1em;width:10em;color:inherit;}
 .modal-footer .btn-primary {border-radius:5rem;float:none;border:1px solid var(--textvariant);background-color:var(--btnshade4);color:var(--adapttext);}
 .modal.fade {top:0;top:env(safe-area-inset-top);transition:none;}
 .modal.fade.in {transition:none;}
@@ -333,12 +333,12 @@ li.modal-dropdown-text:focus {color:#eee;}
 	.playlist span {line-height:initial;}
 	.playlist .active {padding-left:.5em;}
 	#playlist .songtime {top: 0px;}
-	#timeknob {padding:0px;}
+	#timeknob, #volknob {margin:1em 0;}
 	#countdown-display{margin-top:-10px;}
 	.countdown-caret {font-size:.9em;margin-left:2px;}
 	#countdown {height:75%;width:75%;margin:0 auto;padding-bottom:5px;}
 	#volcontrol {height:75%;width:75%;margin:0 auto;}
-	#total {font-size:.9em;margin-top:-10px;}
+	#total {font-size:.9em;}
 	#volknob {padding-top:5px;}
 	#btn-toolbar {margin-top:0px;margin-bottom:0px;}
 	#miscbtns .btn {font-size:.9em;}
@@ -423,14 +423,14 @@ li.modal-dropdown-text:focus {color:#eee;}
 /* Pi 7" Touch */
 @media (height: 479px) and (width: 799px) {
 	.playlist .pll1 {font-size:unset;}
-	#timeknob {padding: 0 0 8px;}
+	/*#timeknob {padding: 0 0 8px;}
 	#total {top:63%;width:100%;}
-	#volknob {padding: 8px 0 0;}
+	#volknob {padding: 8px 0 0;}*/
 	.btn-toolbar {margin-top: 5px;margin-bottom:6px;}
 	#togglebtns {padding-top:.5em;}
 	/*#volumedn{margin-right:.5em;}
 	#volumeup{margin-left:.5em;}*/
-	#extratags {padding-top:5px;}
+	#extratags {padding-top:1em;}
 	#container-appearance, #container-clockradio {max-height: 72vh;}
 	.database-radio li {width:9em;font-size:0.8em;height:auto;}
 	#albumcovers li {width:9em;font-size:0.8em;height:auto;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -24,6 +24,7 @@
 
 html, body {background-attachment:fixed;background-size:cover;height:100%;color:#eee;font-family:"Avenir Next", "Lato";font-size:calc(0.45em + 1vmin);padding:0;cursor:default;
 	--timethumb:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='13' height='20'><rect fill='%23000000' fill-opacity='0' width='13' height='20'/><circle fill='%23303030' cx='6.5' cy='7.5' r='3.5'/></svg>");
+	--fatthumb:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='13' height='20'><rect fill='%23000000' fill-opacity='0' width='20' height='20'/><circle fill='%23303030' cx='6.5' cy='7.5' r='7.5'/></svg>");
 	--btnbarcolor:rgba(96,96,96,0.25);
 	--btnbarback:rgba(50,50,50,0.25);
 	--btnshade:rgba(50,50,50,0.25);
@@ -47,7 +48,7 @@ html, body {background-attachment:fixed;background-size:cover;height:100%;color:
 	--pbfont:calc(0.45em + 1vmin);
 	--radiobadge:url('../images/radio-l.svg');
 	--defcover:'images/default-cover-v6-l.svg';
-	--thumbcols:18vw;
+	--thumbcols:16vw;
 	--mthumbcols:45vw;
 	--coverback:'';
 }
@@ -141,9 +142,9 @@ html {background-color:inherit;}
 #countdown div {margin:0 auto;} /* needed to center the knob */
 .countdown-caret {margin-left:2px;color:var(--accentxts);}
 #countdown-display {position:absolute;top:46%;left:50%;margin-right:0px;margin-bottom:0px;transform:translate(-50%, -50%);font-size:1.9rem;font-weight:500;cursor:pointer;}
-#total {position:absolute;top:60%;left:50%;transform:translate(-50%);margin-left:.4em;/*font-family:monospace;*/}
+#total {position:absolute;top:62%;left:50%;transform:translate(-50%);margin-left:.4em;/*font-family:monospace;*/}
 .total-radio {background-image:var(--radiobadge);background-position:center center;background-repeat:no-repeat;width:22%;height:20px;margin-left:0 !important;}
-#playbtns, #playbtns .btn-group {font-size:1em;}
+#playbtns {margin:1em 0;font-size:1em;}
 #playbtns .btn {font-size:2rem;padding:1rem;}
 #togglebtns {padding-top:2rem;}
 #togglebtns .btn-group {font-size:1em;white-space:normal;width:100%;}
@@ -420,9 +421,17 @@ img.lib-coverart.active {box-shadow:0px 0px .2em .1em var(--accentxts);}
 #screen-saver {color:#eee;text-shadow:0px 0px .25em rgba(0,0,0,0.3);height:100vh;width:100vw;cursor:pointer;text-align:center;}
 #ss-backdrop {height:100vh;filter:blur(20px);overflow:hidden;position:fixed;top:0;left:0;transform:scale(1.2);}
 #ss-style {position:fixed;top:0;left:0;height:100vh;width:100vw;animation:colors2 60s infinite;transform:translateZ(0);}
-#ss-coverart-url img {width:80vh;}
+#ss-coverart-url img {width:75vh;}
 .ss-backdrop {min-width:100vw;min-height:100vh;max-width:unset;transform:translate(-50%, -50%);background-position:center center;position:relative;top:50vh;left:50vw;}
-.ss-coverart {position:fixed;top:5%;width:100%;}
+.ss-coverart {position:fixed;top:1.5em;width:100%;}
+body.cv #menu-bottom {display:flex !important;background-color:transparent;backdrop-filter:none;-webkit-backdrop-filter:none;}
+body.cv #menu-top, body.cv #viewswitch, body.cv #playbar-toggles .coverview, body.cv #playbar-cover {display:none !important;}
+body.cv #content .tab-pane.active {visibility:hidden !important;}
+body.cv #playbar {box-shadow:none;}
+body.cv #playbar-title {font-size:1.4em;top:-40%;transform:translate(-50%, -50%);padding-bottom:0;}
+body.cv #playbar-currentsong, body.cv #playbar-currentalbum {padding-bottom:1em;}
+body.cv #playbar-timeline {top:50%;width:40%;transform:translate(-50%, -50%);}
+body.cv #screen-saver, body.cv #menu-bottom {display:block !important;}
 /* misc */
 #splash {height:100vh;width:100vw;z-index:11111;position:fixed;background:rgba(32,32,32,0.95);backdrop-filter:blur(5px);-webkit-backdrop-filter:blur(5px);display:none;}
 #splash div {position:absolute;top:50%;left:50%;transform:translate(-50%, -50%);font-size:10vw;font-weight:200;letter-spacing:-.06em;opacity:0;transition:1s;}
@@ -508,7 +517,7 @@ input[type='range'].vslide2::-webkit-slider-thumb {background:#fff;background-im
 #playback-switch div {background-color:transparent;height:.25rem;width:2rem;margin:1em auto;border-radius:1em;overflow:hidden;}
 #playbar {display:flex;align-items:center;height:4.8rem;position:absolute;bottom:0;width:100%;color:var(--adapttext);box-shadow: 0px -1px 3px rgba(0,0,0,0.1);} /* was 9.25vh*/
 #playbar-cover {height:4.8rem;width:4.8rem;position:absolute;-webkit-mask-image: linear-gradient(to right, rgba(0,0,0,1), rgba(0,0,0,0) 100%);}
-#playbar-title {width:calc(50vw - 8.5rem);/* Was 5.5rem */;height:auto;position:absolute;font-size:.9em;left:50%;top:50%;transform:translate(-50%, -50%);text-align:center;/*TEST padding-bottom:1.75rem;*/line-height:1.5em;}
+#playbar-title {width:calc(50vw - 8.5rem);/* Was 5.5rem */;height:auto;position:absolute;font-size:.9em;left:50%;top:50%;transform:translate(-50%, -50%);text-align:center;padding-bottom:1rem;/*TEST padding-bottom:1.75rem;*/line-height:1.5em;}
 #playbar-title a {padding:0;margin:0;display:unset;text-align:unset;font-size:.9rem;color:var(--adapttext) !important;}
 #playbar-title span {opacity:.55;}
 #playbar-title span:first-child {opacity:1.0;}
@@ -536,6 +545,8 @@ input[type='range'].vslide2::-webkit-slider-thumb {background:#fff;background-im
 .updater-relnotes {list-style-type:none;margin-left:0;}
 /* Show/hide password plaintext */
 .show-hide-password {font-size:18px;margin-left:.5em}
+#restart-modal {top:5vh;}
+#restart-modal .modal-body .btn {color:#eee;background-color:rgba(228,46,46,0.45);width:12em;margin:1em auto 2em auto;}
 
 /* https: //codepen.io/mallendeo/pen/eLIiG */
 .toggle {background-color:rgba(128,128,128,0.3);}
@@ -568,6 +579,10 @@ input[type='range']::-webkit-slider-thumb {
  height:20px;
  width:11px;
  background-repeat:no-repeat;
+}
+body.cv .timeline-thm input[type='range']::-webkit-slider-thumb {
+    background-image:var(--fatthumb);
+	width:20px;
 }
 
 input[type='range']::-moz-range-thumb {

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -140,6 +140,8 @@ var showMenuTopW;
 var showMenuTopR;
 var thumbw = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='13' height='20'><circle fill='%23f0f0f0' cx='6.5' cy='10' r='3.5'/></svg>";
 var thumbd = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='13' height='20'><circle fill='%23303030' cx='6.5' cy='10' r='3.5'/></svg>";
+var fatthumbw = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='13' height='20'><circle fill='%23f0f0f0' cx='6.5' cy='10' r='5.5'/></svg>";
+var fatthumbd = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='13' height='20'><circle fill='%23303030' cx='6.5' cy='10' r='5.5'/></svg>";
 var blurrr = CSS.supports('-webkit-backdrop-filter','blur(1px)');
 
 // various flags and things
@@ -160,6 +162,7 @@ var currentView = 'playback';
 var alphabitsFilter;
 var lastYIQ = ''; // last yiq value from setColors
 var extraTags = "%track% %disc% %year% %composer% %bitrate% %encoded%";
+var coverView = false; // coverview active or not to save on more expensive conditional in interval timer
 
 function debugLog(msg)  {
 	if (SESSION.json['debuglog'] == '1') {
@@ -500,7 +503,7 @@ function inpSrcIndicator(cmd, msgText) {
 		$('#inpsrc-preamp-volume').text(preampVolume);
 	}
 	else {
-		if ($('#screen-saver').css('display') == 'none') {
+		if (!coverView) {
             $('#menu-top, .btnlist-top').show();
             $('#index-artists.alphabits').show();
             $('#index-albums.alphabits').show();
@@ -529,23 +532,9 @@ function screenSaver(cmd) {
 		return;
 	}
 	else if (cmd.slice(-1) == '1') {
-        $('#playback-panel').addClass('hidden');
-        $('#menu-top').hide();
-        $('#menu-bottom').show();
-		$('.viewswitch').css('display', 'none');
 		$('#ss-coverart-url').html('<img class="coverart" ' + 'src="' + MPD.json['coverurl'] + '" ' + 'alt="Cover art not found"' + '>');
-        $('#playbar-toggles .coverview').hide();
-
-        if (currentView.indexOf('playback') == -1) {
-            $('#container-radio').css('display', 'none');
-            $('#container-browse').css('display', 'none');
-            $('.container-library').css('display', 'none');
-        }
-
-        $('#playbar-title').css({'padding-bottom':'2em', 'font-size':'1.5em'});
-        $('#menu-bottom').css('background-color', 'transparent');
-
-		$('#screen-saver').show();
+        $('body').addClass('cv');
+		coverView = true;
 	}
 }
 
@@ -755,7 +744,7 @@ function renderUI() {
 		}
 		// screen saver
 		$('#ss-backdrop').html('<img class="ss-backdrop" ' + 'src="' + MPD.json['coverurl'] + '">');
-		if ($('#screen-saver').css('display') == 'block') {
+		if (coverView) {
 			$('#ss-coverart-url').html('<img class="coverart" ' + 'src="' + MPD.json['coverurl'] + '" ' + 'alt="Cover art not found"' + '>');
 		}
 
@@ -1529,7 +1518,7 @@ function refreshTimeKnob() {
 		}
 		else {
 			$('#playbar-timeline').show();
-			$('#playbar-title').css('padding-bottom', '1.5em');
+			//$('#playbar-title').css('padding-bottom', '1.5em');
 			//$('#playbar-radio').hide();
 		}
 	}
@@ -1538,9 +1527,9 @@ function refreshTimeKnob() {
 		var tt = $('#timetrack'); // move these out of the timer
 		var pb = $('playbar-#timetrack');
 		var ti = $('#time');
-		var cv = currentView.indexOf('playback');
+		var cur = currentView.indexOf('playback');
         UI.knob = setInterval(function() {
-			if (UI.mobile || cv == -1) {
+			if (UI.mobile || cur == -1 || coverView == true) {
 				if (!timeSliderMove) {
 					syncTimers();
 					if (UI.mobile) {
@@ -2770,7 +2759,7 @@ function btnbarfix(temp1,temp2) {
 		var tempa = hexToRgb(accentColor);
 		UI.accenta = rgbaToRgb(.3 - tempx, .75, temprgba, tempa);
 	}
-	document.body.style.setProperty('--btnbarback', rgbaToRgb(.90, '.95', temprgba, temprgb));
+	document.body.style.setProperty('--btnbarback', rgbaToRgb(.90, '.9', temprgba, temprgb));
 }
 
 function getYIQ(color) {
@@ -2800,6 +2789,7 @@ function setColors() {
 		lastYIQ = yiqBool;
 		if (yiqBool) {
 			document.body.style.setProperty('--timethumb', 'url("' + thumbd + '")');
+			document.body.style.setProperty('--fatthumb', 'url("' + fatthumbd + '")');
 			document.body.style.setProperty('--timecolor', 'rgba(96,96,96,0.25)');
 			document.body.style.setProperty('--trackfill', 'rgba(48,48,48,1.0)');
 			document.body.style.setProperty('--radiobadge', 'url("../images/radio-d.svg")');
@@ -2813,6 +2803,7 @@ function setColors() {
 		}
 		else {
 			document.body.style.setProperty('--timethumb', 'url("' + thumbw + '")');
+			document.body.style.setProperty('--fatthumb', 'url("' + fatthumbw + '")');
 			document.body.style.setProperty('--timecolor', 'rgba(240,240,240,0.25)');
 			document.body.style.setProperty('--trackfill', 'rgba(240,240,240,1.0)');
 			document.body.style.setProperty('--radiobadge', 'url("../images/radio-l.svg")');
@@ -3014,14 +3005,14 @@ $('#coverart-url, #playback-switch').click(function(e){
 
     // Prevent a display anomaly
     // Corresponding .show() in $('#playbar-switch... and setCV()
-    /*TEST*/$('#coverart-link').hide();
+    /*TEST*//*$('#coverart-link').hide();*/
 
 	currentView = currentView.split(',')[1];
 	$('#menu-top').css('height', '0');
 	$('#menu-top').css('backdrop-filter', '');
 	$('#menu-bottom').show();
 	$('.viewswitch').css('display', 'flex');
-	$('#library-panel').addClass('active');
+	//$('#library-panel').addClass('active');*/
     syncTimers();
 
 	if (currentView == 'tag') {
@@ -3069,7 +3060,7 @@ $('#coverart-url, #playback-switch').click(function(e){
 // switch to playback panel
 $('#playbar-switch, #playbar-cover').click(function(e){
     //console.log('click playbar');
-    if ($('#screen-saver').css('display') == 'block') {
+    if (coverView) {
         return;
     }
 
@@ -3125,10 +3116,7 @@ function syncTimers() {
 		if (UI.mobile) { // only change when needed to save work
 			$('#m-countdown').text(a);
 			$('#playbar-mcount').text(a);
-		} else { // countdown-display is always running
-			if (currentView.indexOf('playback') == 0) {
-				UI.knobPainted = false;
-			} else {
+		} else if (coverView || currentView.indexOf('playback') == -1) {
 				$('#playbar-countdown').text(a);
 				var c = a.split(':'); // m:s
 				var d = $('#playbar-total').text().split(':');
@@ -3137,8 +3125,9 @@ function syncTimers() {
 				SESSION.json['timecountup'] == 1 ? g = (e / f) * 100 : g = 100 - ((e / f) * 100); // percent of elapsed song
 				$('#playbar-timetrack').val(g * 10); // min = 0, max = 1000
 				g < 50 ? g = 'calc(' + g + '% + 2px)' : g = 'calc(' + g + '% - 2px)'; // adjust for thumb
-				$('#playbar-timeline .timeline-progress').css('width', g);
-			}
+				$('#playbar-timeline .timeline-progress').css('width', g);				
+		} else {
+				UI.knobPainted = false;
 		}
 		oldCount = a;
 	}

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -1278,27 +1278,10 @@ jQuery(document).ready(function($) { 'use strict';
             return;
         }
 
-        if ($('#screen-saver').css('display') == 'block' || SESSION.json['scnsaver_timeout'] != 'Never') {
-            $('#screen-saver').hide();
+        if (coverView || SESSION.json['scnsaver_timeout'] != 'Never') {
+			$('body').removeClass('cv');
+			coverView = false;
             setColors();
-
-            $('#playback-panel').removeClass('hidden');
-            $('#menu-top').show();
-            $('#playbar-toggles .coverview').show();
-            $('#container-radio').css('display', '');
-            $('#container-browse').css('display', '');
-            $('.container-library').css('display', '');
-
-            $('#playbar-title').css({'padding-bottom':'0px', 'font-size':'.9em'});
-            $('#menu-bottom').css('background-color', 'var(--btnbarback)');
-
-            if (currentView.indexOf('playback') == -1) {
-                $('#menu-bottom, .viewswitch').css('display', 'flex');
-            }
-            else {
-                $('#menu-bottom').css('display', 'none');
-            }
-
             // Reset screen saver timeout global
             setTimeout(function() { // wait a bit to allow other job that may be queued to be processed
                 var result = sendMoodeCmd('GET', 'resetscnsaver', '', true);


### PR DESCRIPTION
#1 - rewrite to show coverview by adding class 'cv' to body instead of js gymnastics.

#2 - added a global var 'coverView' that denotes cover view state to avoid a conditional with a jquery selector including in the setinterval timer where it's really expensive.

#3 - modified the cv layout a little bit including a new fat thumb for the timeline but I dunno. the album title should prob be in a div below the ss-cover so it can be more naturally placed.

![moode_(iPad Pro 11)](https://user-images.githubusercontent.com/303924/77234491-0e5f7b80-6b6c-11ea-8b16-8fdeb6566976.png)
