### PR TITLE
fix firefox custom scrollbar css

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -556,8 +556,8 @@ ol.playhistory {margin-left:55px;}
    }
 
    /* Firefox */
-   * {
-	   .custom-scrollbars scrollbar-width: thin;
-	   .custom-scrollbars scrollbar-color: auto;
+   .custom-scrollbars * {
+	   scrollbar-width: thin;
+	   scrollbar-color: auto;
    }
 }


### PR DESCRIPTION
Oeps I made an error on the FireFoxcss; the prefix class shouldn't be in front of the properties but of the class itself.