### PR TITLE
Features/additional options for autocfg

### DIFF
--- a/usr/local/bin/moodeutl
+++ b/usr/local/bin/moodeutl
@@ -90,6 +90,9 @@ switch ($option) {
 	case '-F':
 		audio_formats($option);
 		break;
+	case '-i':
+		import_autoconfig();
+		break;
 	case '-l':
 		moode_log();
 		break;
@@ -126,9 +129,10 @@ With no OPTION print the help text and exit.
  -A [add|rm N] \tupdate features availability
  -d\t\tdump session file (requires sudo)
  -D [var name] \tdelete session variable (requires sudo)
- -e\t\texport settings to moodecfg.ini
+ -e\t[filename]\texport settings to moodecfg.ini
  -f\t\tprint supported audio formats
  -F\t\tprint full alsacap info
+ -i\t\timport moodecfg.ini
  -l\t\tprint moode log
  -m\t\trun system monitor
  -q\t\tquery sql database
@@ -375,4 +379,9 @@ function export_autoconfig($argv) {
 	$cfgfile = count($argv)==3 ? $argv[2] : sprintf("/home/pi/moodecfg-%s.ini",  date('ymd_His'));
 	echo "Current moOde settings exported to ".$cfgfile."\n";
 	echo shell_exec('/var/www/command/autocfggen.php > '.$cfgfile);
+}
+
+function import_autoconfig() {
+	echo "Import moOde autoconfig settings\n";
+	echo shell_exec('sudo /var/www/command/autocfgimport.php');
 }

--- a/www/command/autocfgimport.php
+++ b/www/command/autocfgimport.php
@@ -1,0 +1,44 @@
+#!/usr/bin/php
+<?php
+/**
+ * moOde audio player (C) 2014 Tim Curtis
+ * http://moodeaudio.org
+ *
+ * This Program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This Program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * 2020-MM-DD TC moOde 7.0.0
+ *
+ */
+
+ /**
+  * autocfggen exports the supported autoconfig settings to the screen.
+  * Don't use this file directly but use the moodeutl -x option
+  */
+
+require_once dirname(__FILE__) . '/../inc/playerlib.php';
+
+playerSession('open', '' ,'');
+
+if (file_exists('/boot/moodecfg.ini')) {
+	sysCmd('truncate ' . AUTOCFG_LOG . ' --size 0');
+	autoConfig('/boot/moodecfg.ini');
+  sysCmd('sync');
+  session_write_close();
+}
+else {
+  autoCfgLog('autocfg: no file "/boot/moodecfg.ini" to import\n');
+  print("no file \"/boot/moodecfg.ini\" to import\n");
+}
+
+?>

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -2558,6 +2558,26 @@ function autoConfigSettings() {
 		playerSession('write', array_key_first($values), $values[array_key_first($values)]);
 	}
 
+	function setCfgMpd($values) {
+		$dbh = cfgdb_connect();
+		$total_query ='';
+		foreach ($values  as $key=>$value) {
+			$query = sprintf('update cfg_mpd set value="%s" where param="%s"; ', $value,  $key);
+			$result = sdbquery($query, $dbh);
+		}
+	}
+
+	function getCfgMpd($values) {
+		$dbh = cfgdb_connect();
+		$result ='';
+		foreach ($values  as $key) {
+			$query = 'select param,value from cfg_mpd where param="'.$key.'"';
+			$rows = sdbquery($query, $dbh);
+			$result = $result . sprintf("%s = \"%s\"\n", $key, $rows[0]['value']);
+		}
+		return $result;
+	}
+
 	// configuration of the autoconfig item handling
 	// - requires - array of autoconfig items that should be present (all) before the handler is executed.
 	//            most item only have 1 autoconfig item, but network setting requires multiple to be present
@@ -2618,6 +2638,21 @@ function autoConfigSettings() {
 			cfgI2sOverlay($values['i2sdevice'] == "None" ? 'none' : $values['i2sdevice']);
 			playerSession('write', 'i2sdevice', $values['i2sdevice']);
 		}],
+
+		'MPD',
+		['requires' => ['mixer_type'] , 'handler' => setCfgMpd, 'custom_write' => getCfgMpd],
+		['requires' => ['device'] , 'handler' => setCfgMpd, 'custom_write' => getCfgMpd],
+		['requires' => ['selective_resample_mode'] , 'handler' => setCfgMpd, 'custom_write' => getCfgMpd],
+		['requires' => ['sox_quality'] , 'handler' => setCfgMpd, 'custom_write' => getCfgMpd],
+		['requires' => ['sox_multithreading'] , 'handler' => setCfgMpd, 'custom_write' => getCfgMpd],
+		['requires' => ['sox_precision',
+						'sox_phase_response',
+						'sox_passband_end',
+						'sox_stopband_begin',
+						'sox_attenuation',
+						'sox_flags']
+		 , 'handler' => setCfgMpd, 'custom_write' => getCfgMpd],
+
 		'Renderers',
 		['requires' => ['btsvc'] , 'handler' => setPlayerSession],
 		['requires' => ['pairing_agent'] , 'handler' => setPlayerSession],
@@ -2816,7 +2851,7 @@ function autoConfig($cfgfile) {
 		autoCfgLog('autocfg: Caught exception: '.  $e->getMessage() );
 	}
 
-	sysCmd('rm ' . $cfgfile);
+ 	sysCmd('rm ' . $cfgfile);
 	autoCfgLog('autocfg: Configuration file deleted');
 	autoCfgLog('autocfg: Auto-configure complete');
 }


### PR DESCRIPTION
- moodeutl -i  for manual importing the /boot/moodecfg.ini
- support for export and import of the library sources
- support for mpd options:
  - mixer_type
  - device (device index if not a i2s device is used)
  - selective_resample_mode
  - sox_quality
  - sox_multithreading
  - sox_precision
  - sox_phase_response
  - sox_passband_end
  - sox_stopband_begin
  - sox_attenuation
  - sox_flags
