### PR TITLE
Add Clear Filter to Library menu

### DIFF
--- a/www/css/fontawesome-moode.css
+++ b/www/css/fontawesome-moode.css
@@ -409,6 +409,9 @@ readers do not read off random characters that represent icons */
 .fa-tv:before {
   content: "\f26c"; }
 
+.fa-undo:before {
+  content: "\f0e2"; }
+
 .fa-volume-off:before {
   content: "\f026"; }
 

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -294,6 +294,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .viewswitch .btn {position:relative;width:100%;line-height:2.75rem;font-size:1.1rem;font-family:inherit;padding:0 0.5rem;background-color:transparent;text-align:left;}
 .viewswitch .btn.active {color:inherit;}
 .viewswitch .btn:hover {background-color:var(--accentxta);}
+.viewswitch .btn.filter-clear {display:none;}
 #viewswitch-search:hover {background-color:inherit;}
 .viewswitch .btn i {padding:0;width:1.75em;text-align:center;margin-right:.25rem;}
 .viewswitch .btn.no-icon {padding-left:1rem;}

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -3503,7 +3503,7 @@ function setLibMenuHeader () {
 		}
 		headerText += SESSION.json['library_flatlist_filter'] == 'None' ? '' : SESSION.json['library_flatlist_filter'] == 'Any' ? ' (' + SESSION.json['library_flatlist_filter_str'] + ')' : ' (' + SESSION.json['library_flatlist_filter'] + ')';
 	}
