### PR TITLE
Coverart file noredirect anymore

### DIFF
--- a/www/command/worker.php
+++ b/www/command/worker.php
@@ -130,13 +130,6 @@ else {
 	workerLog('worker: ALSA volume (None)');
 }
 
-// Establish music root for external
-if (extMusicRoot('new') !== true) {
-	workerLog('worker: Problem setting external music root');
-	workerLog('worker: Exited');
-	exit;
-}
-
 //
 workerLog('worker: -- System');
 //
@@ -854,9 +847,6 @@ function chkMaintenance() {
 		if ($free_space[0] < 512000) {
 			workerLog('Maintenance: Free disk space < 512M required for in-place updates');
 		}
-
-		// Reapply external music root
-		extMusicRoot('reapply');
 
 		$GLOBALS['maint_interval'] = $_SESSION['maint_interval'];
 		//workerLog('worker: Maintenance completed');

--- a/www/coverart.php
+++ b/www/coverart.php
@@ -61,18 +61,20 @@ function getImage($path) {
 	$ext = pathinfo($path, PATHINFO_EXTENSION);
 
 	switch (strtolower($ext)) {
-		// image file -> redirect
+		// image file -> serve from disc
 		case 'gif':
 		case 'jpg':
 		case 'jpeg':
 		case 'png':
 		case 'tif':
 		case 'tiff':
-			$path = '/' . $GLOBALS['musicroot_ext'] . substr($path, strlen(MPD_MUSICROOT)-1);
-			$path = str_replace('#', '%23', $path);
-			header('Location: ' . $path);
-			exit(0);
-
+			$mimeType = 'image/'.$ext;
+			$filesize = filesize($path);
+			$fh = fopen($path, 'rb');
+			$imageData = fread($fh, $filesize);
+			fclose($fh);
+			outImage($mimeType, $imageData);
+			break;
 		// embedded images
 		case 'mp3':
 			require_once 'Zend/Media/Id3v2.php';

--- a/www/coverart.php
+++ b/www/coverart.php
@@ -173,10 +173,8 @@ function parseFolder($path) {
 session_id(playerSession('getsessionid'));
 $return = session_start();
 $search_pri = $_SESSION['library_covsearchpri'];
-$musicroot_ext = $_SESSION['musicroot_ext']; // $GLOBALS['musicroot_ext']
 session_write_close();
 //workerLog('coverart: $search_pri=' . $search_pri);
-//workerLog('coverart: $musicroot_ext=' . $musicroot_ext);
 
 // Get options- cmd line or GET
 $options = getopt('p:', array('path:'));

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -243,21 +243,6 @@ function integrityCheck() {
 	return $warning === true ? 'passed with warnings' : 'passed';
 }
 
-function extMusicRoot($option = 'new') {
-	if (!($option == 'new' || $option == 'reapply')) {
-		return false;
-	}
-
-	if ($option == 'new') {
-		$_SESSION['musicroot_ext'] = rand(1000000, 9999999);
-	}
-
-	sysCmd('find /var/www -type l -delete');
-	sysCmd('ln -s ' . MPD_MUSICROOT . ' /var/www/' . $_SESSION['musicroot_ext']);
-
-	return true;
-}
-
 // socket routines for engine-cmd.php
 function sendEngCmd ($cmd) {
 	//workerLog('sendEngCmd(): cmd: ' . $cmd);


### PR DESCRIPTION
Followup of #123 

If cover art is requested there are two possible sources:

1. embedded art in the song
2. artwork in in a file

For first the following request delivers and image:
http://moodedev/coverart.php/NAS%2FArtist%2FAlbums%2FlSong.flac

For the second the following request:
http://moodedev/coverart.php/NAS%2FArtist%2FAlbums%2FlSong.flac
Results in a redirect to:
http://moodedev/3063407/NAS/Artist/Album/cover.jpg

Instead of a redirectign if would be more inline to also deliver the cover file directly from disk.

Also this make the construction with the symbolic link unneeded anymore, so everything related to `musicroot_ext `is removed.

 