### PR TITLE
Allow non-square thumbs

### DIFF
--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -50,6 +50,7 @@ html, body {background-attachment:fixed;background-size:cover;height:100%;color:
 	--defcover:'images/default-cover-v6-l.svg';
 	--thumbcols:0px;
 	--thumbimagesize:0px;
+	--thumbmargin:0px;
 	--coverback:'';
 	--config_modal_btn_bg:rgba(64,64,64,0.08);
 	--npicon: url('../images/4band-npicon/audiow.svg');
@@ -209,15 +210,15 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #albumsList li {padding-top:.4em;padding-bottom:.4em;}
 #albumsList .tag-cover-text {display:inline-block;vertical-align:middle;transform:translate(0, .2em);min-width:50%;max-width:calc(100% - 3.6rem);/*line-height:1.6rem;*/}
 #library-panel .lib-entry span {max-width:100%;display:inline;}
-#library-panel.limited .lib-entry span {display:inline-block;}
+#content.limited .lib-entry span {display:inline-block;}
 #top-columns .lib-entry {font-size: 1em;}
 #top-columns .album-name-art, #top-columns .album-name {display:block !important;vertical-align:middle;min-width:25vw;}
 #top-columns .album-name-art {line-height:1.25em;}
 #albumsList .lib-entry span.artist-name {display:none}
 #albumsList .artist-name-art, #albumsList .album-year {vertical-align:top;line-height:normal;font-size:.85em;color:var(--textvariant);}
 #albumsList .album-year {margin-left:0;margin-left:.3em;}
-#library-panel.limited .artist-name-art, #library-panel.limited #albumcovers .artist-name {max-width:67%;}
-#library-panel.limited .lib-entry, #library-panel.limited .lib-entry span {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
+#content.limited .artist-name-art, #content.limited #albumcovers .artist-name {max-width:67%;}
+#content.limited .lib-entry, #content.limited .lib-entry span, #content.limited .station-name {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
 .database .active {font-size:inherit;font-weight:700;}
 .playlist .active .pll1, .cv-playlist .active .pll1 {color:var(--accentxts);font-weight:700;}
 .playlist li.active:before, .cv-playlist li.active:before {color:transparent !important;background:var(--npicon) no-repeat right;background-size:1em;}
@@ -229,7 +230,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .database .db-icon {display:block;float:left;height:19px;line-height:19px;width:1.875em;padding:0;color:inherit;}
 .database .db-icon .btn {font-size:1em;padding:1em .4em 1em .4em;}
 .database .db-icon .btn img {margin-top:-.5em;}
-.db-icon.db-song.db-browse.db-action img, .db-icon.db-radiofolder-icon.db-browse.db-action img {width:90%;}
+/*.db-icon.db-song.db-browse.db-action img, .db-icon.db-radiofolder-icon.db-browse.db-action img {width:90%;}*/
 .db-song.db-action a {width:100vw;height:2em;/*padding-top:.75em !important;*/}
 #lib-file .songtrack {left:0px;text-align:right;width:2em;float:left;display:table-cell;}
 #lib-file .songname {overflow:hidden;width:40%;height:auto;float:left;margin-left:1em;display:table-cell;}
@@ -397,7 +398,8 @@ img.lib-artistart {float:left;width:calc(20vw - 1rem);height: calc(20vw - 1rem);
 #lib-albumcover {height:100%;width:100%;position:absolute;box-sizing:border-box;left:0%;top:2.75em;top:calc(env(safe-area-inset-top) + 2.75em);overflow:auto;overflow-x:hidden;-webkit-overflow-scrolling:touch;}
 #albumcovers {text-align:center;margin:0;padding-bottom:12em;}
 #albumcovers .lib-entry, .database-radio .lib-entry {width:var(--thumbcols);text-align:center;display:inline-block;vertical-align:top;height:auto;font-size:.95em;padding:0 0 .4em 0;}
-#albumcovers .lib-entry img, .database-radio img {height:var(--thumbimagesize);width:var(--thumbimagesize);max-height:var(--thumbimagesize);margin:.75em 0 .5em 0;}
+#albumcovers .lib-entry img, .database-radio img {position:absolute;left:var(--thumbmargin);bottom:0;width:var(--thumbimagesize);max-height:var(--thumbimagesize);}
+#albumcovers .thumbHW, #radiocovers .thumbHW {height:var(--thumbimagesize);width:var(--thumbimagesize);position:relative;margin:.75em 0 .5em 0;}
 #albumcovers .album-name {display:block !important;}
 #albumcovers .artyear {color:var(--textvariant);font-weight:500;}
 #albumcovers .artist-name, #albumcovers .album-year {margin:0 .15em;}

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -560,11 +560,10 @@ function disableVolKnob() {
     $('#volumeup, #volumedn, #volumedn-2, #volumeup-2, .volume-display').css('opacity', '.3');
 	$('.volume-display div, #inpsrc-preamp-volume, #playbar-volume-level').text('0dB');
 	$('.volume-display').css('cursor', 'unset');
-
+    $('.volume-popup-btn').hide();
 	if (UI.mobile) {
 		$('#mvol-progress').css('width', '100%');
 		$('.repeat').show();
-        $('.volume-popup-btn').hide();
 	}
 }
 
@@ -1350,7 +1349,7 @@ function renderRadioView() {
     var data = '';
     $.getJSON('command/moode.php?cmd=read_cfg_radio', function(data) {
         // Lazyload method
-        var radioViewLazy = GLOBAL.nativeLazyLoad ? '<img loading="lazy" src="' : '<img class="lazy-radioview" data-original="';
+        var radioViewLazy = GLOBAL.nativeLazyLoad ? '<div class="thumbHW"><img loading="lazy" src="' : '<div class="thumbHW"><img class="lazy-radioview" data-original="';
         // Sort/Group and Show/Hide options
         var sortTag = SESSION.json['radioview_sort_group'].split(',')[0].toLowerCase();
         var groupMethod = SESSION.json['radioview_sort_group'].split(',')[1];
@@ -1629,10 +1628,10 @@ function renderRadioView() {
             // Construct station entries
             var imgUrl = data[i].logo == 'local' ? 'imagesw/radio-logos/thumbs/' + data[i].name + '.jpg' : data[i].logo;
     		output += '<li id="ra-' + (i + 1) + '" data-path="' + 'RADIO/' + data[i].name + '.pls';
-    		output += '"><div class="db-icon db-song db-browse db-action">' + radioViewLazy + imgUrl  + '"><div class="cover-menu" data-toggle="context" data-target="#context-menu-radio-item"></div></div><div class="db-entry db-song db-browse"></div>';
+    		output += '"><div class="db-icon db-song db-browse db-action">' + radioViewLazy + imgUrl  + '"></div><div class="cover-menu" data-toggle="context" data-target="#context-menu-radio-item"></div></div><div class="db-entry db-song db-browse"></div>';
             output += radioViewHdDiv;
 			output += radioViewBgDiv;
-            output += '<span class="station-name">' + data[i].name + '</span>';
+            output += '<div class="station-name">' + data[i].name + '</div>';
             output += subGenreDiv;
             output += countryDiv;
             output += bitrateDiv;
@@ -2437,7 +2436,7 @@ $('#btn-appearance-update').click(function(e){
 	}
     if (SESSION.json['library_tagview_covers'] != $('#show-tagview-covers span').text()) {libraryOptionsChange = true;}
     if (SESSION.json['library_ellipsis_limited_text'] != $('#ellipsis-limited-text span').text()) {
-		$('#ellipsis-limited-text span').text() == "Yes" ? $('#library-panel').addClass('limited') : $('#library-panel').removeClass('limited');
+		$('#ellipsis-limited-text span').text() == "Yes" ? $('#content').addClass('limited') : $('#content').removeClass('limited');
 	}
     // Covers and Thumbnails
     if (SESSION.json['library_covsearchpri'] != getParamOrValue('value', $('#cover-search-priority span').text())) {libraryOptionsChange = true;}
@@ -3662,6 +3661,7 @@ function getThumbHW() {
 	var columnW = parseInt(($(window).width() - (2 * GLOBAL.sbw) - divM) / cols);
 	UI.thumbHW = columnW - (divM / 2);
 	$("body").get(0).style.setProperty("--thumbimagesize", UI.thumbHW + 'px');
+	$("body").get(0).style.setProperty("--thumbmargin", ((columnW - UI.thumbHW) / 2) + 'px');
 	$("body").get(0).style.setProperty("--thumbcols", columnW + 'px');
 }
 

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -582,11 +582,11 @@ var renderAlbums = function() {
 
     if (GLOBAL.nativeLazyLoad) {
     	var tagViewLazy = '<img loading="lazy" src="';
-        var albumViewLazy = '<img loading="lazy" src="' ;
+        var albumViewLazy = '<div class="thumbHW"><img loading="lazy" src="' ;
     }
     else {
     	var tagViewLazy = '<img class="lazy-tagview" data-original="';
-    	var albumViewLazy = '<img class="lazy-albumview" data-original="';
+    	var albumViewLazy = '<div class="thumbHW"><img class="lazy-albumview" data-original="';
     }
 
     // SESSION.json['library_encoded_at']
@@ -634,7 +634,7 @@ var renderAlbums = function() {
         }
 
 		output2 += '<li class="lib-entry">'
-            + albumViewLazy + filteredAlbumCovers[i].imgurl + '">'
+            + albumViewLazy + filteredAlbumCovers[i].imgurl + '"></div>'
             + '<div class="cover-menu" data-toggle="context" data-target="#context-menu-lib-album"></div>'
 			+ albumViewHdDiv
 			+ albumViewBgDiv
@@ -658,7 +658,7 @@ var renderAlbums = function() {
 
     // Set ellipsis text
 	if (SESSION.json["library_ellipsis_limited_text"] == "Yes") {
-		$('#library-panel').addClass('limited');
+		$('#content').addClass('limited');
 	}
 
 	// Headers clicked

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -37,6 +37,17 @@ jQuery(document).ready(function($) { 'use strict';
         }
     }
 
+	// resize thumbs on window resize
+	$(window).bind('resize', function(e){
+	    window.resizeEvt;
+	    $(window).resize(function(){
+	        clearTimeout(window.resizeEvt);
+	        window.resizeEvt = setTimeout(function(){
+				getThumbHW();
+	        }, 750);
+	    });
+	});
+
 	// Compensate for Android popup kbd changing the viewport, also for notch phones
 	$("meta[name=viewport]").attr("content", "height=" + $(window).height() + ", width=" + $(window).width() + ", initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover");
 	// Store device pixel ratio


### PR DESCRIPTION
This uses a div to contain the thumbnail image which lets us apply the h/w to that. Images with less height are aligned to the bottom, images with more height are truncated to square.

Also:

1) Switches the limited class from #library-panel to #content so that we can apply ellipsis limited text to the radio view.

2) Removes some leftover width:90% css for radio thumbs.

3) First stab at a window resize event handler to adjust thumbnail image size on the fly.

4) Remove volume popup button on landscape playbar if volume is disabled.

![moode_(iPad Pro 11) (1)](https://user-images.githubusercontent.com/303924/94221229-843bfb00-fe9f-11ea-956b-83c4039318b0.png)
