### PR TITLE
Proposal to hide the volume controls when MPD volume is disabled

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -27,6 +27,16 @@ require_once dirname(__FILE__) . '/inc/playerlib.php';
 
 playerSession('open', '', '');
 session_write_close();
+$dbh = cfgdb_connect();
+
+// Load settings
+$result = cfgdb_read('cfg_mpd', $dbh);
+$mpdconf = array();
+
+foreach ($result as $row) {
+	$mpdconf[$row['param']] = $row['value'];
+}
+$_vol_disabled = (($mpdconf['mixer_type'] == 'disabled') ? "style=\"display:none\"" : "");
 
 $section = basename(__FILE__, '.php');
 

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -79,7 +79,7 @@
 							<button aria-label="Next" class="btn btn-cmd next"><i class="fas fa-step-forward"></i></button>
 						</div>
 					</div>
-					<div id="volzone">
+					<div id="volzone" $_vol_disabled>
 						<div id="volknob">
 							<div id="volcontrol" class="volume-step-limiter">
 


### PR DESCRIPTION
It has always bugged me that the volume controls are displayed when I have MPD volume disabled.  I tried a quick hack to see if I could remove it easily.  I'm happy to improve this.

Load the MPD config
If the `mixer_type` is disabled then set a flag (I've hacked in `style="display:none"` because I wanted to see if it would work before digging into the CSS properly)
else display as usual.

Looking forward to feedback.