### PR TITLE
Replace jquery ready eventhandler (Variant 2)

### DIFF
--- a/www/footer.php
+++ b/www/footer.php
@@ -171,20 +171,7 @@
 	<span class="reconnect-msg">System shut down</span>
 </div>
 
-<!-- DISPLAY MESSAGES -->
-<!--removeIf(USEBUNDLE)-->
-<script src="js/jquery-1.8.2.min.js"></script>
-<script src="js/jquery-ui-1.10.0.custom.min.js"></script>
-<!--endRemoveIf(USEBUNDLE)-->
-
 <?php
-    if (isset($_SESSION['notify']['title']) && $_SESSION['notify']['title'] != '') {
-        ui_notify($_SESSION['notify']);
-        $_SESSION['notify']['title'] = '';
-        $_SESSION['notify']['msg'] = '';
-        $_SESSION['notify']['duration'] = '3';
-    }
-
     //workerLog('-- footer.php');
     $return = session_write_close();
 	//workerLog('session_write_close=' . (($return) ? 'TRUE' : 'FALSE'));

--- a/www/header.php
+++ b/www/header.php
@@ -53,6 +53,12 @@
 
     <!-- Common JS -->
 	<!-- build:js js/lib.min.js defer -->
+
+	<!--removeIf(USEBUNDLE)-->
+	<script src="js/jquery-1.8.2.min.js" />
+	<script src="js/jquery-ui-1.10.0.custom.min.js" defer></script>
+	<!--endRemoveIf(USEBUNDLE)-->
+
 	<!-- BUNDLE_TAG
 	<script src="js/jquery-1.8.2.js" />
 	<script src="js/jquery-ui/jquery-ui.js" ></script>
@@ -112,7 +118,15 @@
 		<!--endRemoveIf(NOCONFIGSECTION)-->
 
 	<!--removeIf(GENINDEXDEV)-->
-    <?php } ?>
+	<?php }
+	    // INSTALL DISPLAY MESSAGES FUNCTION, IS ACTUALY CALLED AFTER onready by applicatio.js  |scripts-panels.js
+		if (isset($_SESSION['notify']['title']) && $_SESSION['notify']['title'] != '') {
+			ui_notify($_SESSION['notify']);
+			$_SESSION['notify']['title'] = '';
+			$_SESSION['notify']['msg'] = '';
+			$_SESSION['notify']['duration'] = '3';
+		}
+	?>
 	<!--endRemoveIf(GENINDEXDEV)-->
 
 	<!-- MOBILE APP ICONS -->

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -1850,9 +1850,9 @@ function sourceMount($action, $id = '') {
 }
 
 function ui_notify($notify) {
-	$script .= "<script>";
-	$script .= "jQuery(document).ready(function() {";
-	$script .= "$.pnotify.defaults.history = false;";
+	$script .= "<script>\n";
+	$script .= "function ui_notify() {\n";
+	$script .= "$.pnotify.defaults.history = false;\n";
 	$script .= "$.pnotify({";
 	$script .= "title: '" . $notify['title'] . "',";
 	$script .= "text: '" . $notify['msg'] . "',";
@@ -1864,9 +1864,9 @@ function ui_notify($notify) {
 	else {
 		$script .= "delay: '3000',";
 	}
-	$script .= "opacity: 1.0});";
-	$script .= "});";
-	$script .= "</script>";
+	$script .= "opacity: 1.0});\n";
+	$script .= "}\n";
+	$script .= "</script>\n";
 
 	echo $script;
 }

--- a/www/js/application.js
+++ b/www/js/application.js
@@ -31,6 +31,11 @@ $(function () {
 });
 
 $(document).ready(function() {
+    // call $.pnotify is created by backend
+    if( window.ui_notify != undefined ) {
+        ui_notify();
+    }
+
     // Todo list
     $(".todo li").click(function() {
         $(this).toggleClass("todo-done");

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -22,6 +22,11 @@
  *
  */
 jQuery(document).ready(function($) { 'use strict';
+    // call $.pnotify if created by backend
+    if( window.ui_notify != undefined ) {
+        ui_notify();
+	}
+
     GLOBAL.scriptSection = 'panels';
 	$('#config-back').hide();
 	$('#config-tabs').css('display', 'none');


### PR DESCRIPTION
The current www/footer.php use at the bottom a two stage rocket:

- First; synchronous jquery files are loaded (very unexpected place to find the load of scripts by the way) .
- Second; an event handler on on document ready is registered with a jQuery(document).ready to create a pnotifier (this code is generated by a php method ui_notify)
When using gulp for bundling the jquery source all resources are marked with defer for loading, which breaks the functionality above.

New implementation
- Instead of registering on document ready handler, just make it function.
- Call the function from application.js and script-panels.js. Central control of what the app does and when.
- Move the include of the jquery files at the bottom to the header.php. Central place where it is clear which resource are used.

After that it makes a little bit more sense and less tricks are needed.
