### PR TITLE
Multiple Artists support

### DIFF
--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -472,13 +472,39 @@ function genFlatList($sock) {
 				$item = count($flat);
 				$flat[$item][$element] = $value;
 			}
-			// @Atair: Gather possible multiple Genre values as array
+			// @Atair: Gather possible multiple Genre, Artist, and Performer values as array
 			elseif ($element == 'Genre') {
 				if ($flat[$item]['Genre']) {
 					array_push($flat[$item]['Genre'], $value);
 				}
 				else {
 					$flat[$item]['Genre'] = array($value);
+				}
+			}
+			elseif ($element == 'Artist') {
+				if ($flat[$item]['Artist']) {
+					array_push($flat[$item]['Artist'], $value);
+				}
+				else {
+					$flat[$item]['Artist'] = array($value);
+				}
+			}
+			//@Atair: add performers to artists
+			elseif ($element == 'Performer') {
+				if ($flat[$item]['Artist']) {
+					array_push($flat[$item]['Artist'], $value);
+				}
+				else {
+					$flat[$item]['Artist'] = array($value);
+				}
+			}
+			//@Atair: add conductor to artists
+			elseif ($element == 'Conductor') {
+				if ($flat[$item]['Artist']) {
+					array_push($flat[$item]['Artist'], $value);
+				}
+				else {
+					$flat[$item]['Artist'] = array($value);
 				}
 			}
 			else {
@@ -557,8 +583,14 @@ function genLibrary($flat) {
 				'tracknum' => ($flatData['Track'] ? $flatData['Track'] : ''),
 				'title' => ($flatData['Title'] ? $flatData['Title'] : 'Unknown Title'),
 				'disc' => ($flatData['Disc'] ? $flatData['Disc'] : '1'),
-				'artist' => ($flatData['Artist'] ? $flatData['Artist'] : 'Unknown Artist'),
-				'album_artist' => $flatData['AlbumArtist'],
+				//@Atair:
+				// 1. artist can safely be empty, because it is no longed used as substitute for missing album_artist
+				// 2. album_artist shall never be empty, otherwise the sort routines in scripts-library.js complain,
+				//    because they expect artist as string and not as array in album_artist || artist constructs
+				// 3. When AlbumArtist is not defined and artist contains a single value, it is assumed that Artist should be a surrogate for ALbumArtist.
+				//    otherwise, when Artist is an array of two and more values or empty, the AlbumArtist is set to 'Unknown' (this is regarded as bad tagging)
+				'artist' => ($flatData['Artist'] ? $flatData['Artist'] : array()), //@Atair: array is expected in scripts-library.js even when empty
+				'album_artist' => ($flatData['AlbumArtist'] ? $flatData['AlbumArtist'] : (count($flatData['Artist']) == 1 ? $flatData['Artist'][0] : 'Unknown AlbumArtist')),
 				'composer' => ($flatData['Composer'] ? $flatData['Composer'] : 'Composer tag missing'),
 				'conductor' => ($flatData['Conductor'] ? $flatData['Conductor'] : 'Conductor tag missing'),
 				'year' => getTrackYear($flatData),
@@ -580,7 +612,7 @@ function genLibrary($flat) {
 	if (count($lib) == 1 && empty($lib[0]['file'])) {
 		$lib[0]['file'] = '';
 		$lib[0]['title'] = '';
-		$lib[0]['artist'] = '';
+		$lib[0]['artist'] = array('');
 		$lib[0]['album'] = 'Nothing found';
 		$lib[0]['album_artist'] = '';
 		$lib[0]['genre'] = array('');
@@ -746,14 +778,19 @@ function genLibraryUTF8Rep($flat) {
 				'tracknum' => utf8rep(($flatData['Track'] ? $flatData['Track'] : '')),
 				'title' => utf8rep(($flatData['Title'] ? $flatData['Title'] : 'Unknown Title')),
 				'disc' => ($flatData['Disc'] ? $flatData['Disc'] : '1'),
-				'artist' => utf8rep(($flatData['Artist'] ? $flatData['Artist'] : 'Unknown Artist')),
-				'album_artist' => utf8rep($flatData['AlbumArtist']),
+				'artist' => utf8repArray(($flatData['Artist'] ? $flatData['Artist'] : array())), //@Atair: array is expected in scripts-library.js even when empty
+				//@Atair:
+				// 1. album_artist shall never be empty, otherwise the sort routines in scripts-library.js complain,
+				//    because they expect artist as string and not as array in album_artist || artist constructs
+				// 2. When AlbumArtist is not defined and artist contains a single value, it is assumed that Artist should be a surrogate for ALbumArtist.
+				//    otherwise, when Artist is an array of two and more values or empty, the AlbumArtist is set to 'Unknown' (this is regarded as bad tagging)
+				'album_artist' => utf8rep(($flatData['AlbumArtist'] ? $flatData['AlbumArtist'] : (count($flatData['Artist']) == 1 ? $flatData['Artist'][0] : 'Unknown AlbumArtist'))),
 				'composer' => utf8rep(($flatData['Composer'] ? $flatData['Composer'] : 'Composer tag missing')),
 				'conductor' => utf8rep(($flatData['Conductor'] ? $flatData['Conductor'] : 'Conductor tag missing')),
 				'year' => utf8rep(getTrackYear($flatData)),
 				'time' => utf8rep($flatData['Time']),
 				'album' => utf8rep(($flatData['Album'] ? $flatData['Album'] : 'Unknown Album')),
-				'genre' => utf8rep(($flatData['Genre'] ? $flatData['Genre'] : array('Unknown'))), // @Atair: 'Unknown' genre has to be an array
+				'genre' => utf8repArray(($flatData['Genre'] ? $flatData['Genre'] : array('Unknown'))), // @Atair: 'Unknown' genre has to be an array
 				'time_mmss' => utf8rep(songTime($flatData['Time'])),
 				'last_modified' => $flatData['Last-Modified'],
 				'encoded_at' => utf8rep(getEncodedAt($flatData, 'default', true)),
@@ -769,7 +806,7 @@ function genLibraryUTF8Rep($flat) {
 	if (count($lib) == 1 && empty($lib[0]['file'])) {
 		$lib[0]['file'] = '';
 		$lib[0]['title'] = '';
-		$lib[0]['artist'] = '';
+		$lib[0]['artist'] = array('');
 		$lib[0]['album'] = 'Nothing found';
 		$lib[0]['album_artist'] = '';
 		$lib[0]['genre'] = array('');
@@ -789,6 +826,15 @@ function genLibraryUTF8Rep($flat) {
 
 	return $json_lib;
 }
+
+//@Atair: utf8rep for arrays
+function utf8repArray($some_array) {
+	for ($i=0; $i<count($some_array); $i++) {
+		$some_array[$i] = utf8rep($some_array[$i]);
+	}
+	return $some_array;
+}
+
 // UTF8 replace (@lazybat)
 function utf8rep($some_string) {
 	// Reject overly long 2 byte sequences, as well as characters above U+10000 and replace with ? (@lazybat)


### PR DESCRIPTION
Please review my modifications to support multiple track artists.
1. The assumption is that album_artist should be never empty. To this end, in case it is empty, it is set either to artist if artist is a single value or otherwise to 'Unknown AlbumArtist'. In consequence, in scripts-library.js all constructs of the form album_artist || artist can be simplified to just album_artist, for example in sorting by AlbumArtist. (Sorting by Artist makes no sense when multiple Artists exist per track).
2. playerlist.php also cares now for (multiple) performer tags and adds them to the artists array. (Artist is regarded as generic term). (Note that also conductor would be in this category, but is not supported by mpd.)
3. All artist related functions are modified to support arrays of artists.
4. In tag view, when albums are filtered by selected artists, expanding/collapsing the track list of an album by clicking the album cover is extended to support multiple artists too.