### PR TITLE
A few minor fixes

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -394,7 +394,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#ss-currentsong {font-size:1.5em;}
 	#ss-currentalbum, #ss-currentartist {font-size:1.25em;}
 	#lib-coverart-meta-area {width:18vw;}
-	#volcontrol, #volcontrol-2, #countdown {height:15vw;width:15vw;}
+	#volcontrol, #countdown {height:15vw;width:15vw;}
 }
 /* iPad landscape */
 @media (orientation:landscape) and (min-width:768px) and (max-width:1024px) {

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -3651,7 +3651,7 @@ function submitLibraryUpdate (path) {
 
 function getThumbHW() {
 	var cols = SESSION.json['library_thumbnail_columns'].slice(0,1);
-	if (UI.mobile) cols = cols - 4;
+	if (UI.mobile) cols -= 4;
 	var divM = Math.round(2 * convertRem(1.5)); // 1.5rem l/r margin for div
 	var columnW = parseInt(($(window).width() - (2 * GLOBAL.sbw) - divM) / cols);
 	UI.thumbHW = columnW - (divM / 2);

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -39,6 +39,7 @@ jQuery(document).ready(function($) { 'use strict';
 
     // Resize thumbs on window resize
 	$(window).bind('resize', function(e){
+		UI.mobile = $(window).width() <= 480 ? true : false;
 		getThumbHW();
 	});
 

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -24,7 +24,7 @@
  */
 -->
 
-<div id="content" class="tab-content">
+<div id="content" class="tab-content visacc">
 	<!-- SCREEN SAVER -->
 	<div id="screen-saver" class="hide" href="#notarget">
 		<div id="ss-backdrop"></div>
@@ -66,7 +66,7 @@
 					<div id="timezone">
 						<div id="timeknob">
 							<div id="countdown">
-								<input aria-label="Playback Time" class="playbackknob" id="time" data-min="0" data-max="1000" data-width="100%" data-thickness=".13" data-bgColor="rgba(50,50,50,0.5)" data-fgcolor="transparent" data-readonly="false">
+								<input aria-label="Playback Time" class="playbackknob" id="time" data-min="0" data-max="1000" data-width="100%" data-thickness=".14" data-bgColor="rgba(50,50,50,0.5)" data-fgcolor="transparent" data-readonly="false">
 							</div>
 							<div aria-label="Countdown Display" id="countdown-display" href="#notarget"></div>
 							<div aria-label="Total" id="total"></div>
@@ -85,7 +85,7 @@
 						<div id="volknob">
 							<div id="volcontrol" class="volume-step-limiter">
 
-								<input aria-label="Volume" readonly class="volumeknob" id="volume" data-min="0" data-max="100" step="10" data-width="100%" data-thickness=".13" data-bgColor="rgba(50,50,50,0.5)" data-fgColor="transparent" data-readOnly="false" data-cursor="false" data-angleArc="340" data-angleOffset="-170">
+								<input aria-label="Volume" readonly class="volumeknob" id="volume" data-min="0" data-max="100" step="10" data-width="100%" data-thickness=".14" data-bgColor="rgba(50,50,50,0.5)" data-fgColor="transparent" data-readOnly="false" data-cursor="false" data-angleArc="340" data-angleOffset="-170">
 							</div>
 							<div id="volbtns">
 								<button aria-label="Volume Up" id="volumeup" class="btn btn-cmd btn-volume">+</button>


### PR DESCRIPTION
Make some changes discussed on the forum and address a knob issue I just noticed.

#1 remove the large overlay volume knob from being set to 15vw for large displays

#2 minor code simplification in getThumbHW (use var -= value instead of var = var - value)

#3 set UI.mobile on resize event

#4 make knob thickness on the playback screen slightly bigger to work around apparent bug in ios 14 I just noticed (.13 to .14)