### PR TITLE
Fix playlist alignment on small phone portrait

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -239,7 +239,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#playbtns .btn {font-size:3em;padding:.5em 1em;}
 	.dbtn {display:inline-block;font-size:3em;padding:0 1rem;width:25%;line-height:20px;vertical-align:middle;}
 	.playlist span {line-height:normal;margin-left:calc(3.5rem + 1vmin);display:block;}
-	.playlist span {margin-left:calc(3.8rem + 1vmin);}
+	.playlist span {margin-left:calc(3.8rem + 1vmin) !important;}
 	.playlist {padding:0 0 9rem 0;min-height:33vh;}
 	.playlist li:before {font-size:unset;}
 	.playlist .pl-action, .playlist .db-action a {padding:.4em 1.25em 1em 0;}


### PR DESCRIPTION
On a phone in portrait mode the calculation of the margin left on the second line of a playlist item is out of alignment due to an !important override. This fixes the issue for small phone screens in portrait mode.

Can be reproduced by adding one radio station to the playlist (clear/play). The line contains a microphone icon which the whole line is positioned slightly too far to the left (the calc isn't seeing the 3.8rem and is miscalculating). Adding the important override into moode.css fixes the issue. Will need to be included in mode.min.css to see the fix in the mobile browser.

Thank you for the great project to contribute to.