### PR TITLE
Add scrolling / select to ralbum

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -273,6 +273,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#volumeup-2, #volumedn-2 {height:4rem;margin:2rem 0;font-size:8.5vw;}
 	#volume-popup .volume-display {font-size:9.5vw}
 	#volume-pad {height:85vw;width:85vw;}
+	#volpad .volume-display-db {left:65%;font-size:1.5em;}
 	#menu-top .dropdown.open {background-color:transparent;border-radius:unset;box-shadow:none;backdrop-filter:none;padding-left:0}
 	/* playbar */
 	#playbar-div {display:block;}
@@ -427,7 +428,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 @media (width:375px) and (height:812px) {
 	.playlist {padding:0 0 8rem 0;min-height:35vh;}
 }
-/* iPhone XS Max */
+/* iPhone Max sizes */
 @media (width:414px) and (height:896px) {
 	.ui-pnotify {left:50%;top:25%;transform:translate(-50%, -50%);}
 	#playbar-toggles {right:calc(env(safe-area-inset-right) + 1rem);}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -122,7 +122,8 @@ html {background-color:inherit;}
 #volcontrol, #volcontrol-2 {margin:auto;height:17vw;width:17vw;}
 .volume-display {position:relative;font-size:2.5vw;color:var(--adapttext);font-weight:500;cursor:pointer;height:50%;}
 .volume-display div {position:relative;top:50%;transform:translate(0, -50%);min-height:33%;text-align:center;}
-.volume-display-db {position:absolute;top: 46%;left:115%;font-size:1vw;color:var(--adapttext);text-align:center;}
+.volume-display-db {position:absolute;top:50%;left:65%;z-index:0;font-size:.8em;transform:translate(0, -50%);}
+#volpad .volume-display-db {left:70%;}
 #volume, #volume-2 {display:none;} /* using .volume-display to overlay this element so it can be used as a mute toggle */
 #volzone, #timezone, #volbtns-2 {font-family:'SF Mono', 'Roboto Mono', monospace;} /* 'Letter Gothic Std', */
 #volbtns, #volbtns-2 {display:flex;position:absolute;transform:translate(-50%,-50%);top:50%;left:50%;height:70%;margin:0 auto;flex-direction:column;}
@@ -159,13 +160,13 @@ html {background-color:inherit;}
 .btnlist.btnlist-top.btnlist-top-pl {top:0px;top:env(safe-area-inset-top);width:35%;z-index:1004;display:none;}
 .btn.btn-primary.btn-small, .btn.btn-primary.btn-medium {background:rgba(128,128,128,0.2);margin-top:-4px;}
 #menu-top {line-height:2.75rem;padding-top:0;padding-top:env(safe-area-inset-top);height:0;z-index:1002;display:flex;}
-#menu-top .dropdown {top:0;top:calc(env(safe-area-inset-top) + 0);right:.75rem;position:absolute;}
-#menu-top .dropdown-menu {right:0;}
+#menu-top .dropdown {top:0;top:calc(env(safe-area-inset-top) + 0);right:0;position:absolute;}
+#menu-top .dropdown-menu {right:.75rem;}
 #menu-top .dropdown-menu > li > a i, #context-menus .dropdown-menu > li > a i {width:1.75em;display:inline-block;text-align:center;}
 .dropdown-menu > li > a:hover, .dropdown-menu > li > a:active, .dropdown-menu > li > a:focus {background-color:var(--accentxta);background-image:none;}
 #menu-top a:hover, #menu-top a:focus, #context-menus .dropdown-menu a:hover, #context-menus .dropdown-menu a:focus {text-decoration:none;outline:none;}
 #menu-top #config-back i {font-size:1.35rem;position:relative;top:1px;}
-#menu-settings {color:transparent;position:relative;bottom:.3rem;right:0;line-height:2.75rem;height:1.9rem;z-index:1001;padding:0 .75rem;border-radius:0;border-bottom:1px solid transparent;font-size:1.7rem;font-weight:500;margin-right:.1rem;}
+#menu-settings {color:transparent;position:relative;bottom:.3rem;right:0;line-height:2.75rem;height:1.9rem;z-index:1001;padding:0 1.5rem;border-radius:0;border-bottom:1px solid transparent;font-size:1.7rem;font-weight:500;margin-right:.1rem;}
 #mbrand, #mblur {font-weight:600;position:absolute;left:50%;top:-.25rem;}
 #mbrand {color:var(--adapttext);text-shadow: 0 0 0.25rem rgba(0,0,0,0.5);transform:translate(-50%);}
 #mblur {letter-spacing:-.56em;color:transparent;text-shadow:0 0 2px var(--btnshade4);transform:translate(calc(-50% - .28em));opacity:.75;}
@@ -397,7 +398,7 @@ img.lib-artistart {float:left;width:calc(20vw - 1rem);height: calc(20vw - 1rem);
 .controls.controls-tog {line-height:30px;}
 .form-horizontal .help-block {line-height:normal;margin-top:0px;padding-top:0px;margin-bottom:.5em;}
 /* album cover panel */
-#lib-albumcover {height:100%;width:100%;position:absolute;box-sizing:border-box;left:0%;top:2.75em;top:calc(env(safe-area-inset-top) + 2.75em);overflow:auto;overflow-x:hidden;-webkit-overflow-scrolling:touch;}
+#lib-albumcover {height:100%;width:100%;position:fixed;box-sizing:border-box;left:0%;top:2.75rem;top:calc(env(safe-area-inset-top) + 2.75rem);overflow:auto;overflow-x:hidden;-webkit-overflow-scrolling:touch;}
 #albumcovers {text-align:center;margin:0;padding-bottom:12em;}
 #albumcovers .lib-entry, .database-radio .lib-entry {width:var(--thumbcols);text-align:center;display:inline-block;vertical-align:top;height:auto;font-size:.95em;padding:0 0 .4em 0;}
 #albumcovers .lib-entry img, .database-radio img {position:absolute;left:var(--thumbmargin);bottom:0;object-fit:contain;width:var(--thumbimagesize);max-height:var(--thumbimagesize);}
@@ -411,7 +412,7 @@ img.lib-artistart {float:left;width:calc(20vw - 1rem);height: calc(20vw - 1rem);
 #radiocovers, #albumcovers {width:100%;margin-left:0;}
 #lib-genre ul, #lib-artist ul, #lib-album ul {width:calc(100% - (var(--sbw) + 1.17rem));margin:.25em 0;}
 /**/
-#random-album {position:absolute;top:env(safe-area-inset-top);left:7rem;line-height:2.75rem;height:2.75rem;transform:none;padding:.15em .5em 0 .5em;cursor:pointer;}
+#random-album {position:absolute;top:env(safe-area-inset-top);right:7rem;line-height:2.6rem;transform:none;padding:.15rem 2rem 0 2rem;cursor:pointer;}
 #random-album i {font-size:1.1rem;color:var(--adapttext);opacity:.35;}
 /* coverview screen saver */
 #screen-saver {color:#eee;text-shadow:0px 0px .25em rgba(0,0,0,0.3);height:100vh;width:100vw;cursor:pointer;text-align:center;}

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -47,7 +47,7 @@ const DEFAULT_TIMEOUT   = 250;
 const CLRPLAY_TIMEOUT   = 500;
 const LAZYLOAD_TIMEOUT  = 500;
 const SEARCH_TIMEOUT    = 750;
-const RALBUM_TIMEOUT    = 1500;
+const RALBUM_TIMEOUT    = 500;
 const ENGINE_TIMEOUT    = 3000;
 
 // Album and Radio HD parameters
@@ -3333,7 +3333,7 @@ $('#coverart-url, #playback-switch').click(function(e){
 				//customScroll('albumcovers', UI.libPos[1], 0);
                 if ($('#tracklist-toggle').text().trim() == 'Hide tracks') {
                     $('#bottom-row').css('display', 'flex')
-        			$('#lib-albumcover').css('height', 'calc(47% - 2em)'); // Was 1.75em
+        			$('#lib-albumcover').css('height', 'calc(50% - env(safe-area-inset-top) - 2.75rem)'); // Was 1.75em
         			$('#index-albumcovers').hide();
                 }
 			}
@@ -3481,7 +3481,7 @@ function makeActive (vswitch, panel, view) {
 			$('#library-panel').addClass('covers').removeClass('tag');
             if ($('#tracklist-toggle').text().trim() == 'Hide tracks') {
                 $('#bottom-row').css('display', 'flex')
-                $('#lib-albumcover').css('height', 'calc(47% - 2em)'); // Was 1.75em
+                $('#lib-albumcover').css('height', 'calc(50% - env(safe-area-inset-top) - 2.75rem)'); // Was 1.75em
                 $('#index-albumcovers').hide();
             }
             else {
@@ -3573,7 +3573,7 @@ function lazyLode(view, skip, force) {
  			case 'album':
  				selector = 'img.lazy-albumview';
  				container = '#lib-albumcover';
-				skip = true;
+				//skip = true;
 				break;
 		 	case 'playlist':				
 				selector = 'img.lazy-playlistview';

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -65,15 +65,18 @@ if (!Object.values) {
 function loadLibrary() {
     //console.log('loadLibrary(): loading=' + GLOBAL.libLoading, currentView);
     GLOBAL.libLoading = true;
-    if (currentView == 'tag' || currentView == 'album') {
-        notify('library_loading');
-    }
+	var libpop = setTimeout(function(){
+	    if (currentView == 'tag' || currentView == 'album') {
+	        notify('library_loading');
+	    }		
+	}, 2000);
 
 	$.post('command/moode.php?cmd=loadlib', function(data) {
         $('#lib-content').show();
 		renderLibrary(data);
         GLOBAL.libRendered = true;
         GLOBAL.libLoading = false;
+		clearTimeout(libpop);
 
 	}, 'json');
 }
@@ -793,7 +796,8 @@ var renderSongs = function(albumPos) {
 		}
 	}
 
-	$('#songsList').html(output);
+	var element = document.getElementById('songsList');
+	element.innerHTML = output;
 
     // Display album name heading:
     // - if more than 1 album for clicked artist
@@ -1000,6 +1004,11 @@ $('#albumsList').on('click', '.lib-entry', function(e) {
 
 // Click random album button
 $('#random-album').click(function(e) {
+	
+	// remove old active classes...
+	$('#albumsList .lib-entry').eq(UI.libPos[0]).removeClass('active');
+	$('#albumcovers .lib-entry').eq(UI.libPos[1]).removeClass('active');
+	
 	var array = new Uint16Array(1);
     LIB.albumClicked = true;
 	window.crypto.getRandomValues(array);
@@ -1022,9 +1031,9 @@ $('#random-album').click(function(e) {
 
 	storeLibPos(UI.libPos);
 
-	$(itemSelector).removeClass('active');
+	//$(itemSelector).removeClass('active');
 	$(itemSelector).eq(pos).addClass('active');
-	customScroll(scrollSelector, pos, 200);
+	customScroll(scrollSelector, pos, 0);
 
 	clickedLibItem(e, keyAlbum(albumobj), LIB.filters.albums, renderSongs);
 });
@@ -1091,6 +1100,12 @@ $('#albumcovers').on('click', 'img', function(e) {
 // Random album instant play button on Playback
 $('.ralbum').click(function(e) {
     if (SESSION.json['library_instant_play'] != 'No action') {
+		
+		// remove old active classes...
+		$('#albumsList .lib-entry').eq(UI.libPos[0]).removeClass('active');
+		$('#albumcovers .lib-entry').eq(UI.libPos[1]).removeClass('active');
+		
+		
     	$('.ralbum svg').attr('class', 'spin');
     	setTimeout(function() {
     		$('.ralbum svg').attr('class', '');
@@ -1133,6 +1148,16 @@ $('.ralbum').click(function(e) {
                 });
         	}, CLRPLAY_TIMEOUT);
         }
+		if (UI.libPos[1] >= 0 && currentView == 'album') {
+			customScroll('albumcovers', UI.libPos[1], 0);
+			$('#albumcovers .lib-entry').eq(UI.libPos[1]).addClass('active');
+		}
+		if (UI.libPos[0] >= 0 && currentView == 'tag') {
+			customScroll('albums', UI.libPos[0], 0);
+			$('#albumsList .lib-entry').eq(UI.libPos[0]).addClass('active');
+			$('#albumsList .lib-entry').eq(UI.libPos[0]).click();
+		}
+		storeLibPos(UI.libPos);
     }
 });
 
@@ -1340,7 +1365,7 @@ $('#context-menu-lib-album a').click(function(e) {
 		if ($('#bottom-row').css('display') == 'none') {
 			$('#tracklist-toggle').html('<i class="fal fa-list sx"></i> Hide tracks');
 			$('#bottom-row').css('display', 'flex')
-			$('#lib-albumcover').css('height', 'calc(47% - 2em)'); // Was 1.75em
+			$('#lib-albumcover').css('height', 'calc(50% - env(safe-area-inset-top) - 2.75rem)'); // Was 1.75em
 			$('#index-albumcovers').hide();
 		}
 		else {

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -90,9 +90,9 @@
 							<div id="volbtns">
 								<button aria-label="Volume Up" id="volumeup" class="btn btn-cmd btn-volume">+</button>
 								<div aria-label="Volume Display" class="volume-display" href="#notarget"><div></div></div>
-								<div aria-label="Volume Display dB" class="volume-display-db"></div>
 								<button aria-label="Volume Down" id="volumedn" class="btn btn-cmd btn-volume">−</button>
 							</div>
+							<div aria-label="Volume Display dB" class="volume-display-db"></div>
 						</div>
 					</div>
 					<div id="togglebtns">
@@ -2108,6 +2108,7 @@
 				<div aria-label="Volume Display" class="volume-display" href="#notarget"><div></div></div>
 				<button aria-label="Volume Down" id="volumedn-2" class="btn btn-cmd btn-volume btn-primary" ontouchstart=""><i class="far fa-minus fa-xs"></i></button>
 		</div>
+		<div aria-label="Volume Display dB" class="volume-display-db"></div>
 	</div>
 	<div class="modal-footer">
 		<button aria-label="Close" class="btn singleton" data-dismiss="modal" aria-hidden="true">Close</button>


### PR DESCRIPTION
This adds scrolling to and selecting of the album selected by the ralbum button.

Also:

#1 change random-album to be smarter about what li to remove the active class from

#2 fixes second volume number positioning & size for people who love volume numbers

#3 makes the m menu a bigger hit target, this addresses an issue where ios lets you drag the scrollbar and so was annoying for things on the right side of the screen.

#4 moves the random album button (tag/album) to the right side so most people don't have their hand in front of the screen when they press it, and makes it a bigger hit target

#5 adjusts the ralbum timeout from 1500 to 500.

#6 fixes an issue where "show tracks..." on mobile in album view would have the album covers overlapping the bottom row region a bit

#7 WIP for a delayed notification popup on long library loads, it auto-dismisses while the library may still be loading but it does that now so...