### PR TITLE
Add h/w to thumb image element

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -256,8 +256,8 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#lib-albumcover {left:0;}
 	/* ellipsis madness */
 	#artistsList li, #genresList li, #albumsList li {max-width:calc(50vw - 2.3rem);min-width:33vw;}
-	#albumcovers .lib-entry, .database-radio li {width:var(--mthumbcols);}
-	#albumcovers .lib-entry img, .database-radio img {max-height:calc(var(--mthumbcols) * .9);}
+	#albumcovers .lib-entry, .database-radio li {width:var(--thumbcols);}
+	#albumcovers .lib-entry img, .database-radio img {max-height:var(--thumbimagesize);}
 	/* stuff */
 	#ss-currentsong {font-size:1.5em;}
 	#ss-currentalbum, #ss-currentartist {font-size:1.25em;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -48,8 +48,8 @@ html, body {background-attachment:fixed;background-size:cover;height:100%;color:
 	--pbfont:calc(0.45em + 1vmin);
 	--radiobadge:url('../images/radio-l.svg');
 	--defcover:'images/default-cover-v6-l.svg';
-	--thumbcols:15vw;
-	--mthumbcols:45vw;
+	--thumbcols:0px;
+	--thumbimagesize:0px;
 	--coverback:'';
 	--config_modal_btn_bg:rgba(64,64,64,0.08);
 	--npicon: url('../images/audiow.svg');
@@ -194,7 +194,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .playlist li, .cv-playlist li, .database li, .database-radio li {display:block;position:relative;margin:0;cursor:pointer;text-align:left;padding-left:.75em;}
 /*.playlist li:before {display:block;float:left;width:2.5em;line-height:normal;text-align:right;counter-increment:item;content:counter(item) ' ';color:var(--textvariant);font-size:1em;letter-spacing:-1px;}*/
 .playlist li:before, .cv-playlist li:before {float:left;width:2.9em;letter-spacing:-1px;text-align:right;line-height:normal;counter-increment:item;content:counter(item) ' ';font-size:1em;margin-top:2px;}
-.database-radio li {width:var(--thumbcols);text-align:center;font-size:.95em;/*margin:.25em .75em .75em .75em*/;display:inline-block;vertical-align:top;height:auto;padding:0 0 .5em 0;}
+.database-radio li {width:var(--thumbcols);text-align:center;font-size:.95em;margin:0 .1em;display:inline-block;vertical-align:top;height:auto;padding:0 0 .5em 0;}
 .database li {margin-left:2px;margin-right:5px;padding:0;}
 .playlist li.active:before, .cv-playlist li.active:before {color:var(--accentxts);opacity:1;}
 .database span {display:block;font-weight:normal;color:inherit;opacity:.60;}
@@ -224,7 +224,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 /*.playlist .active .pl-thumb img, .cv-playlist .active .pl-thumb img {filter:brightness(50%);}
 .playlist .active .pl-thumb:after, .cv-playlist .active .pl-thumb:after {position:absolute;top:50%;transform:translate(-120%, -50%);font-family:'Font Awesome 5 Pro';font-size:1.25em;content: "\f028";}*/
 /*.playlist li.active:before {font-family:'Font Awesome 5 Pro';content: "\f028";margin-top:.35em;}*/
