### PR TITLE
remove Name check for radio station

### DIFF
--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -3183,7 +3183,7 @@ function enhanceMetadata($current, $sock, $caller = '') {
 			//debugLog('enhanceMetadata(): iTunes AAC or AIFF file');
 		}
 		// Radio station
-		elseif (isset($song['Name']) || (substr($song['file'], 0, 4) == 'http' && /*!isset($song['Artist'])*/!isset($current['duration']))) {
+		elseif (substr($song['file'], 0, 4) == 'http' && /*!isset($song['Artist'])*/!isset($current['duration'])) {
 			debugLog('enhanceMetadata(): Radio station');
 			$current['artist'] = 'Radio station';
 


### PR DESCRIPTION
Remove check for Name field in mpd response when checking for Radio station as Name can be populated via extended m3u directives when a playlist is loaded.

Addresses #173