### PR TITLE
In the function getCSSRule remove hard dep to 'flat-ui.min.css'.

### DIFF
--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -2848,13 +2848,11 @@ function getCSSRule(ruleName) {
 	for (var i = 0; i < document.styleSheets.length; i++) {
 		var styleSheet = document.styleSheets[i];
 
-		if (styleSheet.href && styleSheet.href.indexOf('flat-ui.min.css') != -1 ) {
-			var cssRules = styleSheet.cssRules;
-			for (var j = 0; j < cssRules.length; j++) {
-				var cssRule = cssRules[j];
-				if (cssRule.selectorText == ruleName) {
-					return cssRule;
-				}
+		var cssRules = styleSheet.cssRules;
+		for (var j = 0; j < cssRules.length; j++) {
+			var cssRule = cssRules[j];
+			if (cssRule.selectorText == ruleName) {
+				return cssRule;
 			}
 		}
 	}


### PR DESCRIPTION
`playerlib.js:getCSSRule` uses a hardcoded stylesheet name in the code, prob done for search optimizing. This construction is in the way of optimizing the resource loading or developing without minimizing.

moOde only calls  `getCSSRule` 3 times and only during startup. For now lets remove the optimization, by removing the `if`. No noticeable difference in loading speed.


```javascript 
// Get CSS rule object
function getCSSRule(ruleName) {
	for (var i = 0; i < document.styleSheets.length; i++) {
		var styleSheet = document.styleSheets[i];

		if (styleSheet.href && styleSheet.href.indexOf('flat-ui.min.css') != -1 ) {
			var cssRules = styleSheet.cssRules;
			for (var j = 0; j < cssRules.length; j++) {
				var cssRule = cssRules[j];
				if (cssRule.selectorText == ruleName) {
					return cssRule;
				}
			}
		}
	}
}
```