### PR TITLE
Extending moodecfg.txt feature

### DIFF
--- a/boot/moodecfg.txt.default
+++ b/boot/moodecfg.txt.default
@@ -65,4 +65,4 @@ cover_scale=1.25
 [other]
 font_size=Normal
 playhist=No
-first_use_help=y,y
+first_use_help=Yes

--- a/boot/moodecfg.txt.default
+++ b/boot/moodecfg.txt.default
@@ -1,10 +1,10 @@
 ##########################################
 # Copy this file to /boot/moodecfg.txt
-# worker will process it at startup then
-# delete it and automatically reboot.
-# 
+# It will be processed at startup and the
+# system will automaticly Restart.
+#
 # All param=value pairs must be present.
-# Set wlanssid=<nothing> to start AP mode.
+# Set wlanssid= blank to start AP mode.
 # Example: wlanssid=
 ##########################################
 
@@ -17,12 +17,32 @@ bluetoothname=Moode Bluetooth
 squeezelitename=Moode
 upnpname=Moode UPNP
 dlnaname=Moode DLNA
-mpdzeroconf=Moode MPD
 
-[services]
+[system]
+timezone=America/Detroit
+keyboard=us
+cpugov=On-demand
+eth0chk=1
+localui=0
+
+[device]
+i2sdevice=None
+
+[renderers]
+btsvc=0
+pairing_agent=0
+rsmafterbt=No
 airplaysvc=0
+rsmafterapl=No
+spotifysvc=0
+rsmafterspot=No
+slsvc=0
+rsmaftersl=No
+
+[upnp/dlna]
 upnpsvc=0
 dlnasvc=0
+upnp_browser=0
 
 [network]
 wlanssid=MySSID
@@ -33,7 +53,16 @@ apdssid=Moode
 apdchan=6
 apdpwd=moodeaudio
 
-[other]
-timezone=America/Detroit
+[theme & background]
 themename=Default
 accentcolor=Emerald
