### PR TITLE
for mpd cmd explicit use of the index.php (don't depend on set index)

### DIFF
--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -173,7 +173,7 @@ function sendMpdCmd(cmd, async) {
 
 	$.ajax({
 		type: 'GET',
-		url: 'command/?cmd=' + cmd,
+		url: 'command/index.php?cmd=' + cmd,
 		async: async,
 		cache: false,
 		success: function(data) {


### PR DESCRIPTION
All other php calls are explicit, only this one isn't. It relies on the server index settings.

This was a problem when using a proxy for frontend development.