### PR TITLE
Replace jquery ready eventhandler

### DIFF
--- a/www/footer.php
+++ b/www/footer.php
@@ -177,6 +177,86 @@
 <script src="js/jquery-ui-1.10.0.custom.min.js"></script>
 <!--endRemoveIf(USEBUNDLE)-->
 
+<script>
+	// Because with bundles jquery is loaded defered, the jQuery(document).ready(function() isn't availabe for the ui_notify construction.
+	// Solution is replace is by an other portable document ready event handler.
+
+	//Copied from https://stackoverflow.com/questions/9899372/pure-javascript-equivalent-of-jquerys-ready-how-to-call-a-function-when-t
+
+	(function(funcName, baseObj) {
+    // The public function name defaults to window.docReady
+    // but you can pass in your own object and own function name and those will be used
+    // if you want to put them in a different namespace
+    funcName = funcName || "docReady";
+    baseObj = baseObj || window;
+    var readyList = [];
+    var readyFired = false;
+    var readyEventHandlersInstalled = false;
+
+    // call this when the document is ready
+    // this function protects itself against being called more than once
+    function ready() {
+        if (!readyFired) {
+            // this must be set to true before we start calling callbacks
+            readyFired = true;
+            for (var i = 0; i < readyList.length; i++) {
+                // if a callback here happens to add new ready handlers,
+                // the docReady() function will see that it already fired
+                // and will schedule the callback to run right after
+                // this event loop finishes so all handlers will still execute
+                // in order and no new ones will be added to the readyList
+                // while we are processing the list
+                readyList[i].fn.call(window, readyList[i].ctx);
+            }
+            // allow any closures held by these functions to free
+            readyList = [];
+        }
+    }
+
+    function readyStateChange() {
+        if ( document.readyState === "complete" ) {
+            ready();
+        }
+    }
+
+    // This is the one public interface
+    // docReady(fn, context);
+    // the context argument is optional - if present, it will be passed
+    // as an argument to the callback
+    baseObj[funcName] = function(callback, context) {
+        if (typeof callback !== "function") {
+            throw new TypeError("callback for docReady(fn) must be a function");
+        }
+        // if ready has already fired, then just schedule the callback
+        // to fire asynchronously, but right away
+        if (readyFired) {
+            setTimeout(function() {callback(context);}, 1);
+            return;
+        } else {
+            // add the function and context to the list
+            readyList.push({fn: callback, ctx: context});
+        }
+        // if document already ready to go, schedule the ready function to run
+        if (document.readyState === "complete") {
+            setTimeout(ready, 1);
+        } else if (!readyEventHandlersInstalled) {
+            // otherwise if we don't have event handlers installed, install them
+            if (document.addEventListener) {
+                // first choice is DOMContentLoaded event
+                document.addEventListener("DOMContentLoaded", ready, false);
+                // backup is window load event
+                window.addEventListener("load", ready, false);
+            } else {
+                // must be IE
+                document.attachEvent("onreadystatechange", readyStateChange);
+                window.attachEvent("onload", ready);
+            }
+            readyEventHandlersInstalled = true;
+        }
+    }
+})("docReady", window);
+
+</script>
 <?php
     if (isset($_SESSION['notify']['title']) && $_SESSION['notify']['title'] != '') {
         ui_notify($_SESSION['notify']);

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -1851,7 +1851,7 @@ function sourceMount($action, $id = '') {
 
 function ui_notify($notify) {
 	$script .= "<script>";
-	$script .= "jQuery(document).ready(function() {";
+	$script .= "docReady(function() {"; // this function is created in the footer.php script at the bottom
 	$script .= "$.pnotify.defaults.history = false;";
 	$script .= "$.pnotify({";
 	$script .= "title: '" . $notify['title'] . "',";


### PR DESCRIPTION
The current `www/footer.php` use at the bottom a two stage rocket:

- First; synchronous jquery files are loaded (very unexpected place to find the load of scripts by the way) .
- Second; an event handler on on document ready is registered with a `jQuery(document).ready` to create a pnotifier (this code is generated by a php method `ui_notify`)

When using gulp for bundling the jquery source all resources are marked with `defer` for loading, which breaks the functionality above. 
I replaced the code `jQuery(document).ready` by a generic multi plaform function `docReady`. Because the php function `ui_notify` make use of it I had to change it also.