+alphablend=1.0
+adaptive=No
+cover_backdrop=No
+cover_blur=20px
+cover_scale=1.25
+
+[other]
+font_size=Normal
+playhist=No
+first_use_help=y,y

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -2838,7 +2838,7 @@ function autoConfig($cfgfile) {
 
 	playerSession('write', 'font_size', $autocfg['font_size']);
 	playerSession('write', 'playhist', $autocfg['playhist']);
-	playerSession('write', 'first_use_help', $autocfg['first_use_help']);
+	playerSession('write', 'first_use_help', ($autocfg['first_use_help'] == 'Yes' ? 'y,y' : 'n,n'));
 
 	autoCfgLog('autocfg: Font size: ' . $autocfg['font_size']);
 	autoCfgLog('autocfg: Play history: ' . $autocfg['playhist']);

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -2737,6 +2737,7 @@ function autoConfig($cfgfile) {
 	autoCfgLog('autocfg: - Device');
 	//
 
+	cfgI2sOverlay($autocfg['i2sdevice'] == "None" ? 'none' : $autocfg['i2sdevice']);
 	playerSession('write', 'i2sdevice', $autocfg['i2sdevice']);
 
 	autoCfgLog('autocfg: i2sdevice: ' . $autocfg['i2sdevice']);

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -2702,8 +2702,8 @@ function autoConfig($cfgfile) {
 	sysCmd('/var/www/command/util.sh chg-name dlna "Moode DLNA" ' . '"' . $autocfg['dlnaname'] . '"');
 	playerSession('write', 'dlnaname', $autocfg['dlnaname']);
 
-	sysCmd('/var/www/command/util.sh chg-name mpdzeroconf ' . "'" . '"Moode MPD"' . "'" . ' ' . "'" . '"' . $autocfg['mpdzeroconf'] . '"' . "'");
-	cfgdb_update('cfg_mpd', cfgdb_connect(), 'zeroconf_name', $autocfg['mpdzeroconf']);
+	//sysCmd('/var/www/command/util.sh chg-name mpdzeroconf ' . "'" . '"Moode MPD"' . "'" . ' ' . "'" . '"' . $autocfg['mpdzeroconf'] . '"' . "'");
+	//cfgdb_update('cfg_mpd', cfgdb_connect(), 'zeroconf_name', $autocfg['mpdzeroconf']);
 
 	autoCfgLog('autocfg: Host name: ' . $autocfg['hostname']);
 	autoCfgLog('autocfg: Browser title: ' . $autocfg['browsertitle']);
@@ -2711,9 +2711,71 @@ function autoConfig($cfgfile) {
 	autoCfgLog('autocfg: Airplay: ' . $autocfg['airplayname']);
 	autoCfgLog('autocfg: Spotify: ' . $autocfg['spotifyname']);
 	autoCfgLog('autocfg: Squeezelite: ' . $autocfg['squeezelitename']);
-	autoCfgLog('autocfg: UPnP: ' . $autocfg['upnpname']);
+	autoCfgLog('autocfg: UPnP Client: ' . $autocfg['upnpname']);
 	autoCfgLog('autocfg: DLNA: ' . $autocfg['dlnaname']);
-	autoCfgLog('autocfg: MPD zeroconf: ' . $autocfg['mpdzeroconf']);
+	//autoCfgLog('autocfg: MPD zeroconf: ' . $autocfg['mpdzeroconf']);
+
+	//
+	autoCfgLog('autocfg: - System');
+	//
+
+	sysCmd('/var/www/command/util.sh set-timezone ' . $autocfg['timezone']);
+	playerSession('write', 'timezone', $autocfg['timezone']);
+	sysCmd('/var/www/command/util.sh set-keyboard ' . $autocfg['keyboard']);
+	playerSession('write', 'keyboard', $autocfg['keyboard']);
+	playerSession('write', 'cpugov', $autocfg['cpugov'] == 'Performance' ? 'performance' : 'ondemand');
+	playerSession('write', 'eth0chk', $autocfg['eth0chk']);
+	playerSession('write', 'localui', $autocfg['localui']);
+
+	autoCfgLog('autocfg: Time zone: ' . $autocfg['timezone']);
+	autoCfgLog('autocfg: Keyboard: ' . $autocfg['keyboard']);
+	autoCfgLog('autocfg: CPU Governor: ' . $autocfg['cpugov']);
+	autoCfgLog('autocfg: Wait for eth0 address: ' . ($autocfg['eth0chk'] == '0' ? 'No' : 'Yes'));
+	autoCfgLog('autocfg: Local UI: ' . ($autocfg['localui'] == '0' ? 'Off' : 'On'));
+
+	//
+	autoCfgLog('autocfg: - Device');
+	//
+
+	playerSession('write', 'i2sdevice', $autocfg['i2sdevice']);
+
+	autoCfgLog('autocfg: i2sdevice: ' . $autocfg['i2sdevice']);
+
+	//
+	autoCfgLog('autocfg: - Renderers');
+	//
+
+	playerSession('write', 'btsvc', $autocfg['btsvc']);
+	playerSession('write', 'pairing_agent', $autocfg['pairing_agent']);
+	playerSession('write', 'rsmafterbt', $autocfg['rsmafterbt'] == 'No' ? '0' : '1');
+	playerSession('write', 'airplaysvc', $autocfg['airplaysvc']);
+	playerSession('write', 'rsmafterapl', $autocfg['rsmafterapl']);
+	playerSession('write', 'spotifysvc', $autocfg['spotifysvc']);
+	playerSession('write', 'rsmafterspot', $autocfg['rsmafterspot']);
+	playerSession('write', 'slsvc', $autocfg['slsvc']);
+	playerSession('write', 'rsmaftersl', $autocfg['rsmaftersl']);
+
+	autoCfgLog('autocfg: Bluetooth: ' . ($autocfg['btsvc'] == '0' ? 'Off' : 'On'));
+	autoCfgLog('autocfg: Bluetooth pairing agent: ' . ($autocfg['pairing_agent'] == '0' ? 'Off' : 'On'));
+	autoCfgLog('autocfg: Bluetooth resume: ' . $autocfg['rsmafterbt']);
+	autoCfgLog('autocfg: Airplay: ' . ($autocfg['airplaysvc'] == '0' ? 'Off' : 'On'));
+	autoCfgLog('autocfg: Airplay resume: ' . $autocfg['rsmafterapl']);
+	autoCfgLog('autocfg: Spotify: ' . ($autocfg['spotifysvc'] == '0' ? 'Off' : 'On'));
+	autoCfgLog('autocfg: Spotify resume: ' . $autocfg['rsmafterspot']);
+	autoCfgLog('autocfg: Squeezlite: ' . ($autocfg['slsvc'] == '0' ? 'Off' : 'On'));
+	autoCfgLog('autocfg: Squeezlite resume: ' . $autocfg['rsmaftersl']);
+
+	//
+	autoCfgLog('autocfg: - UPnP/DLNA');
+	//
+
+	playerSession('write', 'upnpsvc', $autocfg['upnpsvc']);
+	playerSession('write', 'dlnasvc', $autocfg['dlnasvc']);
+	playerSession('write', 'upnp_browser', $autocfg['upnp_browser']);
+
+	autoCfgLog('autocfg: UPnP Client: ' . ($autocfg['upnpsvc'] == '0' ? 'Off' : 'On'));
+	autoCfgLog('autocfg: DLNA: ' . ($autocfg['dlnasvc'] == '0' ? 'Off' : 'On'));
+	autoCfgLog('autocfg: UPnP Browser: ' . ($autocfg['upnp_browser'] == '0' ? 'Off' : 'On'));
 
 	//
 	autoCfgLog('autocfg: - Network (wlan0)');
@@ -2751,29 +2813,35 @@ function autoConfig($cfgfile) {
 	autoCfgLog('autocfg: Channel: ' . $autocfg['apdchan']);
 
 	//
-	autoCfgLog('autocfg: - Services');
+	autoCfgLog('autocfg: - Theme & Background');
 	//
 
-	playerSession('write', 'airplaysvc', $autocfg['airplaysvc']);
-	playerSession('write', 'upnpsvc', $autocfg['upnpsvc']);
-	playerSession('write', 'dlnasvc', $autocfg['dlnasvc']);
+	playerSession('write', 'themename', $autocfg['themename']);
+	playerSession('write', 'accent_color', $autocfg['accentcolor']);
+	playerSession('write', 'alphablend', $autocfg['alphablend']);
+	playerSession('write', 'adaptive', $autocfg['adaptive']);
+	playerSession('write', 'cover_backdrop', $autocfg['cover_backdrop']);
+	playerSession('write', 'cover_blur', $autocfg['cover_blur']);
+	playerSession('write', 'cover_scale', $autocfg['cover_scale']);
 
-	autoCfgLog('autocfg: Airplay: ' . ($autocfg['airplaysvc'] == '0' ? 'Off' : 'On'));
-	autoCfgLog('autocfg: UPnP: ' . ($autocfg['upnpsvc'] == '0' ? 'Off' : 'On'));
-	autoCfgLog('autocfg: DLNA: ' . ($autocfg['dlnasvc'] == '0' ? 'Off' : 'On'));
+	autoCfgLog('autocfg: Theme name: ' . $autocfg['themename']);
+	autoCfgLog('autocfg: Accent color: ' . $autocfg['accentcolor']);
+	autoCfgLog('autocfg: Adapting coloring: ' . $autocfg['adaptive']);
+	autoCfgLog('autocfg: Cover backdrop: ' . $autocfg['cover_backdrop']);
+	autoCfgLog('autocfg: Cover blur: ' . $autocfg['cover_blur']);
+	autoCfgLog('autocfg: Cover scale: ' . $autocfg['cover_scale']);
 
 	//
 	autoCfgLog('autocfg: - Other');
 	//
 
-	sysCmd('/var/www/command/util.sh set-timezone ' . $autocfg['timezone']);
-	playerSession('write', 'timezone', $autocfg['timezone']);
-	playerSession('write', 'themename', $autocfg['themename']);
-	playerSession('write', 'accent_color', $autocfg['accentcolor']);
+	playerSession('write', 'font_size', $autocfg['font_size']);
+	playerSession('write', 'playhist', $autocfg['playhist']);
+	playerSession('write', 'first_use_help', $autocfg['first_use_help']);
 
-	autoCfgLog('autocfg: Time zone: ' . $autocfg['timezone']);
-	autoCfgLog('autocfg: Theme name: ' . $autocfg['themename']);
-	autoCfgLog('autocfg: Accent color: ' . $autocfg['accentcolor']);
+	autoCfgLog('autocfg: Font size: ' . $autocfg['font_size']);
+	autoCfgLog('autocfg: Play history: ' . $autocfg['playhist']);
+	autoCfgLog('autocfg: first use help: ' . $autocfg['first_use_help']);
 
 	sysCmd('rm ' . $cfgfile);
 	autoCfgLog('autocfg: Configuration file deleted');

--- a/www/setup.txt
+++ b/www/setup.txt
@@ -188,12 +188,32 @@ bluetoothname=Moode Bluetooth
 squeezelitename=Moode
 upnpname=Moode UPNP
 dlnaname=Moode DLNA
-mpdzeroconf=Moode MPD
 
-[services]
+[system]
+timezone=America/Detroit
+keyboard=us
+cpugov=On-demand
+eth0chk=1
+localui=0
+
+[device]
+i2sdevice=None
+
+[renderers]
+btsvc=0
+pairing_agent=0
+rsmafterbt=0
 airplaysvc=0
+rsmafterapl=No
+spotifysvc=0
+rsmafterspot=No
+slsvc=0
+rsmaftersl=No
+
+[upnp/dlna]
 upnpsvc=0
 dlnasvc=0
+upnp_browser=0
 
 [network]
 wlanssid=MySSID
@@ -204,10 +224,19 @@ apdssid=Moode
 apdchan=6
 apdpwd=moodeaudio
 
-[other]
-timezone=America/Detroit
+[theme & background]
 themename=Default
 accentcolor=Emerald
+alphablend=1.0
+adaptive=No
+cover_backdrop=No
+cover_blur=20px
+cover_scale=1.25
+
+[other]
+font_size=Normal
+playhist=No
+first_use_help=y,y
 
 ////////////////////////////////////////////////////////
 //

--- a/www/setup.txt
+++ b/www/setup.txt
@@ -236,7 +236,7 @@ cover_scale=1.25
 [other]
 font_size=Normal
 playhist=No
-first_use_help=y,y
+first_use_help=Yes
 
 ////////////////////////////////////////////////////////
 //

--- a/www/setup.txt
+++ b/www/setup.txt
@@ -202,7 +202,7 @@ i2sdevice=None
 [renderers]
 btsvc=0
 pairing_agent=0
-rsmafterbt=0
+rsmafterbt=No
 airplaysvc=0
 rsmafterapl=No
 spotifysvc=0


### PR DESCRIPTION
 - Changing sections name for matching the names in web UI
 - Adding all the renderers and the possibility to resuming
 - Adding ability to set I2S device
 - Adding system options: keyboard, local UI, CPU Governor and Wait for eth0 address
 - Adding more theme options
 - Removing mpdzeroconf option, since we do not have the possibility to change it in web UI
 - Updating setup.txt and moodecfg.txt

I've running tests, that seems to work, you can see a autocfg.log from one of my test
[autocfg.log](https://github.com/moode-player/moode/files/5233647/autocfg.log)

