### PR TITLE
WIP for addressing library lazy load issues

### DIFF
--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -210,7 +210,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #albumsList li {padding-top:.4em;padding-bottom:.4em;}
 #albumsList .tag-cover-text {display:inline-block;vertical-align:middle;transform:translate(0, .2em);min-width:50%;max-width:calc(100% - 3.6rem);/*line-height:1.6rem;*/}
 #library-panel .lib-entry span {max-width:100%;display:inline;}
-#library-panel.limited .lib-entry span {display:inline-block;}
+#library-panel.limited .album-name, #library-panel.limited .artist-name, #library-panel.limited .album-year {display:inline-block;}
 #top-columns .lib-entry {font-size: 1em;}
 #top-columns .album-name-art, #top-columns .album-name {display:block !important;vertical-align:middle;min-width:25vw;}
 #top-columns .album-name-art {line-height:1.25em;}
@@ -218,13 +218,13 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #albumsList .artist-name-art, #albumsList .album-year {vertical-align:top;line-height:normal;font-size:.85em;color:var(--textvariant);}
 #albumsList .album-year {margin-left:0;margin-left:.3em;}
 #library-panel.limited .artist-name-art, #library-panel.limited #albumcovers .artist-name {max-width:67%;}
-#library-panel.limited .lib-entry span, #radio-panel.limited .station-name {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
+#library-panel.limited .album-name, #library-panel.limited .artist-name, #library-panel.limited .album-year, #radio-panel.limited .station-name {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
 .database .active {font-size:inherit;font-weight:700;}
 .playlist .active .pll1, .cv-playlist .active .pll1 {color:var(--accentxts);font-weight:700;}
 .playlist li.active:before, .cv-playlist li.active:before {color:transparent !important;background:var(--npicon) no-repeat right;background-size:1em;}
 .playlist .pll1, .cv-playlist .pll1 {font-weight:400;opacity:1;text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
 .playlist .pl-entry, .cv-playlist .pl-entry {padding:0px;}
-.playlist .pl-thumb, .cv-playlist .pl-thumb {float: left; width: 2.4em; margin-left: 1.2vmin; margin-right: 1.2vmin;border-radius:.2em;filter:brightness(80%);overflow:hidden;}
+.playlist .pl-thumb, .cv-playlist .pl-thumb {float: left; width: 2.4em; margin-left: 1.2vmin !important; margin-right: 1.2vmin;border-radius:.2em;filter:brightness(80%);overflow:hidden;}
 .database .db-entry {margin-left:2.5em;padding:1em 0;max-width:calc(100vw - 10px);overflow:hidden;}
 .database .db-song {padding:.5em 0;}
 .database .db-icon {display:block;float:left;height:19px;line-height:19px;width:1.875em;padding:0;color:inherit;}
@@ -254,6 +254,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .btnlist:focus {outline:none;}
 .btnlist.pl-prevPage, .btnlist.db-prevPage, .btnlist.pl-firstPage, .btnlist.db-firstPage {padding:0 .3em;}
 .btnlist-top-db, .btnlist-top-ra {position:relative;background-color:rgba(128,128,128,.1);;color:var(--adapttext);border-radius:.25em;border:1px solid var(--btnshade);width:calc(100vw - 2.5em);height:2.1rem;padding:0 !important;margin:0 auto;}
+#searchResetRa {display:none;}
 #pl-filter, #lib-album-filter, #ra-filter {padding:0}
 #db-browse .dropdown {display:block;height:40px;line-height:40px;margin:0 20px 0 0;}
 #db-browse .dropdown-menu {background:transparent;border:none;border-radius:0px;box-shadow:none;list-style:none outside none;margin:0;/*min-width:100px;*/padding:0;border-top:1px solid #000;border-left:1px solid #000;border-right:1px solid #000;position:absolute;top:100%;z-index:1000;}
@@ -398,9 +399,9 @@ img.lib-artistart {float:left;width:calc(20vw - 1rem);height: calc(20vw - 1rem);
 #lib-albumcover {height:100%;width:100%;position:absolute;box-sizing:border-box;left:0%;top:2.75em;top:calc(env(safe-area-inset-top) + 2.75em);overflow:auto;overflow-x:hidden;-webkit-overflow-scrolling:touch;}
 #albumcovers {text-align:center;margin:0;padding-bottom:12em;}
 #albumcovers .lib-entry, .database-radio .lib-entry {width:var(--thumbcols);text-align:center;display:inline-block;vertical-align:top;height:auto;font-size:.95em;padding:0 0 .4em 0;}
-#albumcovers .lib-entry img, .database-radio img {position:absolute;left:var(--thumbmargin);bottom:0;width:var(--thumbimagesize);max-height:var(--thumbimagesize);}
+#albumcovers .lib-entry img, .database-radio img {position:absolute;left:var(--thumbmargin);bottom:0;object-fit:contain;width:var(--thumbimagesize);max-height:var(--thumbimagesize);}
 #albumcovers .thumbHW, #radiocovers .thumbHW {height:var(--thumbimagesize);width:var(--thumbimagesize);position:relative;margin:.75em 0 .5em 0;}
-#albumcovers .album-name {display:block !important;}
+/*#albumcovers .album-name {display:block !important;}*/
 #albumcovers .artyear {color:var(--textvariant);font-weight:500;}
 #albumcovers .artist-name, #albumcovers .album-year {margin:0 .15em;}
 /* index improvements */

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -218,7 +218,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #albumsList .artist-name-art, #albumsList .album-year {vertical-align:top;line-height:normal;font-size:.85em;color:var(--textvariant);}
 #albumsList .album-year {margin-left:0;margin-left:.3em;}
 #library-panel.limited .artist-name-art, #library-panel.limited #albumcovers .artist-name {max-width:67%;}
-#library-panel.limited .lib-entry, #radio-panel.limited .station-name {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
+#library-panel.limited .lib-entry span, #library-panel.limited .album-name, #library-panel.limited .artist-name, #library-panel.limited .album-year, #radio-panel.limited .station-name {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
 .database .active {font-size:inherit;font-weight:700;}
 .playlist .active .pll1, .cv-playlist .active .pll1 {color:var(--accentxts);font-weight:700;}
 .playlist li.active:before, .cv-playlist li.active:before {color:transparent !important;background:var(--npicon) no-repeat right;background-size:1em;}
@@ -370,7 +370,7 @@ img.lib-artistart {float:left;width:calc(20vw - 1rem);height: calc(20vw - 1rem);
 #lib-content li {display:block;position:relative;cursor:pointer;line-height:1.25em;}
 #songsList {padding-bottom:calc(10em + env(safe-area-inset-bottom));margin:.5em .25em;width:calc(100% - var(--sbw));}
 /**/
-#lib-genre li, #lib-artist li/*, #lib-album li*/ {padding: 0.4em 0.5em;/*line-height:2em; /*margin-top:7px;*/}
+#lib-genre li, #lib-artist li/*, #lib-album li*/ {padding: 0.4em 0.5em;text-overflow:ellipsis;overflow:hidden;white-space:nowrap;/*line-height:2em; /*margin-top:7px;*/}
 #lib-content #lib-file li {cursor:default;padding:.15em 0 .5em 0;}
 #lib-content #lib-file li:nth-child(odd) {background:rgba(128,128,128,0.1);}
 #lib-content #lib-file li:nth-child(odd).active {font-weight:600;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -218,13 +218,13 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #albumsList .artist-name-art, #albumsList .album-year {vertical-align:top;line-height:normal;font-size:.85em;color:var(--textvariant);}
 #albumsList .album-year {margin-left:0;margin-left:.3em;}
 #library-panel.limited .artist-name-art, #library-panel.limited #albumcovers .artist-name {max-width:67%;}
-#library-panel.limited .album-name, #library-panel.limited .artist-name, #library-panel.limited .album-year, #radio-panel.limited .station-name {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
+#library-panel.limited .lib-entry, #radio-panel.limited .station-name {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
 .database .active {font-size:inherit;font-weight:700;}
 .playlist .active .pll1, .cv-playlist .active .pll1 {color:var(--accentxts);font-weight:700;}
 .playlist li.active:before, .cv-playlist li.active:before {color:transparent !important;background:var(--npicon) no-repeat right;background-size:1em;}
 .playlist .pll1, .cv-playlist .pll1 {font-weight:400;opacity:1;text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
 .playlist .pl-entry, .cv-playlist .pl-entry {padding:0px;}
-.playlist .pl-thumb, .cv-playlist .pl-thumb {float: left; width: 2.4em; margin-left: 1.2vmin !important; margin-right: 1.2vmin;border-radius:.2em;filter:brightness(80%);overflow:hidden;}
+.playlist .pl-thumb, .cv-playlist .pl-thumb {float: left; width: 2.4em; margin-left: 1.2vmin!important; margin-right: 1.2vmin;border-radius:.2em;filter:brightness(80%);overflow:hidden;}
 .database .db-entry {margin-left:2.5em;padding:1em 0;max-width:calc(100vw - 10px);overflow:hidden;}
 .database .db-song {padding:.5em 0;}
 .database .db-icon {display:block;float:left;height:19px;line-height:19px;width:1.875em;padding:0;color:inherit;}

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -1649,6 +1649,9 @@ function renderRadioView() {
         // Render the list
     	//$('ul.database-radio').html(output);
 		currentView == 'radio' ? $('#radiocovers').html(output, lazyLode('radio')) : $('#radiocovers').html(output);
+		//var element = document.getElementById('radiocovers');
+		//$.when(element.innerHTML = output).promise().done(function(){lazyLode('radio')});
+
     });
 }
 
@@ -1686,12 +1689,12 @@ function refreshTimer(startFrom, stopTo, state) {
 		}
     }
 	else if (state == 'stop') {
-		if (SESSION.json['timecountup'] == "1" || parseInt(MPD.json['time']) == 0) {
+		/*if (SESSION.json['timecountup'] == "1" || parseInt(MPD.json['time']) == 0) {
 			$('#countdown-display').countdown({since: 0, compact: true, format: 'hMS', layout: '{h<}{hn}{sep}{h>}{mnn}{sep}{snn}'});
     	}
 		else {
 			$('#countdown-display').countdown({until: 0, compact: true, format: 'hMS', layout: '{h<}{hn}{sep}{h>}{mnn}{sep}{snn}'});
-	    }
+	    }*/
 
 		$('#countdown-display').countdown('pause');
     }
@@ -1752,6 +1755,8 @@ function refreshTimeKnob() {
 		var tt = $('#timetrack');
 		var ti = $('#time');
         UI.knob = setInterval(function() {
+            delta === 0 ? GLOBAL.initTime = GLOBAL.initTime + 0.5 : GLOBAL.initTime = GLOBAL.initTime + 0.1; // fast paint when radio station playing
+			
 			if (UI.mobile || coverView || currentView.indexOf('playback' == -1)) {
 				if (!timeSliderMove) {
 					syncTimers();
@@ -1760,7 +1765,6 @@ function refreshTimeKnob() {
 					}					
 				}
 			}
-            delta === 0 ? GLOBAL.initTime = GLOBAL.initTime + 0.5 : GLOBAL.initTime = GLOBAL.initTime + 0.1; // fast paint when radio station playing
 			if (!UI.mobile) {
 	            if (delta === 0 && GLOBAL.initTime > 100) { // stops painting when radio (delta = 0) and knob fully painted
 					window.clearInterval(UI.knob)

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -1088,8 +1088,8 @@ function renderPlaylist() {
 
 		// Render playlist
 		
-		SESSION.json['playlist_art'] ? $.when($('#playlist ul').html(output)).then(lazyLode('playlist')) : $('#playlist ul').html(output);
-       // $('#playlist ul').html(output);
+		SESSION.json['playlist_art'] ? $('#playlist ul').html(output, lazyLode('playlist')) : $('#playlist ul').html(output);
+        //$('#playlist ul').html(output);
         //$('#cv-playlist ul').html(output);
 
         if (output) {
@@ -1648,7 +1648,7 @@ function renderRadioView() {
 
         // Render the list
     	//$('ul.database-radio').html(output);
-		$.when($('#radiocovers').html(output)).then(lazyLode('radio'))
+		currentView == 'radio' ? $('#radiocovers').html(output, lazyLode('radio')) : $('#radiocovers').html(output);
     });
 }
 
@@ -3537,6 +3537,7 @@ function setLibMenuHeader () {
 }
 
 function lazyLode(view) {
+	console.log(view);
     // If browser does not support native lazy load then fall back to JQuery lazy load
     if (!GLOBAL.nativeLazyLoad) {
  		var container, selector;
@@ -3567,10 +3568,12 @@ function lazyLode(view) {
  		}
 
         if (selector && container) {
-			$(selector).lazyload({
-				container: $(container)
-			});
-        }
+			setTimeout(function(){
+				$(selector).lazyload({
+					container: $(container)
+				});				
+			}, DEFAULT_TIMEOUT);
+		}
  	}
 }
 

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -646,10 +646,10 @@ var renderAlbums = function() {
 	}
 
     // Output the lists
-	SESSION.json['library_tagview_covers'] ? $.when($('#albumsList').html(output)).then(lazyLode('tag')) : $('#albumsList').html(output);
-	$.when($('#albumcovers').html(output2)).then(lazyLode('album'));
-	//$('#albumsList').html(output);
-	//$('#albumcovers').html(output2);
+	//SESSION.json['library_tagview_covers'] == 'Yes' ? $.when($('#albumsList').html(output)).then(lazyLode('tag')) : $('#albumsList').html(output);
+	//$.when($('#albumcovers').html(output2)).then(lazyLode('album'));
+	$('#albumsList').html(output);
+	$('#albumcovers').html(output2);
 
 	// If only 1 album automatically highlight and display tracks
 	if (filteredAlbums.length == 1) {

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -543,7 +543,10 @@ var renderGenres = function() {
 			+ '">' + allGenres[i] + '</li>';
 	}
 
-	$('#genresList').html(output);
+	var element = document.getElementById('genresList');
+	element.innerHTML = output;
+
+	//$('#genresList').html(output);
 	if (UI.libPos[0] == -2) {
 		$('#lib-genre').scrollTo(0, 200);
 	}
@@ -561,7 +564,10 @@ var renderArtists = function() {
 			+ '">' + filteredArtists[i] + '</li>';
 	}
 
-	$('#artistsList').html(output);
+	var element = document.getElementById('artistsList');
+	element.innerHTML = output;
+
+	//$('#artistsList').html(output);
 
 	if (UI.libPos[0] == -2) {
 		$('#lib-artist').scrollTo(0, 200);
@@ -648,8 +654,12 @@ var renderAlbums = function() {
     // Output the lists
 	//SESSION.json['library_tagview_covers'] == 'Yes' ? $.when($('#albumsList').html(output)).then(lazyLode('tag')) : $('#albumsList').html(output);
 	//$.when($('#albumcovers').html(output2)).then(lazyLode('album'));
-	$('#albumsList').html(output);
-	$('#albumcovers').html(output2);
+	var element = document.getElementById('albumsList');
+	element.innerHTML = output;
+	var element = document.getElementById('albumcovers');
+	element.innerHTML = output2;
+	//$('#albumsList').html(output);
+	//$('#albumcovers').html(output2);
 
 	// If only 1 album automatically highlight and display tracks
 	if (filteredAlbums.length == 1) {
@@ -786,7 +796,11 @@ var renderSongs = function(albumPos) {
 		}
 	}
 
-	$('#songsList').html(output);
+
+	var element = document.getElementById('songsList');
+	element.innerHTML = output;
+
+	//$('#songsList').html(output);
 
     // Display album name heading:
     // - if more than 1 album for clicked artist

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -646,8 +646,10 @@ var renderAlbums = function() {
 	}
 
     // Output the lists
-	$('#albumsList').html(output);
-	$('#albumcovers').html(output2);
+	SESSION.json['library_tagview_covers'] ? $.when($('#albumsList').html(output)).then(lazyLode('tag')) : $('#albumsList').html(output);
+	$.when($('#albumcovers').html(output2)).then(lazyLode('album'));
+	//$('#albumsList').html(output);
+	//$('#albumcovers').html(output2);
 
 	// If only 1 album automatically highlight and display tracks
 	if (filteredAlbums.length == 1) {

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -138,12 +138,7 @@ jQuery(document).ready(function($) { 'use strict';
 
     	// only display transparency related theme options if alphablend is < 1
     	$('#alpha-blend').on('DOMSubtreeModified',function(){
-    		if ($('#alpha-blend span').text() < 1) {
-    			$('#cover-options').show();
-    		}
-            else {
-    			$('#cover-options').css('display', '');
-    		}
+    		$('#alpha-blend span').text() < 1 ? $('#cover-options').show() : $('#cover-options').css('display', '');
     	});
 
     	/*themeMback = 'rgba(' + THEME.json[SESSION.json['themename']]['bg_color'] + ',' + themeOp +')';

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -890,12 +890,12 @@ jQuery(document).ready(function($) { 'use strict';
     // Refresh the station list
 	$('#ra-refresh').click(function(e) {
 		mpdDbCmd('lsinfo_radio');
-        setTimeout(function() {
-            lazyLode('radio');
-        }, DEFAULT_TIMEOUT);
-        setTimeout(function() {
+        //setTimeout(function() {
+            //lazyLode('radio');
+			//}, DEFAULT_TIMEOUT);
+        //setTimeout(function() {
             $('#database-radio').scrollTo(0, 200);
-        }, DEFAULT_TIMEOUT);
+			//}, DEFAULT_TIMEOUT);
 
 		UI.radioPos = -1;
 		storeRadioPos(UI.radioPos)

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -281,6 +281,9 @@ jQuery(document).ready(function($) { 'use strict';
     	if (currentView.indexOf('playback') != -1) {
     		$('#playback-panel').addClass('active');
     		$(window).scrollTop(0); // make sure it's scrolled to top
+			/*setTimeout(function(){
+				lazyLode('playlist');
+			}, 500);*/
     		if (UI.mobile) {
     			$('#container-playlist').css('visibility','hidden');
     			$('#playback-controls').show();
@@ -301,12 +304,11 @@ jQuery(document).ready(function($) { 'use strict';
         // Radio view
     	if (currentView == 'radio') {
     		makeActive('.radio-view-btn','#radio-panel', currentView);
-
     		setTimeout(function() {
     			if (UI.radioPos >= 0) {
-    				customScroll('radio', UI.radioPos, 200);
+    				customScroll('radio', UI.radioPos, 0);
     			}
-    		}, DEFAULT_TIMEOUT);
+    		}, 250);
     	}
         // Folder view
     	else if (currentView == 'folder') {


### PR DESCRIPTION
The lazyload library was never designed to deal with dynamically added content so we used settimeout statements to pause for the lists to populate. This doesn't always happen in time which results in no thumbs.

This implements .when().then() to the list output routines with the then() being a call to lazyLode(). This lets the list finish populating before lazyload() is ever called. All other subsequent calls to .lazyload() shouldn't need to be placed in a settimeout statement.

This also:

#1 limits the scope of the .limited class some more

#2 fixes a playlist thumb margin issue

#3 hides the e.g. radio search reset by default so it doesn't flash on/off on page reload

#4 adds object-fit as discussed on the forum

#5 adds lazylode calls to the thumb column setting as when it increases more thumbs are exposed, etc.

#6 reverts the conditional in the setinterval to use coverview & currentView

#7 fixes radio search (span div swap)