### PR TITLE
Adjust method of setting thumbnail h/w

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -165,9 +165,9 @@ li.modal-dropdown-text:focus {color:#eee;}
 	.lib-entry-song {font-size:.95em;}
 	#lib-file {left:0%;width:100%;padding-left:0px;}
 
-	#tagview-text-cover {font-size:1rem;width:75px;height:75px;}
-	#lib-coverart-img {float:left;min-width:75px;width:75px;height:75px;margin:0;}
-	#lib-coverart-meta-area img {height:75px;width:75px;min-width:75px;max-width:75px;margin:.25em .25em .25em .5em;}
+	#tagview-text-cover {font-size:1rem;width:75px;height:75px;padding:0;margin:.25em;}
+	#lib-coverart-img {float:left;min-width:75px;width:75px;height:75px;margin:.25em;position:relative;}
+	#lib-coverart-meta-area img {height:75px;width:75px;min-width:75px;max-width:75px;left:.25em;top:.25em;}
 	#lib-coverart-meta-area {float:left;width:100%;line-height:14px;}
 	#lib-meta-summary {width:calc(100% - 75px - 1em);line-height:normal;font-size:.9em;margin:.5em 0;float:right;}
 
@@ -210,6 +210,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#mobile-time {display:block;}
 	.btn btn-cmd btn-toggle {font-size:.75em;}
 	img.coverart {width:50vh;height:auto;max-width:90vw;max-height:90vw;border:none;}
+	#playback-firstuse-help {height:50vh;width:50vh;max-height:90vw;max-width:90vw;left:50%;transform:translate(-50%);}
 	img.libart {width:90%;}
 	.modal-sm2 {min-width:80%;}
 	.form-horizontal .controls {margin-left:32.5%;}
@@ -217,7 +218,6 @@ li.modal-dropdown-text:focus {color:#eee;}
 	.form-horizontal .control-label {float:left;width:30%;padding-top:4px;text-align:right;}
 	.bootstrap-select:not([class*="span"]) {width:140px;}
 	.btnlist-top-db button, .btnlist-top-ra button {font-size:1.5rem;width:3.1rem;}
-	.playlist .pl-thumb, .cv-playlist .pl-thumb {/*display:none;*/margin-left:1.2vmin !important;margin-right:1.2vmin;margin-top:4px;}
 	#playbar-hd-badge {margin-top:.6em;}
 	#playbar-volume-level {font-size:1.2rem;vertical-align:initial}
 	#playbar-volume-popup-btn {width:initial!important;}
@@ -250,14 +250,12 @@ li.modal-dropdown-text:focus {color:#eee;}
 	.playlist span {line-height:normal;margin-left:calc(3.5rem + 1vmin);display:block;}
 	.playlist span {margin-left:calc(3.8rem + 1vmin) !important;}
 	.playlist {padding:0 0 9rem 0;min-height:33vh;}
-	.playlist li:before {font-size:unset;width:1.75em!important;}
+	/*.playlist li:before {width:1.75em!important;}*/
 	.playlist .pl-action, .playlist .db-action a {padding:.4em 1.25em 1em 0;}
 	.ui-pnotify {top:40% !important;}
 	#lib-albumcover {left:0;}
 	/* ellipsis madness */
 	#artistsList li, #genresList li, #albumsList li {max-width:calc(50vw - 2.3rem);min-width:33vw;}
-	#albumcovers .lib-entry, .database-radio li {width:var(--thumbcols);}
-	#albumcovers .lib-entry img, .database-radio img {max-height:var(--thumbimagesize);}
 	/* stuff */
 	#ss-currentsong {font-size:1.5em;}
 	#ss-currentalbum, #ss-currentartist {font-size:1.25em;}
@@ -366,8 +364,9 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#currentsong, #currentalbum {padding-top:.75em;font-size:1.1em;}
 }
 /* media queries */
-@media (max-height:640px) {
+@media (max-height:640px) and (orientation:portrait)  {
 	img.coverart {width:45vh;}
+	#playback-firstuse-help {height:45vh;width:45vh;}
 }
 /* iPhone5 portrait */
 @media (max-height:568px) and (max-width:320px) {
@@ -412,6 +411,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#playbtns {margin:.25em 0;}
 	#playbar-title {font-size:1rem;}
 	img.coverart {width:55vh;}
+	#playback-firstuse-help {height:55vh;width:55vh;}
 }
 @media (min-height:443px) and (width:799px) { /* 443 = Square pixel AR, 479 = Default pixel AR */
 	.playlist .pll1 {font-size:1rem;}
@@ -420,6 +420,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#playbtns {margin:.25em 0;}
 	#playbar-title {font-size:1rem;}
 	img.coverart {width:55vh;}
+	#playback-firstuse-help {height:55vh;width:55vh;}
 }
 
 /* iPhone X */
@@ -466,6 +467,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#playback-panel.newui #volzone {right:12.5%;top:59%;}
 	#playback-panel.newui #playback-cover {width:60vw;} /* 60% cover h/w */
 	#playback-panel.newui #coverart-url, #playback-panel.newui img.coverart {width:60vw;max-height:60vw;}
+	#playback-panel.newui #playback-firstuse-help {height:60vw;width:60vw;}
 	#playback-panel.newui #container-playlist, #playback-panel.cv #container-playlist {width:60%;height:58%;}
 	#playback-panel.newui #playback-queue, #playback-panel.cv #playback-queue {width:60%;}
 }
@@ -474,10 +476,12 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#playback-panel.newui #volzone {top:61%;}
 	#playback-panel.newui #playback-cover {width:70vw;} /* 70% cover h/w */
 	#playback-panel.newui #coverart-url, #playback-panel.newui img.coverart {width:70vw;max-height:70vw;}
+	#playback-panel.newui #playback-firstuse-help {height:70vw;width:70vw;}
 	#playback-panel.newui #playback-queue, #playback-panel.cv #playback-queue {width:60%;}
 }
 @media (orientation: landscape) and (max-aspect-ratio:3/2){
 	#playback-panel.newui #coverart-url, #playback-panel.newui #playback-cover, #playback-panel.newui img.coverart {width:40vw;max-height:40vw;}
+	#playback-panel.newui #playback-firstuse-help {height:40vw;width:40vw;}
 	#playback-panel.newui #timezone, #playback-panel.newui #volzone {height:40vw;}
 }
 @media (height:834px) and (width:1194px) {

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -192,11 +192,10 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #database-radio {height:calc(100vh - 2.75em);}
 .database-radio {text-align:center;padding:0 0 14rem 0;}
 .playlist li, .cv-playlist li, .database li, .database-radio li {display:block;position:relative;margin:0;cursor:pointer;text-align:left;padding-left:.75em;}
-/*.playlist li:before {display:block;float:left;width:2.5em;line-height:normal;text-align:right;counter-increment:item;content:counter(item) ' ';color:var(--textvariant);font-size:1em;letter-spacing:-1px;}*/
 .playlist li:before, .cv-playlist li:before {float:left;width:2.9em;letter-spacing:-1px;text-align:right;line-height:normal;counter-increment:item;content:counter(item) ' ';font-size:1em;margin-top:2px;}
 .database-radio li {width:var(--thumbcols);text-align:center;font-size:.95em;margin:0 .1em;display:inline-block;vertical-align:top;height:auto;padding:0 0 .5em 0;}
 .database li {margin-left:2px;margin-right:5px;padding:0;}
-.playlist li.active:before, .cv-playlist li.active:before {color:var(--accentxts);opacity:1;}
+/*.playlist li.active:before, .cv-playlist li.active:before {color:var(--accentxts);opacity:1;}*/
 .database span {display:block;font-weight:normal;color:inherit;opacity:.60;}
 .playlist span, .cv-playlist span {line-height:normal;margin-left:calc(3em + 1vmin);display:block;}
 .pll1 {font-size:1em;}
@@ -221,10 +220,10 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #library-panel.limited .lib-entry, #library-panel.limited .lib-entry span {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
 .database .active {font-size:inherit;font-weight:700;}
 .playlist .active .pll1, .cv-playlist .active .pll1 {color:var(--accentxts);font-weight:700;}
-.playlist li.active:before, .cv-playlist li.active:before {width:2.9em;color:transparent !important;background:var(--npicon) no-repeat right;background-size:1em;/*margin-top:.35em;*/}
+.playlist li.active:before, .cv-playlist li.active:before {color:transparent !important;background:var(--npicon) no-repeat right;background-size:1em;}
 .playlist .pll1, .cv-playlist .pll1 {font-weight:400;opacity:1;text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
 .playlist .pl-entry, .cv-playlist .pl-entry {padding:0px;}
-.playlist .pl-thumb, .cv-playlist .pl-thumb {float: left; width: 2.4rem; margin-left: 1.2vmin; margin-right: 1.2vmin;border-radius:.2em;filter:brightness(80%);overflow:hidden;}
+.playlist .pl-thumb, .cv-playlist .pl-thumb {float: left; width: 2.4em; margin-left: 1.2vmin; margin-right: 1.2vmin;border-radius:.2em;filter:brightness(80%);overflow:hidden;}
 .database .db-entry {margin-left:2.5em;padding:1em 0;max-width:calc(100vw - 10px);overflow:hidden;}
 .database .db-song {padding:.5em 0;}
 .database .db-icon {display:block;float:left;height:19px;line-height:19px;width:1.875em;padding:0;color:inherit;}
@@ -246,7 +245,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .database .db-action {float:left;width:3.2rem;padding:0;position:relative;}
 .database .db-action i {width:2.2rem;}
 .playlist .pl-action, .playlist .db-action a {position:relative;width:4.5em;margin-left:1em;font-weight:normal;text-decoration:none;z-index:3;font-size:.9em;line-height:.625em;padding:.318em 0;float:right;}
-.cv-playlist .pl-action, .cv-playlist .db-action a {position:relative;width:4.5em;margin-left:1em;font-weight:normal;text-decoration:none;z-index:3;font-size:.9em;line-height:.625em;padding:.318em 0;float:right;}
+.cv-playlist .pl-action, .cv-playlist .db-action a {position:relative;width:4.5em;margin-left:1em!important;font-weight:normal;text-decoration:none;z-index:3;font-size:.9em;line-height:.625em;padding:.318em 0;float:right;}
 #db-search-results {font-style:italic;float:left;padding:1em .5em 0em .5em;font-size:1em;display:none;}
 #pl-saveName, #pl-favName {width:85%;}
 .input-append, .input-prepend {margin-bottom:0em;font-size:1em;}
@@ -355,15 +354,15 @@ code, pre {background-color:inherit;color:inherit;border:none;font-size:.8em;}
 #lib-coverart-meta-area {width:20vw;line-height:normal;padding:0;float:left;position:fixed;}
 #lib-coverart-img {margin:.5em .25em 0 .5em;}
 #lib-coverart-img a {display:inline-block;}
-#lib-meta-summary {margin-left:.5em;line-height:normal;}
+#lib-meta-summary {margin-left:.5em;line-height:normal;font-size:.9em;}
 img.lib-coverart {float:left;width:calc(20vw - 1em);box-shadow:0px 0px .2em rgba(0,0,0,0.2);}
 img.lib-coverart.active {box-shadow:0px 0px .2em .1em var(--accentxts);}
-img.lib-artistart {float:left;width:calc(20vw - 1em);height: calc(20vw - 2em);box-shadow:0px 0px .2em rgba(0,0,0,0.2);position:absolute;opacity:.4}
+img.lib-artistart {float:left;width:calc(20vw - 1rem);height: calc(20vw - 1rem);box-shadow:0px 0px .2em rgba(0,0,0,0.2);position:absolute;opacity:.4}
 .lib-albumname-meta {margin-top:0px;font-weight:700;text-align:center;}
-.lib-artistname-meta {margin-top:0;text-overflow:ellipsis;white-space:nowrap;overflow:hidden;font-size:calc(0.40em + 1vmin);font-weight:700;text-align:center;cursor:pointer;}
-.lib-albumyear-meta {display:none;font-size:calc(0.40em + 1vmin);font-weight:normal;text-align:center;}
-.lib-numtracks-meta {font-size:calc(0.40em + 1vmin);font-weight:normal;font-style:italic;color:inherit !important;text-align:center;}
-.lib-encoded-at-meta {font-size:calc(0.30em + 1vmin);font-weight:normal;font-style:italic;color:inherit !important;text-align:center;}
+.lib-artistname-meta {margin-top:0;text-overflow:ellipsis;white-space:nowrap;overflow:hidden;font-weight:700;text-align:center;cursor:pointer;}
+.lib-albumyear-meta {display:none;text-align:center;}
+.lib-numtracks-meta {font-style:italic;margin-top:.5em;color:inherit !important;text-align:center;}
+.lib-encoded-at-meta {font-style:italic;color:inherit !important;text-align:center;}
 /* index improvements */
 #lib-content ul {display:table;overflow-x:hidden;word-break:break-word;}
 #lib-content li {display:block;position:relative;cursor:pointer;line-height:1.25em;}
@@ -382,7 +381,7 @@ img.lib-artistart {float:left;width:calc(20vw - 1em);height: calc(20vw - 2em);bo
 .lib-action .btn {font-size:.9em;line-height:normal;margin-top:.45em;padding-right:100vw;opacity:0} /* click whole line for menu */
 .lib-disc {margin:0;text-transform:uppercase;/*background-color:rgba(128,128,128,0.1);box-shadow:0 .04em .025em rgba(0,0,0,0.15);*/display:none;}
 .lib-disc a {font-size:.9em;opacity:.75;}
-.lib-album-heading {font-size:.9em;opacity:.75;margin:0;text-transform:uppercase;background-color:rgba(128,128,128,0.1);box-shadow:0 .04em .025em rgba(0,0,0,0.15);display:none;}
+.lib-album-heading {font-size:.9em;opacity:.75;padding:.75em;margin:0;text-transform:uppercase;background-color:rgba(128,128,128,0.1);box-shadow:0 .04em .025em rgba(0,0,0,0.15);display:none;}
 #songsList .lib-disc a.active {font-weight:700;color:unset;}
 #songsList li.active {font-weight:700;background-color:unset;}
 #trackscontainer {width:calc(80vw - var(--sbw));float:right;} /* Was 81vw */
@@ -398,7 +397,7 @@ img.lib-artistart {float:left;width:calc(20vw - 1em);height: calc(20vw - 2em);bo
 #lib-albumcover {height:100%;width:100%;position:absolute;box-sizing:border-box;left:0%;top:2.75em;top:calc(env(safe-area-inset-top) + 2.75em);overflow:auto;overflow-x:hidden;-webkit-overflow-scrolling:touch;}
 #albumcovers {text-align:center;margin:0;padding-bottom:12em;}
 #albumcovers .lib-entry, .database-radio .lib-entry {width:var(--thumbcols);text-align:center;display:inline-block;vertical-align:top;height:auto;font-size:.95em;padding:0 0 .4em 0;}
-#albumcovers .lib-entry img, .database-radio img {max-height:var(--thumbimagesize);margin:.75em 0 .5em 0;}
+#albumcovers .lib-entry img, .database-radio img {height:var(--thumbimagesize);width:var(--thumbimagesize);max-height:var(--thumbimagesize);margin:.75em 0 .5em 0;}
 #albumcovers .album-name {display:block !important;}
 #albumcovers .artyear {color:var(--textvariant);font-weight:500;}
 #albumcovers .artist-name, #albumcovers .album-year {margin:0 .15em;}
@@ -633,7 +632,7 @@ input[type='range'].vslide2::-moz-range-track {height:10em;width:2px;border-radi
 .config-label {color:#eee;margin-left:.35em;}
 .busy-spinner {position:absolute;right:3.25rem;top:.2rem;top:calc(env(safe-area-inset-top) + .2rem);display:none;}
 .busy-spinner svg {stroke:var(--adapttext);height:1rem;width:1rem;}
-#tagview-text-cover {position:relative;font-size:1.8rem;line-height:1.1em;height:calc(20vw - 1em);width:100%;background:rgba(64,64,64,.2);box-shadow: 0px 0px .2em rgba(0,0,0,0.2);}
+#tagview-text-cover {position:relative;font-size:1.8rem;line-height:1.1em;height:calc(20vw - 1rem);width:calc(20vw - 1rem);background:rgba(64,64,64,.2);box-shadow: 0px 0px .2em rgba(0,0,0,0.2);}
 #station-path {text-align:center;}
 #track-info-text {text-align:left;}
 .no-tagview-covers {padding-top:.4em;padding-bottom:.4em;}
@@ -651,9 +650,13 @@ input[type='range'].vslide2::-moz-range-track {height:10em;width:2px;border-radi
 /* Radio view */
 .radioview-metadata-text {color:var(--textvariant);}
 /* First use help */
-#playback-firstuse-help {display:none;}
-#playbar-firstuse-help {display:none;position:absolute;left:0;top:0;z-index:9999}
-#playback-firstuse-help i, #playbar-firstuse-help i {cursor:pointer;}
+#playback-firstuse-help, #playbar-firstuse-help {display:none;position:absolute;background:rgba(0,0,0,0.9);cursor:pointer;}
+#playback-firstuse-help:after, #playbar-firstuse-help:after {position:absolute;top:.75em;right:.75em;font-family:"Font Awesome 5 Pro";content:"\f057";color:var(--accentxts);font-size:1.75em;} 
+#playback-firstuse-help {height:calc(38vw - 2em);width:calc(38vw - 2em);z-index:999;}
+#playbar-firstuse-help {z-index:9999;height:100%;width:100%;}
+#playback-firstuse-help div, #playbar-firstuse-help div {box-sizing:border-box;border:2px dashed var(--accentxts);height:calc(100% - 8px);width:calc(100% - 8px);margin:4px 0 0 4px;}
+#playback-firstuse-help div:after, #playbar-firstuse-help div:after {font-size:2.25em;position:absolute;top:50%;left:50%;transform:translate(-50%, -50%);content:"Tap on the cover art to switch to the Library";}
+#playbar-firstuse-help div:after {font-size: 1.75em;content:"Tap on the Playbar to switch to Playback ";}
 /* New/edit radio station modals */
 #new-station-format, #edit-station-format {text-transform:uppercase;}
 #import-export-msg {line-height:24px;color:var(--adapttext);}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -651,7 +651,7 @@ input[type='range'].vslide2::-moz-range-track {height:10em;width:2px;border-radi
 .radioview-metadata-text {color:var(--textvariant);}
 /* First use help */
 #playback-firstuse-help, #playbar-firstuse-help {display:none;position:absolute;background:rgba(0,0,0,0.9);cursor:pointer;}
-#playback-firstuse-help:after, #playbar-firstuse-help:after {position:absolute;top:.75em;right:.75em;font-family:"Font Awesome 5 Pro";content:"\f057";color:var(--accentxts);font-size:1.75em;} 
+#playback-firstuse-help:after, #playbar-firstuse-help:after {position:absolute;top:.75em;right:.75em;font-family:"Font Awesome 5 Pro";content:"\f057";color:var(--accentxts);font-size:1.75em;font-weight:100;} 
 #playback-firstuse-help {height:calc(38vw - 2em);width:calc(38vw - 2em);z-index:999;}
 #playbar-firstuse-help {z-index:9999;height:100%;width:100%;}
 #playback-firstuse-help div, #playbar-firstuse-help div {box-sizing:border-box;border:2px dashed var(--accentxts);height:calc(100% - 8px);width:calc(100% - 8px);margin:4px 0 0 4px;}

--- a/www/header.php
+++ b/www/header.php
@@ -156,7 +156,7 @@
 	<div id="menu-bottom" class="btn-group btn-list ui-footer ui-bar-f ui-footer-fixed slidedown" data-position="fixed" data-role="footer" role="banner">
 		<div id="playbar">
 			<div aria-label="Cover" id="playbar-cover"></div>
-			<div aria-label="First use help" id="playbar-firstuse-help">Tap on the Playbar to switch to Playback <i class="fal fa-times-circle"></i></div>
+			<div aria-label="First use help" id="playbar-firstuse-help"><div></div></div>
             <div aria-label="Switch to Playback" id="playbar-switch"><div></div></div>
 			<div id="playbar-controls">
 				<button aria-label="Previous" class="btn btn-cmd prev"><i class="fas fa-step-backward"></i></button>

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -2393,6 +2393,7 @@ $('#btn-appearance-update').click(function(e){
 	var fontSizeChange = false;
     var encodedAtChange = false;
     var playlistArtChange = false;
+	var thumbSizeChange = false;
 
 	// Set open/closed state for accordion headers
 	var temp = [0,0,0,0,0];
@@ -2442,7 +2443,7 @@ $('#btn-appearance-update').click(function(e){
     if (SESSION.json['library_covsearchpri'] != getParamOrValue('value', $('#cover-search-priority span').text())) {libraryOptionsChange = true;}
     if (SESSION.json['library_hiresthm'] != $('#hires-thumbnails span').text()) {libraryOptionsChange = true;}
     if (SESSION.json['library_thumbnail_columns'] != $('#thumbnail-columns span').text()) {
-		libraryOptionsChange = true;
+		thumbSizeChange = true;
 	}
 
     // CoverView
@@ -2538,6 +2539,9 @@ $('#btn-appearance-update').click(function(e){
 	if(playlistArtChange == true) {
 		renderPlaylist();
 	}
+	if(thumbSizeChange){
+		getThumbHW();
+	}
 
     // Update database
     $.post('command/moode.php?cmd=updcfgsystem',
@@ -2595,7 +2599,6 @@ $('#btn-appearance-update').click(function(e){
                 (SESSION.json['bgimage'] != '' && SESSION.json['cover_backdrop'] == 'No') || UI.bgImgChange == true) {
                 notify('settings_updated', 'Auto-refresh in 2 seconds');
 				// set library & radio thumb image size
-				getThumbHW();
                 setTimeout(function() {
                     location.reload(true);
                 }, 2000);

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -1350,7 +1350,7 @@ function renderRadioView() {
     var data = '';
     $.getJSON('command/moode.php?cmd=read_cfg_radio', function(data) {
         // Lazyload method
-        var radioViewLazy = GLOBAL.nativeLazyLoad ? '<img loading="lazy" height="' + UI.thumbHW + '" width="' + UI.thumbHW + '" src="' : '<img class="lazy-radioview" height="' + UI.thumbHW + '" width="' + UI.thumbHW + '" data-original="';
+        var radioViewLazy = GLOBAL.nativeLazyLoad ? '<img loading="lazy" src="' : '<img class="lazy-radioview" data-original="';
         // Sort/Group and Show/Hide options
         var sortTag = SESSION.json['radioview_sort_group'].split(',')[0].toLowerCase();
         var groupMethod = SESSION.json['radioview_sort_group'].split(',')[1];
@@ -3293,7 +3293,6 @@ $('#coverart-url, #playback-switch').click(function(e){
 		e.stopImmediatePropagation();
 		return;
 	}
-
     // TEST: Fixes issue where some elements briefly remain on-screen when switching between Playback and Library
     $('#coverart-link').hide();
 

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -583,11 +583,11 @@ var renderAlbums = function() {
 
     if (GLOBAL.nativeLazyLoad) {
     	var tagViewLazy = '<img loading="lazy" src="';
-        var albumViewLazy = '<img loading="lazy" height="' + UI.thumbHW + '" width="' + UI.thumbHW + '" src="' ;
+        var albumViewLazy = '<img loading="lazy" src="' ;
     }
     else {
     	var tagViewLazy = '<img class="lazy-tagview" data-original="';
-    	var albumViewLazy = '<img class="lazy-albumview" height="' + UI.thumbHW + '" width="' + UI.thumbHW + '" data-original="';
+    	var albumViewLazy = '<img class="lazy-albumview" data-original="';
     }
 
     // SESSION.json['library_encoded_at']

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -1324,6 +1324,16 @@ jQuery(document).ready(function($) { 'use strict';
         $.post('command/moode.php?cmd=disconnect-renderer', {'job':job});
 	});
 
+    // First use help
+    $('#playback-firstuse-help').click(function(e) {
+        $('#playback-firstuse-help').css('display', '');
+        $.post('command/moode.php?cmd=updcfgsystem', {'first_use_help': 'n,' + SESSION.json['first_use_help'].split(',')[1]});
+    });
+    $('#playbar-firstuse-help').click(function(e) {
+        $('#playbar-firstuse-help').css('display', '');
+        $.post('command/moode.php?cmd=updcfgsystem', {'first_use_help': SESSION.json['first_use_help'].split(',')[0] + ',n'});
+    });
+
     // CoverView screen saver reset
     $('#screen-saver, #playback-panel, #library-panel, #folder-panel, #radio-panel, #menu-bottom').click(function(e) {
         //console.log('resetscnsaver: timeout (' + SESSION.json['scnsaver_timeout'] + ', currentView: ' + currentView + ')');
@@ -1357,16 +1367,6 @@ jQuery(document).ready(function($) { 'use strict';
                 $.get('command/moode.php?cmd=resetscnsaver');
             }, 3000);
         }
-    });
-
-    // First use help
-    $('#playback-firstuse-help i').click(function(e) {
-        $('#playback-firstuse-help').css('display', 'none');
-        $.post('command/moode.php?cmd=updcfgsystem', {'first_use_help': 'n,' + SESSION.json['first_use_help'].split(',')[1]});
-    });
-    $('#playbar-firstuse-help i').click(function(e) {
-        $('#playbar-firstuse-help').css('display', 'none');
-        $.post('command/moode.php?cmd=updcfgsystem', {'first_use_help': SESSION.json['first_use_help'].split(',')[0] + ',n'});
     });
 
 	// Info button (i) show/hide toggle

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -113,7 +113,7 @@
 				<!-- Cover art and song metadata -->
 				<div id="playback-cover" class="span4">
 					<div class="covers">
-						<div id="playback-firstuse-help">Tap on the cover art to switch to the Library <i class="fal fa-times-circle"></i></div>
+						<div id="playback-firstuse-help"><div></div></div>
 						<div aria-label="Cover Art" id="coverart-url"></div>
 						<div id="timeline">
 							<div class="timeline-bg"></div>


### PR DESCRIPTION
This now uses css vars to set the h/w which saves list bloat. It also:

1) changes the first use help to overlay the entire element that needs to be clicked on aka fun with css content.

2) fixes the tag lib file cover art size (was compressed vertically a bit in landscape) and adjusts sizes & positioning.

3) adjusts the overlay button thing so it occupied the same exact position, removes the padding, etc.

4) fixed the mobile version of same so it scrolls like it should.

5) removed all of the weird font sizes for the tag view lib-file meta area, it just needed to be set to .9em for everything and that done once in the parent element.

5) change pl-thumb width to use em instead of rem (fixes stair step with weird screen sizes)

6) removed smaller width for mobile playlist :before because it'd cause wrapping for larger lists, maybe just for smaller mobile screens?