### PR TITLE
Fix lazyload image loading

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -251,7 +251,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	.playlist span {margin-left:calc(3.8rem + 1vmin) !important;}
 	.playlist {padding:0 0 9rem 0;min-height:33vh;}
 	/*.playlist li:before {width:1.75em!important;}*/
-	.playlist .pl-action, .playlist .db-action a {padding:.4em 1.25em 1em 0;}
+	.playlist .pl-action, .playlist .db-action a {padding:.4em 1.25em 1em 0;margin-left:1.25em!important;}
 	.ui-pnotify {top:40% !important;}
 	#lib-albumcover {left:0;}
 	/* ellipsis madness */
@@ -277,7 +277,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	/* playbar */
 	#playbar-div {display:block;}
 	#playbar-mtime {display:flex;position:relative;}
-	#playbar-title {text-align:left;top:0;margin-left:1.25rem;width:53vw;height:auto;position:relative;transform:none;font-size:1.3em;line-height:2.2em;left:0;padding:0;text-shadow:0 0 1px var(--btnbarback);}
+	#playbar-title {text-align:left;top:0;margin-left:1em;width:53vw;height:auto;position:relative;transform:none;font-size:1.4em;line-height:2.2em;left:0;padding:0;text-shadow:0 0 1px var(--btnbarback);}
 	#playbar-controls {right:.25rem;transform:none;top:0;left:unset;opacity:1;}
 	#playbar-time, #playbar-total {line-height:1.5rem;}
 	#playbar-controls .btn {padding:.5em;font-size:2.5rem;-webkit-tap-highlight-color:transparent;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -405,6 +405,7 @@ img.lib-artistart {float:left;width:calc(20vw - 1rem);height: calc(20vw - 1rem);
 /*#albumcovers .album-name {display:block !important;}*/
 #albumcovers .artyear {color:var(--textvariant);font-weight:500;}
 #albumcovers .artist-name, #albumcovers .album-year {margin:0 .15em;}
+#albumcovers .album-name {font-weight:600;}
 /* index improvements */
 /*#radiocovers, #albumcovers {width:calc(100% - var(--sbw) - 2.34rem);margin-left:calc(var(--sbw) + 1.17rem);}*/
 #radiocovers, #albumcovers {width:100%;margin-left:0;}

