### PR TITLE
Fix missing closing bracket in flat-ui.css

### DIFF
--- a/www/css/flat-ui.css
+++ b/www/css/flat-ui.css
@@ -2405,3 +2405,4 @@ body.vjs-full-window {
 
 .mll, .mhl, .mal {
   margin-left: 20px; }
+}


### PR DESCRIPTION
The min file is correct, but the original file is missing a closing bracket on the end of the file.