### PR TITLE
gulp deploy footer.php for sysinfo.sh

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -461,7 +461,6 @@ gulp.task('deployback', gulp.series(['patchheader','patchfooter', 'minifyhtml'],
                       ,'!'+pkg.app.src+'/templates/indextpl.min.html'
                       ,'!'+pkg.app.src+'/templates/indextpl.html'
                       ,'!'+pkg.app.src+'/header.php'
-                      ,'!'+pkg.app.src+'/footer.php'
                       ,'!'+pkg.app.src+'/footer.min.php'
                       ],
                       {base: pkg.app.src})


### PR DESCRIPTION
Add footer.php to the gulp deploy list, because sysinfo.sh depends on footer.php for release number extraction