--- a/www/js/jquery.lazyload.js
+++ b/www/js/jquery.lazyload.js
@@ -17,7 +17,6 @@
 
 (function($, window, document, undefined) {
     var $window = $(window);
-
     $.fn.lazyload = function(options) {
         var elements = this;
         var $container;
@@ -29,24 +28,23 @@
             container       : window,
             data_attribute  : "original",
             data_srcset     : "srcset",
-            skip_invisible  : true,
+            skip_invisible  : false,
             appear          : null,
             load            : null,
-			// Gray square
-			placeholder     : "data:image/gif;base64,R0lGODdhAQABAPAAAMPDwwAAACwAAAAAAQABAAACAkQBADs="
+			placeholder     : null
         };
 
         function update() {
             var counter = 0;
-
             elements.each(function() {
+				//console.log('li');
                 var $this = $(this);
                 if (settings.skip_invisible && !$this.is(":visible")) {
+					//console.log('skipped');
                     return;
                 }
                 if ($.abovethetop(this, settings) ||
                     $.leftofbegin(this, settings)) {
-                        /* Nothing. */
                 } else if (!$.belowthefold(this, settings) &&
                     !$.rightoffold(this, settings)) {
                         $this.trigger("appear");
@@ -78,14 +76,13 @@
         /* Cache container as jQuery as object. */
         $container = (settings.container === undefined ||
                       settings.container === window) ? $window : $(settings.container);
-
         /* Fire one scroll event per scroll. Not one scroll event per image. */
         if (0 === settings.event.indexOf("scroll")) {
             $container.off(settings.event).on(settings.event, function() {
                 return update();
             });
         }
-
+		//console.log($container);
         this.each(function() {
             var self = this;
             var $self = $(self);
@@ -112,15 +109,15 @@
 						})
                         .one("load", function() {
                             var original = $self.attr("data-" + settings.data_attribute);
-                            var srcset = $self.attr("data-" + settings.data_srcset);
+                            //var srcset = $self.attr("data-" + settings.data_srcset);
 
                             if (original != $self.attr("src")) {
                                 $self.hide();
                                 if ($self.is("img")) {
                                     $self.attr("src", original);
-                                    if (srcset != null) {
+                                    /*if (srcset != null) {
                                         $self.attr("srcset", srcset);
-                                    }
+                                    }*/
                                 }
 								/*if ($self.is("video")) { // not needed
                                     $self.attr("poster", original);

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -964,14 +964,14 @@ function updateActivePlItem() {
         }
     });
 
-    setTimeout(function() {
+    //setTimeout(function() {
         if ($('#playback-panel').hasClass('active')) {
             customScroll('playlist', parseInt(MPD.json['song']));
             if ($('#cv-playlist').css('display') == 'block') {
                 customScroll('cv-playlist', parseInt(MPD.json['song']));
             }
         }
-    }, DEFAULT_TIMEOUT);
+		//}, DEFAULT_TIMEOUT);
 }
 
 // Render the Playlist
@@ -1104,14 +1104,14 @@ function renderPlaylist() {
                 }
     		}
 
-            setTimeout(function() {
+            //setTimeout(function() {
                 if ($('#playback-panel').hasClass('active')) {
                     customScroll('playlist', parseInt(MPD.json['song']));
                     if ($('#cv-playlist').css('display') == 'block') {
                         customScroll('cv-playlist', parseInt(MPD.json['song']));
                     }
                 }
-            }, DEFAULT_TIMEOUT);
+				//}, DEFAULT_TIMEOUT);
         }
         else {
             $('#playback-hd-badge, #playbar-hd-badge, #ss-hd-badge').hide();
@@ -1250,9 +1250,11 @@ function renderFolderView(data, path, searchstr) {
 
 	// Scroll and highlight
     // NOTE: Don't highlight if at root or only 1 item in list
-	customScroll('folder', UI.dbPos[UI.dbPos[10]], 100);
-	if (path != '' && UI.dbPos[UI.dbPos[10]] > 1) {
-		$('#db-' + UI.dbPos[UI.dbPos[10]].toString()).addClass('active');
+	if (currentView == 'folder') {
+		customScroll('folder', UI.dbPos[UI.dbPos[10]], 100);
+		if (path != '' && UI.dbPos[UI.dbPos[10]] > 1) {
+			$('#db-' + UI.dbPos[UI.dbPos[10]].toString()).addClass('active');
+		}
 	}
 }
 // Format entries for Folder view
@@ -3314,11 +3316,11 @@ $('#coverart-url, #playback-switch').click(function(e){
 
 	if (currentView == 'tag') {
 		makeActive('.tag-view-btn','#library-panel','tag');
-		setTimeout(function() {
+		/*setTimeout(function() {
 			if (UI.libPos[0] >= 0) {
 				customScroll('albums', UI.libPos[0], 200);
 			}
-		}, DEFAULT_TIMEOUT);
+		}, DEFAULT_TIMEOUT);*/
 
         if (!GLOBAL.libRendered) {
             loadLibrary();
@@ -3326,16 +3328,16 @@ $('#coverart-url, #playback-switch').click(function(e){
 	}
 	else if (currentView == 'album') {
 		makeActive('.album-view-btn','#library-panel','album');
-		setTimeout(function() {
+		//setTimeout(function() {
 			if (UI.libPos[1] >= 0) {
-				customScroll('albumcovers', UI.libPos[1], 0);
+				//customScroll('albumcovers', UI.libPos[1], 0);
                 if ($('#tracklist-toggle').text().trim() == 'Hide tracks') {
                     $('#bottom-row').css('display', 'flex')
         			$('#lib-albumcover').css('height', 'calc(47% - 2em)'); // Was 1.75em
         			$('#index-albumcovers').hide();
                 }
 			}
-		}, DEFAULT_TIMEOUT);
+			//}, DEFAULT_TIMEOUT);
 
         if (!GLOBAL.libRendered) {
             loadLibrary();
@@ -3343,11 +3345,11 @@ $('#coverart-url, #playback-switch').click(function(e){
 	}
 	else if (currentView == 'radio') {
 		makeActive('.radio-view-btn','#radio-panel',currentView);
-		setTimeout(function() {
+		/*setTimeout(function() {
 			if (UI.radioPos >= 0) {
                 customScroll('radio', UI.radioPos, 0);
 			}
-		}, DEFAULT_TIMEOUT);
+			}, DEFAULT_TIMEOUT);*/
 	}
 	// Default to folder view
 	else {
@@ -3393,9 +3395,9 @@ $('#playbar-switch, #playbar-cover, #playbar-title').click(function(e){
 			var a = $('#countdown-display').text() ? $('#m-countdown').text(a) : $('#m-countdown').text('00:00');
 		}
         else {
-			setTimeout(function() {
+			//setTimeout(function() {
 				customScroll('playlist', parseInt(MPD.json['song']), 0);
-			}, DEFAULT_TIMEOUT);
+				//}, DEFAULT_TIMEOUT);
 		}
 	}
 });
@@ -3565,13 +3567,13 @@ function lazyLode(view, skip, force) {
  				if (SESSION.json['library_tagview_covers'] == 'Yes') {
      				selector = 'img.lazy-tagview';
      				container = '#lib-album';
-					//skip = true;
+					skip = true;
                 }
  				break;
  			case 'album':
  				selector = 'img.lazy-albumview';
  				container = '#lib-albumcover';
-				//skip = true;
+				skip = true;
 				break;
 		 	case 'playlist':				
 				selector = 'img.lazy-playlistview';
@@ -3584,16 +3586,27 @@ function lazyLode(view, skip, force) {
  		}
         if (selector && container) {
 			
-			if ($(container + ' ' + selector).attr('src') && !force) {
-				return;
-			}
 			
-			$.ensure($(container + ' li')).then(
-				$(selector).lazyload({
-					container: $(container),
-					skip_invisible: skip
-				}));			
-        }
+			
+			$.ensure(container + ' li').then(function(){
+				if (!$(container + ' ' + selector).attr('src') || force) {
+					$(container + ' ' + selector).lazyload({
+						container: $(container),
+						skip_invisible: skip
+					});
+				}
+				if (UI.libPos[1] >= 0 && currentView == 'album') {
+					customScroll('albumcovers', UI.libPos[1], 0);
+					$('#albumcovers .lib-entry').eq(UI.libPos[1]).addClass('active');
+				}
+				if (UI.libPos[0] >= 0 && currentView == 'tag') {
+					customScroll('albums', UI.libPos[0], 0);
+					$('#albumsList .lib-entry').eq(UI.libPos[0]).addClass('active');
+    				$('#albumsList .lib-entry').eq(UI.libPos[0]).click();
+				}
+				if (UI.radioPos >= 0 && currentView == 'radio') {customScroll('radio', UI.radioPos, 0);}
+			});
+       }
  	}
 }
 
@@ -3673,5 +3686,5 @@ function getRootElementFontSize() {
       }
     }, 1);
     return promise;
+    clearInterval(interval);
   };
-

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -279,9 +279,9 @@ jQuery(document).ready(function($) { 'use strict';
     			$('#playback-controls').show();
     		}
             else {
-    			setTimeout(function() {
+    			//setTimeout(function() {
     		        customScroll('playlist', parseInt(MPD.json['song']));
-    			}, DEFAULT_TIMEOUT);
+					//}, DEFAULT_TIMEOUT);
     		}
     		$('#menu-bottom').hide();
     	}
@@ -295,11 +295,11 @@ jQuery(document).ready(function($) { 'use strict';
     	if (currentView == 'radio') {
     		makeActive('.radio-view-btn','#radio-panel', currentView);
 
-    		setTimeout(function() {
+    		/*setTimeout(function() {
     			if (UI.radioPos >= 0) {
     				customScroll('radio', UI.radioPos, 200);
     			}
-    		}, DEFAULT_TIMEOUT);
+			}, DEFAULT_TIMEOUT);*/
     	}
         // Folder view
     	else if (currentView == 'folder') {
@@ -311,34 +311,34 @@ jQuery(document).ready(function($) { 'use strict';
     		makeActive('.tag-view-btn','#library-panel', 'tag');
             SESSION.json['library_show_genres'] == 'Yes' ? $('#top-columns').removeClass('nogenre') : $('#top-columns').addClass('nogenre');
 
-            if (!GLOBAL.libRendered) {
-    			//loadLibrary();
-    		}
+            /*if (!GLOBAL.libRendered) { // lib rendered on page load
+    			loadLibrary();
+    		}*/
 
-    		setTimeout(function() {
+    		/*setTimeout(function() {
     			if (UI.libPos[0] >= 0) {
-    			    $('#albumsList .lib-entry').removeClass('active');
+    			    $('#albumsList .lib-entry').removeClass('active'); // none should be active on page load
     				$('#albumsList .lib-entry').eq(UI.libPos[0]).addClass('active');
     				customScroll('albums', UI.libPos[0], 200);
     				$('#albumsList .lib-entry').eq(UI.libPos[0]).click();
     			}
-    		}, DEFAULT_TIMEOUT);
+				//}, DEFAULT_TIMEOUT);*/
     	}
     	// Album view
     	else if (currentView == 'album'){
     		makeActive('.album-view-btn','#library-panel', 'album');
 
-            if (!GLOBAL.libRendered) {
-    			//loadLibrary();
-    		}
+            /*if (!GLOBAL.libRendered) {
+    			loadLibrary();
+    		}*/
 
-    		setTimeout(function() {
+    		/*setTimeout(function() {
     			if (UI.libPos[1] >= 0) { // lib entry clicked or random album
     			    $('#albumcovers .lib-entry').removeClass('active');
     				$('#albumcovers .lib-entry').eq(UI.libPos[1]).addClass('active');
-    				customScroll('albumcovers', UI.libPos[1], 0);
+    				customScroll('albumcovers', UI.libPos[1], 200);
     			}
-    		}, DEFAULT_TIMEOUT);
+				}, DEFAULT_TIMEOUT);*/
     	}
     });
 
@@ -349,11 +349,11 @@ jQuery(document).ready(function($) { 'use strict';
     // Radio view
 	$('.radio-view-btn').click(function(e){
         makeActive('.radio-view-btn','#radio-panel','radio');
-        setTimeout(function() {
+        /*setTimeout(function() {
 			if (UI.radioPos >= 0) {
                 customScroll('radio', UI.radioPos, 0);
 			}
-		}, DEFAULT_TIMEOUT);
+			}, DEFAULT_TIMEOUT);*/
 	});
     // Folder view
 	$('.folder-view-btn').click(function(e){
@@ -365,18 +365,18 @@ jQuery(document).ready(function($) { 'use strict';
 		makeActive('.tag-view-btn','#library-panel','tag');
         SESSION.json['library_show_genres'] == 'Yes' ? $('#top-columns').removeClass('nogenre') : $('#top-columns').addClass('nogenre');
 
-		if (!GLOBAL.libRendered) {
+		/*if (!GLOBAL.libRendered) {
 			loadLibrary();
-		}
+		}*/
 
-		setTimeout(function() {
-			if (UI.libPos[0] >= 0) { // Lib entry clicked or random album
-			    $('#albumsList .lib-entry').removeClass('active');
+		//setTimeout(function() {
+		    $('#albumsList .lib-entry').removeClass('active');
+			/*if (UI.libPos[0] >= 0) { // Lib entry clicked or random album
 				$('#albumsList .lib-entry').eq(UI.libPos[0]).addClass('active');
 				customScroll('albums', UI.libPos[0], 0);
-			}
-			else if (UI.libPos[0] == -2) { // Lib headers clicked
-			    $('#albumsList .lib-entry').removeClass('active');
+			}*/
+			if (UI.libPos[0] == -2) { // Lib headers clicked
+			    //$('#albumsList .lib-entry').removeClass('active');
 				$('#lib-album').scrollTo(0, 0);
 				$('#lib-artist').scrollTo(0, 0);
 				UI.libPos[0] = -1;
@@ -390,7 +390,7 @@ jQuery(document).ready(function($) { 'use strict';
 				UI.libPos[0] = -1;
 				storeLibPos(UI.libPos);
 			}
-		}, DEFAULT_TIMEOUT);
+			//}, DEFAULT_TIMEOUT);
 	});
     // Album view
 	$('.album-view-btn').click(function(e){
@@ -402,19 +402,19 @@ jQuery(document).ready(function($) { 'use strict';
 			loadLibrary();
 		}
 
-		setTimeout(function() {
-			if (UI.libPos[1] >= 0) { // Lib entry clicked or random album
-			    $('#albumcovers .lib-entry').removeClass('active');
+		//setTimeout(function() {
+		    $('#albumcovers .lib-entry').removeClass('active');
+			/*if (UI.libPos[1] >= 0) { // Lib entry clicked or random album
 				$('#albumcovers .lib-entry').eq(UI.libPos[1]).addClass('active');
 				customScroll('albumcovers', UI.libPos[1], 0);
-			}
-			else if (UI.libPos[1] == -2 || UI.libPos[1] == -3) { // Lib headers clicked or search performed
-			    $('#albumcovers .lib-entry').removeClass('active');
+			}*/
+			if (UI.libPos[1] == -2 || UI.libPos[1] == -3) { // Lib headers clicked or search performed
+			   // $('#albumcovers .lib-entry').removeClass('active');
 				$('#lib-albumcover').scrollTo(0, 0);
 				UI.libPos[1] = -1;
 				storeLibPos(UI.libPos);
 			}
-		}, DEFAULT_TIMEOUT);
+			//}, DEFAULT_TIMEOUT);
 	});
 
     // Clear Library tag cache
@@ -762,10 +762,10 @@ jQuery(document).ready(function($) { 'use strict';
     		else {
     			$('#playback-switch').click();
     			$('.tag-view-btn').click();
-    			setTimeout(function() {
+    			//setTimeout(function() {
     				$('#artistsList .lib-entry').filter(function() {return $(this).text() == MPD.json['artist'];}).click();
     				customScroll('artists', UI.libPos[2], 200);
-    			}, DEFAULT_TIMEOUT);
+					//}, DEFAULT_TIMEOUT);
     		}
         }
 	});
@@ -881,12 +881,12 @@ jQuery(document).ready(function($) { 'use strict';
     // Refresh the station list
 	$('#ra-refresh').click(function(e) {
 		mpdDbCmd('lsinfo_radio');
-        setTimeout(function() {
+        //setTimeout(function() {
             lazyLode('radio');
-        }, DEFAULT_TIMEOUT);
-        setTimeout(function() {
+			//}, DEFAULT_TIMEOUT);
+        //setTimeout(function() {
             $('#database-radio').scrollTo(0, 200);
-        }, DEFAULT_TIMEOUT);
+       // }, DEFAULT_TIMEOUT);
 
 		UI.radioPos = -1;
 		storeRadioPos(UI.radioPos)
@@ -1289,12 +1289,12 @@ jQuery(document).ready(function($) { 'use strict';
 
         if ($('#cv-playlist').css('display') == 'block') {
             $('#cv-playlist ul').html($('#playlist ul').html());
-            setTimeout(function() {
+            //setTimeout(function() {
                 if (SESSION.json['playlist_art'] == 'Yes') {
                     lazyLode('cv-playlist');
                 }
                 customScroll('cv-playlist', parseInt(MPD.json['song']));
-            }, DEFAULT_TIMEOUT);
+				//}, DEFAULT_TIMEOUT);
 
             GLOBAL.playbarPlaylistTimer = setTimeout(function() {
                 $('#cv-playlist ul').html('');
@@ -1345,13 +1345,13 @@ jQuery(document).ready(function($) { 'use strict';
             $('#lib-coverart-img').show();
             // TEST: Fixes Queue sometimes not being visable after returning from CoverView
             UI.mobile ? $('#playback-queue').css('width', '99.9%') : $('#playback-queue').css('width', '38.1%');
-            setTimeout(function() {
+            //setTimeout(function() {
                 $('#playback-queue').css('width', ''); // TEST: Restore correct width to force Queue visable
                 if (SESSION.json['playlist_art'] == 'Yes') {
                     lazyLode('playlist');
                 }
                 customScroll('playlist', parseInt(MPD.json['song']));
-            }, DEFAULT_TIMEOUT);
+				//}, DEFAULT_TIMEOUT);
         }
         // Reset screen saver timeout global
         else if (SESSION.json['scnsaver_timeout'] != 'Never') {

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -1071,10 +1071,10 @@ jQuery(document).ready(function($) { 'use strict';
     			}
 
                 if (currentView == 'tag') {
-    				lazyLode('tag');
+    				lazyLode('tag', true, true);
     			}
     			else {
-    				lazyLode('album');
+    				lazyLode('album', true, true);
     				$('#bottom-row').css('display', '');
                     $('#tracklist-toggle').html('<i class="fal fa-list sx"></i> Show tracks');
     			}

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -56,7 +56,7 @@
 				<div id="playback-queue" class="span5">
 					<div id="container-playlist">
 						<div id="playlist">
-							<ul class="playlist"></ul>
+							<ul id="pl-list" class="playlist"></ul>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
This circumvents an issue where lazyload would sometimes be called before the list had populated by adding a function that uses javascript promises to let moode know when an element exists, i.e. $.ensure(this).then(that).

It also:

#1 checks if the view is active before calling lazylode (looking at you playlist & radio)

#2 checks to see if lazyload has already been called and if so skips the actual lazyload call.

#3 allows a call to force lazyload to run anyway (e.g. for typedown search)

#4 allows setting skip_invisible (e.g. for typedown search)

#5 switch radio & playlist to use innerHTML like the two library lists

#6 adds an id to the play queue list markup to facilitate #5

#6 fixes a bug in renderui with the default cover image (was missing a '" ' at the end of the src.

#7 limits MPD.json['date'] to 4 characters which should maybe be done in the php but whatever

#8 adjusts the mobile playbar title text a little: slighty larger, shifted to the left a little.

#9 remove placeholder graphic from lazyload library, sets skip_invisible back to original default value of false and comments out srcset stuff we don't use.