-	$('#menu-header').text(SESSION.json['library_flatlist_filter'] == 'None' ? headerText : headerText);
+	$('#menu-header').text(headerText);
 }
 
 function lazyLode(view, skip, force) {
@@ -3642,7 +3642,9 @@ $.ensure = function (selector) {
 };
 
 function filterhelp(filter, str) {
-	clearTimeout(searchTimer);
+	if (filter != 'None') $('#viewswitch .filter-clear').show();
+	$('#searchResetLib').hide();
+	showSearchResetLib = false;
 	SESSION.json['library_flatlist_filter'] = filter;
 	SESSION.json['library_flatlist_filter_str'] = str ? str : SESSION.json['library_flatlist_filter_str'];
 	console.log(filter, SESSION.json['library_flatlist_filter_str']);

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -84,6 +84,9 @@ jQuery(document).ready(function($) { 'use strict';
     	// Set currentView global
     	currentView = SESSION.json['current_view'];
 
+		// Unhide Clear Filter if filter active
+		if (SESSION.json['library_flatlist_filter'] != 'None') $('#viewswitch .filter-clear').show();
+		
     	// Detect mobile
     	UI.mobile = $(window).width() < 480 ? true : false;
         //console.log('window: ' + $(window).width() + 'x' + $(window).height());
@@ -361,6 +364,10 @@ jQuery(document).ready(function($) { 'use strict';
 			UI.libPos[1] = -1;
 			storeLibPos(UI.libPos);
 		}
+	});
+	$('#viewswitch .filter-clear').on('click', function(e){
+		filterhelp('None');
+		$('#viewswitch .filter-clear').hide();
 	});
 
     // Clear Library tag cache
@@ -968,9 +975,10 @@ jQuery(document).ready(function($) { 'use strict';
 
 			else if (bang == '!f') {
 				filter = filter.toLowerCase();
-				if (!filter) {
+				/*if (!filter) {
 					filterhelp('None');
-				} else if (filter == 'lossless'){
+				}*/
+				if (filter == 'lossless'){
 					filterhelp('Lossless');
 				} else {
 					filterhelp('Any', filter);
@@ -1024,7 +1032,7 @@ jQuery(document).ready(function($) { 'use strict';
     			});
 
     			var s = (count == 1) ? '' : 's';
-    			if (filter != '') {
+    			if (filter != '' && !bang) {
     				$('#menu-header').text((+count) + ' albums found');
     				GLOBAL.searchLib = $('#menu-header').text(); // Save for #menu-header
     			}

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -156,6 +156,7 @@
 				<button aria-label="Folder" class="btn folder-view-btn" href="#library-panel"><i class="fas fa-folder"></i> Folder<span class="pane"><i class="fal fa-check"></i></span></button>
 				<button aria-label="Tag" class="btn tag-view-btn" href="#library-panel"><i class="fas fa-columns"></i> Tag<span class="pane"><i class="fal fa-check"></i></span></button>
 				<button aria-label="Album" class="btn album-view-btn menu-separator" href="#library-panel"><i class="fas fa-th"></i> Album<span class="pane"><i class="fal fa-check"></i></span></button>
+				<button aria-label="Clear Filter" class="btn filter-clear menu-separator"><i class="fas fa-undo"></i> Clear Filter</button>
 				<button aria-label="Clear Library cache" class="btn clear-libcache-btn menu-separator hide" data-toggle="modal" href="#clear-libcache"><i class="far fa-trash"></i> Clear Library cache</button>
 				<button aria-label="All Music" class="btn view-all no-icon" data-cmd="allmusic">All Music<span><i class="fal fa-check"></i></span></button>
 				<button aria-label="Recently Added" class="btn view-recents no-icon" data-cmd="recentmusic">Recently Added<span><i class="fal fa-check"></i></span></button>
@@ -438,23 +439,23 @@
 
 	<div id="context-menu-lib-item" class="context-menu-lib">
 		<ul class="dropdown-menu" role="menu">
-			<!--li class="context-menu menu-separator"><a href="#notarget" data-cmd="one_touch_action"><i class="fal fa-forward sx"></i> One touch action</a></li-->
-			<li><a href="#notarget" data-cmd="add_item"><i class="fal fa-plus sx"></i> Add</a></li>
+			<!-- li class="context-menu menu-separator"><a href="#notarget" data-cmd="one_touch_action"><i class="fal fa-forward sx"></i> One touch action</a></li> -->
 			<li><a href="#notarget" data-cmd="play_item"><i class="fal fa-play sx"></i> Play</a></li>
-			<li><a href="#notarget" data-cmd="add_item_next"><i class="fal fa-plus-circle sx"></i> Add next</a></li>
 			<li><a href="#notarget" data-cmd="play_item_next"><i class="fal fa-play-circle sx"></i> Play next</a></li>
-			<li><a href="#notarget" data-cmd="clear_play_item"><i class="fal fa-chevron-square-right sx"></i> Clear/Play</a></li>
+			<li><a href="#notarget" data-cmd="add_item"><i class="fal fa-plus sx"></i> Add</a></li>
+			<li><a href="#notarget" data-cmd="add_item_next"><i class="fal fa-plus-circle sx"></i> Add next</a></li>
+			<li class="menu-separator"><a href="#notarget" data-cmd="clear_play_item"><i class="fal fa-chevron-square-right sx"></i> Clear/Play</a></li>
 			<li><a href="#notarget" data-cmd="track_info_lib"><i class="fal fa-music sx"></i> Track info</a></li>
 		</ul>
 	</div>
 
 	<div id="context-menu-lib-album" class="context-menu-lib">
 		<ul class="dropdown-menu" role="menu">
-			<!--li id="one-touch-action-li" class="context-menu menu-separator"><a href="#notarget" data-cmd="one_touch_action"><i class="fal fa-forward sx"></i> One touch action</a></li-->
-			<li><a href="#notarget" data-cmd="add_group"><i class="fal fa-plus sx"></i> Add</a></li>
+			<!-- li id="one-touch-action-li" class="context-menu menu-separator"><a href="#notarget" data-cmd="one_touch_action"><i class="fal fa-forward sx"></i> One touch action</a></li -->
 			<li><a href="#notarget" data-cmd="play_group"><i class="fal fa-play sx"></i> Play</a></li>
-			<li><a href="#notarget" data-cmd="add_group_next"><i class="fal fa-plus-circle sx"></i> Add next</a></li>
 			<li><a href="#notarget" data-cmd="play_group_next"><i class="fal fa-play-circle sx"></i> Play next</a></li>
+			<li><a href="#notarget" data-cmd="add_group"><i class="fal fa-plus sx"></i> Add</a></li>
+			<li><a href="#notarget" data-cmd="add_group_next"><i class="fal fa-plus-circle sx"></i> Add next</a></li>
 			<li><a href="#notarget" data-cmd="clear_play_group"><i class="fal fa-chevron-square-right sx"></i> Clear/Play</a></li>
 			<li><a id="tracklist-toggle" href="#notarget" data-cmd="tracklist"><i class="fal fa-list sx"></i> Show tracks</a></li>
 		</ul>


### PR DESCRIPTION
This shows a 'Clear Filter' menu item when a filter is active, selecting it clears the filter and hides the menu item.

Also:

#1 adds fa-undo for use with the new menu item

#2 don't need a conditional for menu-header output now, duh

#3 clears search reset button in filterhelp()

#4 !f by itself no longer clears the filter, by happenstance it shows the last filter which is kind of cool so I left it
