### PR TITLE
fix missing escape char in html

### DIFF
--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -1773,7 +1773,7 @@
 					</div>
 					<a aria-label="Help" class="info-toggle" data-cmd="info-import-station-pkg" href="#notarget"><i class="fas fa-info-circle"></i></a>
 					<div id="info-import-station-pkg" class="help-block hide">
-						Import a radio station ZIP package into the Library. The package contents will replace the existing radio station SQL table, PLS files and station logos. The package must be in the exact format of an exported <b>"stations.zip"</b> file. File size must be < 50MB.
+						Import a radio station ZIP package into the Library. The package contents will replace the existing radio station SQL table, PLS files and station logos. The package must be in the exact format of an exported <b>"stations.zip"</b> file. File size must be &lt; 50MB.
 					</div>
 				</div>
 				<label class="control-label">Export radio stations</label>


### PR DESCRIPTION
A '<' wasn't escaped.