-.playlist li.active:before, .cv-playlist li.active:before {color:transparent !important;background:var(--npicon) no-repeat right;margin-top:.35em;}
+.playlist li.active:before, .cv-playlist li.active:before {color:transparent !important;background:var(--npicon) no-repeat right;background-size:1em;margin-top:.35em;}
 
 .playlist .pll1, .cv-playlist .pll1 {font-weight:400;opacity:1;text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
 .playlist .pl-entry, .cv-playlist .pl-entry {padding:0px;}
@@ -402,7 +402,7 @@ img.lib-artistart {float:left;width:calc(20vw - 1em);height: calc(20vw - 2em);bo
 #lib-albumcover {height:100%;width:100%;position:absolute;box-sizing:border-box;left:0%;top:2.75em;top:calc(env(safe-area-inset-top) + 2.75em);overflow:auto;overflow-x:hidden;-webkit-overflow-scrolling:touch;}
 #albumcovers {text-align:center;margin:0;padding-bottom:12em;}
 #albumcovers .lib-entry, .database-radio .lib-entry {width:var(--thumbcols);text-align:center;display:inline-block;vertical-align:top;height:auto;font-size:.95em;padding:0 0 .4em 0;}
-#albumcovers .lib-entry img, .database-radio img {width:90%;max-height:calc(var(--thumbcols) * .9);margin:.75em 0 .5em 0;}
+#albumcovers .lib-entry img, .database-radio img {max-height:var(--thumbimagesize);margin:.75em 0 .5em 0;}
 #albumcovers .album-name {display:block !important;}
 #albumcovers .artyear {color:var(--textvariant);font-weight:500;}
 #albumcovers .artist-name, #albumcovers .album-year {margin:0 .15em;}

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -532,12 +532,12 @@ var renderAlbums = function() {
 
     if (GLOBAL.nativeLazyLoad) {
     	var tagViewLazy = '<img loading="lazy" src="';
-        var albumViewLazy = tagViewLazy;
+        var albumViewLazy = '<img loading="lazy" height="' + UI.thumbHW + '" width="' + UI.thumbHW + '" src="' ;
     }
     else {
     	var tagViewLazy = '<img class="lazy-tagview" data-original="';
-    	var albumViewLazy = '<img class="lazy-albumview" data-original="';
-    }
+    	var albumViewLazy = '<img class="lazy-albumview" height="' + UI.thumbHW + '" width="' + UI.thumbHW + '" data-original="';
+    }	
 
     // SESSION.json['library_encoded_at']
     // 0 = No (searchable), 1 = HD only, 2 = Text, 3 = Badge, 9 = No
@@ -555,7 +555,7 @@ var renderAlbums = function() {
 
         // filteredAlbums[i].encoded_at
         // [0] bits/rate format. [1] flag: "l" lossy, "s" standard def or "h" high def
-        if (encodedAtOption != 9) {
+        if (encodedAtOption && encodedAtOption != 9) {
             // Tag view
             var tagViewHdDiv = encodedAtOption == 1 && filteredAlbums[i].encoded_at.split(',')[1] == 'h' ? '<div class="lib-encoded-at-hdonly-tagview">' + ALBUM_HD_BADGE_TEXT + '</div>' : '';
             var tagViewNvDiv = encodedAtOption <= 1 ? '<div class="lib-encoded-at-notvisible">' + filteredAlbums[i].encoded_at.split(',')[0] + '</div>' : '';

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -34,12 +34,12 @@ jQuery(document).ready(function($) { 'use strict';
 
 	// Store scrollbar width (it will be 0 for overlay scrollbars and > 0 for always on scrollbars
 	var hiddenDiv = $("<div style='position:absolute; top:-10000px; left:-10000px; width:100px; height:100px; overflow:scroll;'></div>").appendTo("body");
-	var sbw = hiddenDiv.width() - hiddenDiv[0].clientWidth;
-	$("body").get(0).style.setProperty("--sbw", sbw + 'px');
+	GLOBAL.sbw = hiddenDiv.width() - hiddenDiv[0].clientWidth;
+	$("body").get(0).style.setProperty("--sbw", GLOBAL.sbw + 'px');
     //console.log(hiddenDiv.width() - hiddenDiv[0].clientWidth + 'px');
 
     // Enable custom scroll bars unless overlay scroll bars are enabled on the platform (scroll bar width sbw = 0)
-    if (sbw) {
+    if (GLOBAL.sbw) {
         $('body').addClass('custom-scrollbars');
     }
 
@@ -63,8 +63,13 @@ jQuery(document).ready(function($) { 'use strict';
     	// Set currentView global
     	currentView = SESSION.json['current_view'];
 
+    	// mobile
+    	UI.mobile = $(window).width() < 480 ? true : false; /* mobile-ish */
+        //console.log('window: ' + $(window).width() + 'x' + $(window).height());
+        //console.log('viewport: ' + window.innerWidth + 'x' + window.innerHeight);
+
         // Set thumbnail columns
-        setLibraryThumbnailCols(SESSION.json['library_thumbnail_columns'].substring(0, 1));
+        getThumbHW();
 
         // Initiate loads
         loadLibrary();
@@ -78,11 +83,6 @@ jQuery(document).ready(function($) { 'use strict';
     	UI.libPos[0] = parseInt(tmpStr[0]); // album list
     	UI.libPos[1] = parseInt(tmpStr[1]); // album cover
     	UI.libPos[2] = parseInt(tmpStr[2]); // artist list
-
-    	// mobile
-    	UI.mobile = $(window).width() < 480 ? true : false; /* mobile-ish */
-        //console.log('window: ' + $(window).width() + 'x' + $(window).height());
-        //console.log('viewport: ' + window.innerWidth + 'x' + window.innerHeight);
 
         // Set volume knob max
         $('#volume, #volume-2').attr('data-max', SESSION.json['volume_mpd_max']);


### PR DESCRIPTION
This is supposedly a perf win for native lazy load but didn't seem like much if any so I never bothered with it as it uses some memory but it also mostly maximizes screen use and solves the jitter while scrolling up in the album cover & radio views issue without a placeholder or any extra elements.

This also adds back some missing code from the ill-fated tidal image "fix" pr.