### PR TITLE
Misc css changes + appearance dialog disclosure triangles

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -43,16 +43,16 @@ a.btn.btn-medium.btn-primary {font-size:16px;}
 /* general */
 #modal-backdrop{position:fixed;opacity:1;top:0;right:0;bottom:0;left:0;z-index:10000;background-color:var(--modalbkdr);backdrop-filter:blur(5px);-webkit-backdrop-filter:blur(5px);}
 #modal-backdrop.fade{opacity:0;}
-.modal{position:fixed;top:0;top:env(safe-area-inset-top);left:50%;z-index:10001;width:40%;min-width:560px;font-size:1rem;opacity:.9;background-color:inherit;border:none;margin-left:0;border-radius:.4em;box-shadow:0 3px 7px rgba(0, 0, 0, 0.3);background-clip:padding-box;outline:none;transform:translate(-50%,0%);-webkit-overflow-scrolling:touch;} /* 6.4.1 no font size */
+.modal{position:fixed;top:0;top:env(safe-area-inset-top);left:50%;z-index:10001;width:40%;min-width:560px;font-size:1rem;background-color:inherit;border:none;margin-left:0;outline:none;transform:translate(-50%,0%);-webkit-overflow-scrolling:touch;} /* 6.4.1 no font size */
 .modal h4 {font-size:1.25em;}
-.modal-header{padding:1em 1em 1.5em 1em;border-bottom:none;}
+.modal-header{padding:1rem;border-bottom:none;}
 .modal-header .close{margin:0px 0px 0px 0px;color:inherit;position:absolute;right:5px;top:3px;padding:5px;opacity:0.05;}
-.modal-header h3{margin:0;line-height:normal;color:inherit;font-size:1.4em;text-transform:capitalize;text-align:center;}
-.modal-body{position:relative;overflow-y:auto;max-height:calc(100vh - 10.5rem - env(safe-area-inset-bottom));padding:0 1.5rem;color:inherit;-webkit-user-select:auto;} /* 6.4.1 no px */
+.modal-header h3{margin:0;line-height:normal;color:inherit;font-size:1.4rem;text-transform:capitalize;text-align:center;}
+.modal-body{position:relative;overflow-y:auto;overflow-x:hidden;max-height:75vh;padding:0 1.5rem;color:inherit;-webkit-user-select:auto;} /* 6.4.1 no px */
 .modal-sm2 {width:30%;min-width:560px;} /* for the confirmation modals */
 .modal-sm2 .modal-body {padding:0 1em;}
 .modal-form{margin-bottom:0;}
-.modal-footer{padding:1.75rem 0 1rem 0;margin-bottom:0;text-align:right;background-color:transparent;border-top:1px solid rgba(128,128,128,0.3);-webkit-border-radius:0 0 6px 6px;-moz-border-radius:0 0 6px 6px;border-radius:0 0 6px 6px;-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none;}
+.modal-footer{padding:1.5rem 0;margin:0;text-align:center;background-color:transparent;box-shadow:none;border:none;}
 .modal-footer:before,.modal-footer:after{display:table;content:"";line-height:0;}
 .modal-footer:after{clear:both;}
 .modal-footer .btn+.btn{margin-left:0px;margin-bottom:0;/*float:right;*/}
@@ -78,7 +78,7 @@ h6 {font-size: large;font-weight: 500;text-transform: capitalize;text-align: cen
 #playback-panel.newui #playback-queue, #playback-panel.cv #playback-queue {position:relative;width:44%;left:-10000px;;margin:0 auto;}
 #playback-panel.newui #playback-cover, #playback-panel.cv #playback-cover {padding:0;width:33vw;position:absolute;left:50%;transform:translate(-50%);}
 #playback-panel.newui #playback-controls, #playback-panel.cv #playback-controls {margin-left:0px;width:100%;height:calc(100vh - 2.75rem);position:absolute;}
-.btn-group.bootstrap-select .btn {padding:2px 12px;margin-bottom:5px;}
+.btn-group.bootstrap-select .btn {padding:2px 12px;}
 #players, #configure {margin-left:auto;margin-right:auto;text-align:center;}
 #players .btn, #configure .btn {background:var(--config_modal_btn_bg);}
 #players ul > li, #configure ul > li {display:inline-flex;padding:.75em;}
@@ -99,9 +99,13 @@ li.modal-dropdown-text:focus {color:#eee;}
 .help-block, .help-inline {/*color:var(--textvariant);*/color:inherit;}
 .help-block-modal {margin:0 !important;}
 /* dropdown menus */
-#menu-top .dropdown-menu, .viewswitch .dropdown-menu {min-width:14rem;} /* Make this one a bit wider */
-.dropdown-menu > li > a {line-height:2.75em;margin:0;padding:0 .5em;background:none;color:var(--adapttext);font-size:1.1rem;white-space:nowrap;}
-.dropdown-menu {float:right;position:absolute;min-width:12.5rem;left:auto;border:none;list-style:none outside none;background-color:var(--adaptmbg);box-shadow:0px 4px 10px rgba(0, 0, 0, 0.4);border-radius:.5em;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);z-index:1000;white-space:normal;}
+#menu-top .dropdown-menu, .viewswitch .dropdown-menu {min-width:15rem;} /* Make this one a bit wider */
+#current-tab, #menu-header {font-size:1.15rem;}
+.dropdown-menu > li > a, .viewswitch .btn {text-align:left;line-height:2.5em;width:100%;margin:0;padding:0 .5rem;background:none;color:var(--adapttext);font-size:1.1em;font-family:system-ui, "Avenir Next", "Lato";white-space:nowrap;border-radius:0;}
+body.no-touch .dropdown-menu > li > a {font-size:1rem;line-height:2em}
+.dropdown-menu > li:last-child a, .viewswitch .btn:last-child {padding-bottom:.35em;}
+.dropdown-menu > li:first-child a, .viewswitch .btn:first-child {padding-top:.35em;}
+.dropdown-menu {float:right;position:absolute;min-width:13.5rem;left:auto;border:none;list-style:none outside none;background-color:var(--adaptmbg);box-shadow:0px 4px 10px rgba(0, 0, 0, 0.4);border-radius:.5em;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);z-index:1000;white-space:normal;padding:0;}
 .dropdown-menu.open {padding:0;margin:0;}
 .bootstrap-select .dropdown-menu {background-color:transparent;}
 .btn-group.open.bootstrap-select .btn.dropdown-toggle {background-color:rgba(128,128,128,0.3);box-shadow:none;border-radius:4px;}
@@ -110,13 +114,12 @@ li.modal-dropdown-text:focus {color:#eee;}
 .container2 .dropdown-menu.inner {background-color:rgba(50,50,50,0.95) !important;color:#eee !important;-webkit-overflow-scrolling:touch;} /* config theme menu bg */
 /* modal test */
 .modal {min-width:55vw;top:0;top:env(safe-area-inset-top);transition:none;background-color:transparent;color:var(--adapttext);box-shadow:none;}
-.modal .control-label {float:left;padding-top:0;line-height:24px;}
+.modal .control-label {float:left;padding-top:0;}
 .modal .btn.btn-primary.btn-small, .modal .btn.btn-primary.btn-medium {background:var(--btnshade4);}
-.modal .controls input {min-height:26px !important;}
+.modal .controls input {min-height:26px !important;margin:0;}
 .modal .dropdown-menu.inner {background-color:var(--adaptmbg);color:var(--adapttext);}
 .modal .modal-dropdown-text {color:inherit;}
-.modal .bootstrap-select .btn, #preferences-modal input, #clockradio-modal input, #radio-manager-modal input, #editstation-modal input, #newstation-modal input {border: 1px solid var(--textvariant);}
-.modal .modal-footer {border-top: none;text-align:center;}
+.modal .bootstrap-select .btn, #preferences-modal input, #clockradio-modal input, #radio-manager-modal input, #editstation-modal input, #newstation-modal input {border:none;background-color:var(--btnshade2);/*border: 1px solid var(--textvariant);*/}
 .modal-footer .btn {border-radius:5rem;background-color:var(--btnshade4);margin:.2em 1em;width:10em;color:inherit;}
 .modal-footer .btn-primary {border-radius:5rem;float:none;border:1px solid var(--textvariant);background-color:var(--btnshade4);color:var(--adapttext);}
 .modal.fade {top:0;top:env(safe-area-inset-top);transition:none;}
@@ -129,7 +132,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 .checkbox-ctl {margin:.25em 0 .5em .25em !important;}
 .input-height-x {height:1.65em !important;}
 /* forms */
-.modal-body .form-horizontal .controls {margin-left:52%}
+.modal-body .form-horizontal .controls {margin-left:52%;margin-bottom:.5rem;}
 .modal-body .form-horizontal .control-label {width:48%;text-align:right;margin-top:0;}
 /* update package txt ol */
 #update-pkg-ol {font-family:courier new;}
@@ -163,7 +166,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#top-columns {left:-50%;}
 	#lib-genre-header, #lib-genre {left:0%;width:50%;}
 	.lib-entry {padding: 0 .25em;}
-	.lib-entry-song {font-size:.95em;}
+	/*.lib-entry-song {font-size:1em;}*/
 	#lib-file {left:0%;width:100%;padding-left:0px;}
 
 	#tagview-text-cover {font-size:1rem;width:75px;height:75px;padding:0;margin:.25em;}
@@ -173,7 +176,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#lib-meta-summary {width:calc(100% - 75px - 1em);line-height:normal;font-size:.9em;margin:.5em 0;float:right;}
 
 	#songsList {margin:.25em !important;}
-	#lib-file .songname {overflow:hidden;float:left;width:calc(50% - 15px);height:auto;margin-left:5px;}
+	#lib-file .songname {overflow:hidden;float:left;width:calc(49% - 15px);height:auto;margin-left:5px;}
 	#lib-file .songtime {float:left;width:10%;left:50%;margin-left:5px;}
 	#lib-file .songartist {float:left;width:calc(40% - 25px);overflow:hidden;left:60%;margin-left:5px;}
 	#lib-file .songyear {display:none;}
@@ -226,9 +229,11 @@ li.modal-dropdown-text:focus {color:#eee;}
 /* smaller portrait for small screens */
 @media (max-width:479px) and (orientation:portrait) {
 	/*.dropdown-menu {min-width:180px;}*/
-	.dropdown-menu > li > a, .viewswitch .btn, #lib-album-search input {/*font-size:1.25rem;*/}
+	#menu-top .dropdown-menu, .viewswitch .dropdown-menu {min-width:16rem;} /* Make this one a bit wider */
+	#context-menu-playback .dropdown-menu {min-width:15rem;} /* Make this one a bit wider */
+	.dropdown-menu > li > a, .viewswitch .btn, #lib-album-search input {font-size:1.25rem;line-height:2.75em;}
 	#playback-panel, #content {position:relative;}
-	.modal-body{max-height:calc(100vh - 13.5rem - env(safe-area-inset-bottom));padding:0 .5rem;}
+	.modal-body{padding:0 .5rem;max-height:80vh;}
 	.modal-footer .btn {width:40%;}
 	.modal .h5 {width:42%;}
 	.modal-body .form-horizontal .control-label {width:42%;}
@@ -241,10 +246,10 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#togglebtns .btn-group {width:unset;}
 	.tab-content {height:unset;}
 	.covers {width:100%;}
-	/*#menu-top .dropdown-menu > li > a {font-size:1.3rem;}*/
 	#menu-bottom, #playbar {height:8.5rem;}
 	#playbar-cover {height:8.5rem;width:8.5rem;position:absolute;-webkit-mask-image: linear-gradient(to right, rgba(0,0,0,.5), rgba(0,0,0,0) 100%);}
-	#songsList {padding-bottom:calc(10em + env(safe-area-inset-bottom));}
+	#playbar-controls .prev {display:none;}
+	#songsList {padding-bottom:8.5rem;}
 	.lib-artistname-meta, .lib-albumyear-meta, .lib-numtracks-meta {font-size:calc(0.65em + 1vmin);}
 	#playbtns .btn {font-size:3em;padding:.5em 1em;}
 	.dbtn {display:inline-block;font-size:3em;padding:0 1rem;width:25%;line-height:20px;vertical-align:middle;}
@@ -255,6 +260,8 @@ li.modal-dropdown-text:focus {color:#eee;}
 	.playlist .pl-action, .playlist .db-action a {padding:.4em 1.25em 1em 0;margin-left:1.25em!important;}
 	.ui-pnotify {top:40% !important;}
 	#lib-albumcover {left:0;}
+	#lib-meta-summary {line-height:1.75rem;font-size:1em;margin:.25em 0 0 0;float:right;}
+	.lib-numtracks-meta {margin-top:0;}
 	/* ellipsis madness */
 	#artistsList li, #genresList li, #albumsList li {max-width:calc(50vw - 2.3rem);min-width:33vw;}
 	/* stuff */
@@ -279,12 +286,12 @@ li.modal-dropdown-text:focus {color:#eee;}
 	/* playbar */
 	#playbar-div {display:block;}
 	#playbar-mtime {display:flex;position:relative;}
-	#playbar-title {text-align:left;top:0;margin-left:1em;width:53vw;height:auto;position:relative;transform:none;font-size:1.4em;line-height:2.2em;left:0;padding:0;text-shadow:0 0 1px var(--btnbarback);}
+	#playbar-title {text-align:left;top:0;margin-left:1em;width:67vw;height:auto;position:relative;transform:none;font-size:1.4em;line-height:2.2em;left:0;padding:0;text-shadow:0 0 1px var(--btnbarback);}
 	#playbar-controls {right:.25rem;transform:none;top:0;left:unset;opacity:1;}
 	#playbar-time, #playbar-total {line-height:1.5rem;}
 	#playbar-controls .btn {padding:.5em;font-size:2.5rem;-webkit-tap-highlight-color:transparent;}
 	#playbar-toggles {position:absolute;right:1rem;right:calc(env(safe-area-inset-right) + 1rem);bottom:.4em;height:unset;width:unset;top:unset;left:unset;transform:none;}
-	#playbar-toggles .btn {transition:none;border-radius:50%;padding:.5rem .7rem;margin-bottom:.5rem;width:unset;height:unset;line-height:11px;}
+	#playbar-toggles .btn {transition:none;border-radius:50%;padding:1rem .7rem;margin-bottom:0;width:unset;height:unset;line-height:11px;}
 	#playbar-timeline {display:none;}
 	#playbar-toggles .coverview {display:none;}
 	#playbar-toggles .ralbum {display:inline-block;}
@@ -369,6 +376,10 @@ li.modal-dropdown-text:focus {color:#eee;}
 @media (max-height:640px) and (orientation:portrait)  {
 	img.coverart {width:45vh;}
 	#playback-firstuse-help {height:45vh;width:45vh;}
+}
+@media (max-width:360px) {
+	.modal-body .form-horizontal .control-label {width:38%;}
+	.modal-body .form-horizontal .controls {margin-left:40%;}
 }
 /* iPhone5 portrait */
 @media (max-height:568px) and (max-width:320px) {
@@ -528,7 +539,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 #pl-controls {display:none;}
 .clockradio-on-m {color:#dddddd;font-size:16.5px;}
 .clockradio-off-m {color:#7f8c8d;font-size:16.5px;}
-.info-toggle {text-decoration:none;margin-left:5px;font-size:18px;line-height:normal;}
+.info-toggle {text-decoration:none;position:relative;margin:0;top:3px;left:2px;font-size:16px;}
 .set-button {margin: 0 4px 0 8px;} /* for system config page 'set' buttons */
 #quickhelp-icon-lists ul {list-style:none;margin-left:0;}
 #quickhelp-icon-lists p {margin-left:1.5em;}

--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -101,8 +101,8 @@ li.modal-dropdown-text:focus {color:#eee;}
 /* dropdown menus */
 #menu-top .dropdown-menu, .viewswitch .dropdown-menu {min-width:15rem;} /* Make this one a bit wider */
 #current-tab, #menu-header {font-size:1.15rem;}
-.dropdown-menu > li > a, .viewswitch .btn {text-align:left;line-height:2.5em;width:100%;margin:0;padding:0 .5rem;background:none;color:var(--adapttext);font-size:1.1em;font-family:system-ui, "Avenir Next", "Lato";white-space:nowrap;border-radius:0;}
-body.no-touch .dropdown-menu > li > a {font-size:1rem;line-height:2em}
+.dropdown-menu > li > a, .viewswitch .btn {text-align:left;line-height:2.75rem;width:100%;margin:0;padding:0 .5rem;background:none;color:var(--adapttext);font-size:1.1em;font-family:system-ui, "Avenir Next", "Lato";white-space:nowrap;border-radius:0;}
+/*body.no-touch .dropdown-menu > li > a {font-size:1rem;line-height:2em}*/
 .dropdown-menu > li:last-child a, .viewswitch .btn:last-child {padding-bottom:.35em;}
 .dropdown-menu > li:first-child a, .viewswitch .btn:first-child {padding-top:.35em;}
 .dropdown-menu {float:right;position:absolute;min-width:13.5rem;left:auto;border:none;list-style:none outside none;background-color:var(--adaptmbg);box-shadow:0px 4px 10px rgba(0, 0, 0, 0.4);border-radius:.5em;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);z-index:1000;white-space:normal;padding:0;}

--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -100,8 +100,8 @@ li.modal-dropdown-text:focus {color:#eee;}
 .help-block-modal {margin:0 !important;}
 /* dropdown menus */
 #menu-top .dropdown-menu, .viewswitch .dropdown-menu {min-width:15rem;} /* Make this one a bit wider */
-#current-tab, #menu-header {font-size:1.15rem;}
-.dropdown-menu > li > a, .viewswitch .btn {text-align:left;line-height:2.75rem;width:100%;margin:0;padding:0 .5rem;background:none;color:var(--adapttext);font-size:1.1em;font-family:system-ui, "Avenir Next", "Lato";white-space:nowrap;border-radius:0;}
+#current-tab, #menu-header {font-size:1em;}
+.dropdown-menu > li > a, .viewswitch .btn {text-align:left;line-height:2.75rem;margin:0;padding:0 .5em;background:none;color:var(--adapttext);font-size:1em;font-family:system-ui, "Avenir Next", "Lato";white-space:nowrap;border-radius:0;}
 /*body.no-touch .dropdown-menu > li > a {font-size:1rem;line-height:2em}*/
 .dropdown-menu > li:last-child a, .viewswitch .btn:last-child {padding-bottom:.35em;}
 .dropdown-menu > li:first-child a, .viewswitch .btn:first-child {padding-top:.35em;}
@@ -221,7 +221,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	.btnlist.btnlist-top.btnlist-top-lib {width:31%;}
 	.form-horizontal .control-label {float:left;width:30%;padding-top:4px;text-align:right;}
 	.bootstrap-select:not([class*="span"]) {width:140px;}
-	.btnlist-top-db button, .btnlist-top-ra button {font-size:1.5rem;width:3.1rem;}
+	.btnlist-top-db button, .btnlist-top-ra button {font-size:1.2rem;width:3.1rem;}
 	#playbar-hd-badge {margin-top:.6em;}
 	#playbar-volume-level {font-size:1.2rem;vertical-align:initial}
 	#playbar-volume-popup-btn {width:initial!important;}
@@ -231,7 +231,8 @@ li.modal-dropdown-text:focus {color:#eee;}
 	/*.dropdown-menu {min-width:180px;}*/
 	#menu-top .dropdown-menu, .viewswitch .dropdown-menu {min-width:16rem;} /* Make this one a bit wider */
 	#context-menu-playback .dropdown-menu {min-width:15rem;} /* Make this one a bit wider */
-	.dropdown-menu > li > a, .viewswitch .btn, #lib-album-search input {font-size:1.25rem;line-height:2.75em;}
+	#lib-album-search input, #current-tab, #menu-header {font-size:1.11rem;}
+	.dropdown-menu > li > a, .viewswitch .btn, #lib-album-search input {font-size:1.11rem;line-height:2.75em;}
 	#playback-panel, #content {position:relative;}
 	.modal-body{padding:0 .5rem;max-height:80vh;}
 	.modal-footer .btn {width:40%;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -185,14 +185,14 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #coverart-url {position:relative;}
 #container-browse {width:100%;padding:0;top:2.75rem;top:calc(2.75rem + env(safe-area-inset-top));overflow:hidden;position:absolute;}
 #container-radio {width:100%;padding:0;top:2.75rem;top:calc(2.75rem + env(safe-area-inset-top));overflow:hidden;position:absolute;}
-#database, #database-radio {overflow:auto;position:relative;width:100%;top:.25em;bottom:0px;height:calc(100vh - 4.9em);-webkit-overflow-scrolling:touch;}
+#database, #database-radio {overflow:auto;position:relative;width:100%;top:.5em;bottom:0px;height:calc(100vh - 5.15em);-webkit-overflow-scrolling:touch;}
 .input-append input::placeholder {color:var(--textvariant);}
 #pl-filter::placeholder {color:var(--textvariant);}
 #lib-album-filter::placeholder {color:var(--textvariant);font-size:.9em;}
 
 #playlist, #database, #database-radio {padding:0;background:none;}
 .playlist, .cv-playlist, .database, .database-radio {display:block;margin:0;padding:0;list-style:none;counter-reset:item;word-break: break-word;}
-.database {padding:0 0 12rem 0;width:calc(100vw - 2.5em);margin-left:1.75rem;overflow-x:hidden;}
+.database {padding:0 0 12rem 0;width:calc(100vw - 2.5em);margin-left:1.75rem;overflow-x:hidden;position:relative;}
 .playlist .cv-playlist {padding:0 1em 4em 0;}
 #database-radio {height:calc(100vh - 2.75em);}
 .database-radio {text-align:center;padding:0 0 14rem 0;}
@@ -232,7 +232,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .playlist .pl-entry, .cv-playlist .pl-entry {padding:0px;}
 .playlist .pl-thumb, .cv-playlist .pl-thumb {float:left;width:2.4em;height:2.4em;margin-left:1.2vmin!important;margin-right:1.2vmin;border-radius:.2em;filter:brightness(80%);overflow:hidden;}
 .database .db-entry {margin-left:2.5em;padding:1em 0;max-width:calc(100vw - 10px);overflow:hidden;}
-.database .db-song {padding:.5em 0;}
+.database .db-song {padding:0 0 .5em 0;}
 .database .db-icon {display:block;float:left;height:19px;line-height:19px;width:1.875em;padding:0;color:inherit;}
 .database .db-icon .btn {font-size:1em;padding:1em .4em 1em .4em;}
 .database .db-icon .btn img {margin-top:-.5em;}
@@ -252,13 +252,13 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .database .db-action i {width:2.2rem;}
 .playlist .pl-action, .playlist .db-action a {position:relative;width:4.5em;margin-left:1em;font-weight:normal;text-decoration:none;z-index:3;font-size:.9em;line-height:.625em;padding:.318em 0;float:right;}
 .cv-playlist .pl-action, .cv-playlist .db-action a {position:relative;width:4.5em;margin-left:1em!important;font-weight:normal;text-decoration:none;z-index:3;font-size:.9em;line-height:.625em;padding:.318em 0;float:right;}
-#db-search-results {font-style:italic;float:left;padding:1em .5em 0em .5em;font-size:1em;display:none;}
+#db-search-results {font-style:italic;padding:.5em;font-size:1em;display:none;top:0;right:0;position:absolute;}
 #pl-saveName, #pl-favName {width:85%;}
 .input-append, .input-prepend {margin-bottom:0em;font-size:1em;}
 .btnlist {position:fixed;left:0;right:0;display:block;width:auto;height:2.5em;padding:0;background:none;-webkit-border-radius:0px;-moz-border-radius:0px;border-radius:0px;z-index:999;}
 .btnlist:focus {outline:none;}
 .btnlist.pl-prevPage, .btnlist.db-prevPage, .btnlist.pl-firstPage, .btnlist.db-firstPage {padding:0 .3em;}
-.btnlist-top-db, .btnlist-top-ra {position:relative;background-color:rgba(128,128,128,.1);;color:var(--adapttext);border-radius:.25em;border:1px solid var(--btnshade);width:calc(100vw - 2.5em);height:2.1rem;padding:0 !important;margin:0 auto;}
+.btnlist-top-db, .btnlist-top-ra {position:relative;background-color:rgba(128,128,128,.1);;color:var(--adapttext);border-radius:.25em;border:1px solid var(--btnshade);width:calc(100vw - 2.5em);height:2.4rem;padding:0 !important;margin:0 auto;}
 #pl-filter, #lib-album-filter, #ra-filter {padding:0}
 #db-browse .dropdown {display:block;height:40px;line-height:40px;margin:0 20px 0 0;}
 #db-browse .dropdown-menu {background:transparent;border:none;border-radius:0px;box-shadow:none;list-style:none outside none;margin:0;/*min-width:100px;*/padding:0;border-top:1px solid #000;border-left:1px solid #000;border-right:1px solid #000;position:absolute;top:100%;z-index:1000;}
@@ -272,8 +272,8 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #pl-search {left:1rem}
 #savepl-modal, #setfav-modal .modal-body {padding:1em .25em 0 .25em;}
 #pl-save {display:block;float:left;margin-right:0;margin-left:0;z-index:1001;width:100%;text-align:center;}
-#pl-search input, #ra-search input, #lib-album-search input {margin:0;border:none;box-shadow:none;min-height:initial;height:2.75rem;font-size:1rem;padding:0;}
-#ra-search input, #dbfs {margin-left:.5em;padding:0;height:2.1rem;border:none;}
+#pl-search input, #ra-search input, #lib-album-search input {margin:0;border:none;box-shadow:none;min-height:initial;height:2.75rem;font-size:1em;padding:0;}
+#ra-search input, #dbfs {margin-left:.5em;padding:0;height:2.1rem;border:none;font-size:inherit;}
 #searchResetPl {font-size:1rem;top:0;margin-top:.5em;float:left;padding-left:0;}
 #db-browse {margin:0;width:200px;}
 .db-browse-icon {float:left;}
@@ -281,7 +281,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #folder-panel .btn.disabled, #folder-panel .btn[disabled] {background-color:#34495E;color:white;}
 #folder-panel, #radio-panel {width:100%;height:100vh;position:fixed;top:0;overflow:hidden;}
 #library-panel {height:100vh;}
-.btnlist-top-db button, .btnlist-top-ra button {margin:0;line-height:normal;height:2.1rem;width:2.2rem;font-size:1.1rem;border-radius:0;float:left;display:inline-block;padding:.25rem .5rem;border-right: 1px solid var(--btnshade);}
+.btnlist-top-db button, .btnlist-top-ra button {margin:0;line-height:normal;height:2.4rem;width:2.2rem;font-size:1.1rem;border-radius:0;float:left;display:inline-block;padding:.25rem .5rem;border-right: 1px solid var(--btnshade);}
 #reconnect, #restart, #shutdown {position:fixed;top:0;left:0;margin:0;padding:0;text-align:center;width:100%;height:100%;z-index:9999;}
 .reconnect-bg {position:absolute;top:0;left:0;margin:0;padding:0;text-align:center;background-color:var(--modalbkdr);width:100%;height:100%;z-index:9999;}
 .reconnect-btn {position:fixed;padding:.75rem;transform: translate(-50%,-50%);top: 50%;left: 50%;width: 10em;text-transform:uppercase;z-index:9999;font-size:1.25em;cursor:pointer;border-radius:5rem;color:var(--themetext);background-color:var(--btnshade4);}
@@ -293,6 +293,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #searchResetLib {padding:.25em;position:relative;top:50%;transform:translate(0, -50%);font-size:1.2rem;}
 #viewswitch a {color:inherit;}
 .viewswitch div {display:flex;color:var(--adapttext);}
+#viewswitch .btn {width:100%;}
 /*.viewswitch .btn {position:relative;width:100%;line-height:3.45rem;font-size:1.1rem;font-family:inherit;padding:0 0.5rem;background-color:transparent;text-align:left;}*/
 .viewswitch .btn.active {color:inherit;}
 .viewswitch .btn:hover {background-color:var(--accentxta);}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -139,7 +139,7 @@ html {background-color:inherit;}
 #volbtns-2 {z-index:10002;}
 #playbtns .addfav, #playbtns {display:none;}
 #cover-options {display:none;}
-#choose-bgimage, #remove-bgimage, #new-radiologo, #edit-radiologo, #choose-station-pkg, #export-stations {font-size:1em;color:inherit;margin-top:.1em;padding-top:.3em;line-height:1.5em;}
+#choose-bgimage, #remove-bgimage, #new-radiologo, #edit-radiologo, #choose-station-pkg, #export-stations {font-size:1em;color:inherit;margin-top:.1em;padding-top:.3em;}
 #current-bgimage {max-height:calc(1.5rem + 6px);overflow:hidden;max-width:50px;margin:5px 0 0 5px;position:absolute;display:inline-block;border-radius:3px;}
 #countdown {margin:0 auto;height:17vw;width:17vw;}
 #countdown div {margin:0 auto;} /* needed to center the knob */
@@ -166,7 +166,7 @@ html {background-color:inherit;}
 .dropdown-menu > li > a:hover, .dropdown-menu > li > a:active, .dropdown-menu > li > a:focus {background-color:var(--accentxta);background-image:none;}
 #menu-top a:hover, #menu-top a:focus, #context-menus .dropdown-menu a:hover, #context-menus .dropdown-menu a:focus {text-decoration:none;outline:none;}
 #menu-top #config-back i {font-size:1.35rem;position:relative;top:1px;}
-#menu-settings {color:transparent;position:relative;bottom:.3rem;right:0;line-height:2.75rem;height:1.9rem;z-index:1001;padding:0 1.5rem;border-radius:0;border-bottom:1px solid transparent;font-size:1.7rem;font-weight:500;margin-right:.1rem;}
+#menu-settings {color:transparent;position:relative;right:0;line-height:3rem;height:2.75rem;z-index:1001;padding:0 1.5rem;border-radius:0;border-bottom:1px solid transparent;font-size:1.7rem;font-weight:500;margin-right:.1rem;}
 #mbrand, #mblur {font-weight:600;position:absolute;left:50%;top:-.25rem;}
 #mbrand {color:var(--adapttext);text-shadow: 0 0 0.25rem rgba(0,0,0,0.5);transform:translate(-50%);}
 #mblur {letter-spacing:-.56em;color:transparent;text-shadow:0 0 2px var(--btnshade4);transform:translate(calc(-50% - .28em));opacity:.75;}
@@ -188,6 +188,8 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #database, #database-radio {overflow:auto;position:relative;width:100%;top:.25em;bottom:0px;height:calc(100vh - 4.9em);-webkit-overflow-scrolling:touch;}
 .input-append input::placeholder {color:var(--textvariant);}
 #pl-filter::placeholder {color:var(--textvariant);}
+#lib-album-filter::placeholder {color:var(--textvariant);font-size:.9em;}
+
 #playlist, #database, #database-radio {padding:0;background:none;}
 .playlist, .cv-playlist, .database, .database-radio {display:block;margin:0;padding:0;list-style:none;counter-reset:item;word-break: break-word;}
 .database {padding:0 0 12rem 0;width:calc(100vw - 2.5em);margin-left:1.75rem;overflow-x:hidden;}
@@ -208,7 +210,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #genresList li, #artistsList li, #albumsList li {width:calc(100% - (var(--sbw) + 1.17rem));}
 /**/
 #top-columns.nogenre #albumsList li, #top-columns.nogenre #artistsList li {max-width:calc(50vw - 2.3rem);}
-#albumsList .lib-entry img {width:3rem;margin:0 .35em 0 .15em;}
+#albumsList .lib-entry img {width:3rem;margin:0 .35em 0 .15em;height:3rem;object-fit:contain;}
 #albumsList li {padding-top:.4em;padding-bottom:.4em;}
 #albumsList .tag-cover-text {display:inline-block;vertical-align:middle;transform:translate(0, .2em);min-width:50%;max-width:calc(100% - 3.6rem);/*line-height:1.6rem;*/}
 #library-panel .lib-entry span {max-width:100%;display:inline;}
@@ -228,7 +230,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .playlist li.paused:before, .cv-playlist li.paused:before {color:unset!important;background:unset;}
 .playlist .pll1, .cv-playlist .pll1 {font-weight:400;opacity:1;text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
 .playlist .pl-entry, .cv-playlist .pl-entry {padding:0px;}
-.playlist .pl-thumb, .cv-playlist .pl-thumb {float: left; width: 2.4em; margin-left: 1.2vmin!important; margin-right: 1.2vmin;border-radius:.2em;filter:brightness(80%);overflow:hidden;}
+.playlist .pl-thumb, .cv-playlist .pl-thumb {float:left;width:2.4em;height:2.4em;margin-left:1.2vmin!important;margin-right:1.2vmin;border-radius:.2em;filter:brightness(80%);overflow:hidden;}
 .database .db-entry {margin-left:2.5em;padding:1em 0;max-width:calc(100vw - 10px);overflow:hidden;}
 .database .db-song {padding:.5em 0;}
 .database .db-icon {display:block;float:left;height:19px;line-height:19px;width:1.875em;padding:0;color:inherit;}
@@ -265,7 +267,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .btnlist a {font-size:1em;text-decoration:none;color:inherit;}
 #pl-search, #lib-album-search, #ra-search {display:block;float:left;margin:0;z-index:1001;position:relative;}
 #lib-album-search {top:50%; transform:translate(0, -50%);width:8rem;}
-#lib-album-filter {width:8rem;}
+#lib-album-filter {width:11.5rem;}
 /*#pl-search {top:50%; transform:translate(0, -50%);width:11rem;}*/
 #pl-search {left:1rem}
 #savepl-modal, #setfav-modal .modal-body {padding:1em .25em 0 .25em;}
@@ -291,7 +293,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #searchResetLib {padding:.25em;position:relative;top:50%;transform:translate(0, -50%);font-size:1.2rem;}
 #viewswitch a {color:inherit;}
 .viewswitch div {display:flex;color:var(--adapttext);}
-.viewswitch .btn {position:relative;width:100%;line-height:2.75rem;font-size:1.1rem;font-family:inherit;padding:0 0.5rem;background-color:transparent;text-align:left;}
+/*.viewswitch .btn {position:relative;width:100%;line-height:3.45rem;font-size:1.1rem;font-family:inherit;padding:0 0.5rem;background-color:transparent;text-align:left;}*/
 .viewswitch .btn.active {color:inherit;}
 .viewswitch .btn:hover {background-color:var(--accentxta);}
 #viewswitch-search:hover {background-color:inherit;}
@@ -326,9 +328,13 @@ input.input-block-level {display:block;height:41px;line-height:41px;padding:8px 
 .modal .h5 {text-transform:uppercase;font-size:1em;margin-top:0px;margin-bottom:1em;font-weight:600;position:relative;text-align:right;display:inline-block;width:48%;}
 .dtclose, .dtopen {font-weight:600;font-size:1.2em;}
 .accordian:hover {cursor:pointer;}
+.modal .accordian .h5:after {content:"▸";margin-left:.5em;font-size:1.3rem;}
+.modal .accordian.active .h5:after {content:"▾";font-size:1.3rem;}
+.modal .accordian div.kontrol {display:none;}
+.modal .accordian.active div.kontrol {display:block;}
 #preferences-modal div.accordian .control-group {display:none;margin-bottom:1em;}
 #preferences-modal div.accordian.active .control-group {display:block;}
-#preference-modal div.accordian .dtopen {display:none;}
+#preferences-modal div.accordian .dtopen {display:none;}
 .bgimglabel {margin-top:5px;} /* gross but what r u gonna do */
 .modal label, .modal .controls {font-size:1em;}
 .control-label {margin-bottom:0px;font-size:inherit;}
@@ -352,9 +358,9 @@ code, pre {background-color:inherit;color:inherit;border:none;font-size:.8em;}
 #lib-artist-header {left:33.33%;border-top:1px solid var(--btnshade);border-bottom:1px solid var(--btnshade);}
 #lib-album-header {left:66.66%;border-top:1px solid var(--btnshade);border-bottom:1px solid var(--btnshade);border-left:1px solid var(--btnshade);}
 .lib-heading {text-transform:uppercase;font-weight:500;padding-top:3px;font-size:.8em;background:rgba(128,128,128,.1);text-align:center;}
-#lib-genre {top:calc(1.5em + 1px);height:calc(100% - 1.5em);border-right:1px solid var(--btnshade);-webkit-overflow-scrolling:touch;box-sizing:border-box;}
-#lib-artist {top:calc(1.5em + 1px);height:calc(100% - 1.5em);left:33.33%;margin-left:0px;-webkit-overflow-scrolling:touch;box-sizing:border-box;}
-#lib-album {top:calc(1.5em + 1px);height:calc(100% - 1.5em);left:66.66%;border-left:1px solid var(--btnshade);margin-left:0px;-webkit-overflow-scrolling:touch;box-sizing:border-box;}
+#lib-genre, #lib-artist, #lib-album {top:calc(1.75em + 1px);height:calc(100% - 2em);border-right:1px solid var(--btnshade);-webkit-overflow-scrolling:touch;box-sizing:border-box;}
+#lib-artist {left:33.33%;}
+#lib-album {left:66.66%;}
 #lib-file {overflow-y:scroll;overflow-x:hidden;margin:1px 0 0 0;height:100%;width:100%;-webkit-overflow-scrolling:touch;}
 #lib-coverart-meta-area {width:20vw;line-height:normal;padding:0;float:left;position:fixed;}
 #lib-coverart-img {margin:.5em .25em 0 .5em;}
@@ -371,10 +377,10 @@ img.lib-artistart {float:left;width:calc(20vw - 1rem);height: calc(20vw - 1rem);
 /* index improvements */
 #lib-content ul {display:table;overflow-x:hidden;word-break:break-word;}
 #lib-content li {display:block;position:relative;cursor:pointer;line-height:1.25em;}
-#songsList {padding-bottom:calc(10em + env(safe-area-inset-bottom));margin:.5em .25em;width:calc(100% - var(--sbw));}
+#songsList {padding-bottom:5.3rem;margin:.5em .25em;width:calc(100% - var(--sbw));}
 /**/
 #lib-genre li, #lib-artist li {padding: 0.4em 0.5em;}
-#lib-content #lib-file li {;padding:.15em 0 .5em 0;}
+#lib-content #lib-file li {;padding:.75em 0 .85em 0;}
 #lib-content #lib-file li:nth-child(odd) {background:rgba(128,128,128,0.1);}
 #lib-content #lib-file li:nth-child(odd).active {font-weight:600;}
 #lib-content li div.active {color:var(--accentxts);}
@@ -383,7 +389,7 @@ img.lib-artistart {float:left;width:calc(20vw - 1rem);height: calc(20vw - 1rem);
 .lib-entry-song {margin-left:4px;padding-top:4px;line-height:normal;margin-right:26px;}
 .lib-track {cursor:pointer;}
 .lib-disc {margin:0;text-transform:uppercase;display:none;}
-.lib-disc a {font-size:.9em;opacity:.75;}
+.lib-disc a {font-size:1em;opacity:.75;padding:.75em;}
 .lib-album-heading {font-size:.9em;opacity:.75;padding:.75em;margin:0;text-transform:uppercase;background-color:rgba(128,128,128,0.1);box-shadow:0 .04em .025em rgba(0,0,0,0.15);display:none;}
 #songsList .lib-disc a.active {font-weight:700;color:unset;}
 #songsList li.active {font-weight:700;background-color:unset;}
@@ -456,7 +462,7 @@ body.no-touch .cover-menu {opacity:0;}
 input[type="range"].vslide2 {height:10em;width:2.5em;-webkit-appearance: slider-vertical;margin:.5em 0;}
 input[type='range'].vslide2::-webkit-slider-thumb {background:#fff;background-image:'';height:1.25em;width:1.25em;}
 .vslide3 {width:9%;display:inline-block;}
-#menu-bottom {bottom:0;height:4.8rem;width:100%;z-index:9997;background-color:var(--btnbarback);/*border-top:1px solid var(--btnshade2);*/display:none;}
+#menu-bottom {bottom:0;height:5.3rem;width:100%;z-index:9997;background-color:var(--btnbarback);/*border-top:1px solid var(--btnshade2);*/display:none;}
 #menu-bottom .btn:first-child, #menu-bottom .btn:last-child, #menu-bottom .btn.active {border-radius:0;border:none;background-color:transparent;background:transparent;}
 #menu-bottom ul {display:none;color:var(--adapttext);}
 #menu-bottom .btn.active {background-color:transparent;}
@@ -478,11 +484,12 @@ input[type='range'].vslide2::-webkit-slider-thumb {background:#fff;background-im
 .alphabits ul li {display:table-row !important;font-size:.8em;text-transform:uppercase;line-height:normal;font-weight:600;color:var(--textvariant);text-align:center;}
 /**/
 /* playback ellipsis context menu */
-#context-menu-playback .dropdown-menu {min-width:12.5rem;white-space:nowrap;}
-#menu-check-consume, #menu-check-repeat, #menu-check-single {display:none;float:right;color:var(--adapttext);line-height:2.75em;position:absolute;right:.5em;}
+/*#context-menu-playback .dropdown-menu {min-width:15rem;white-space:nowrap;}*/
+#menu-check-consume, #menu-check-repeat, #menu-check-single {display:none;position:absolute;right:.45rem;}
 .dropdown-menu i.fa-check {padding:0;margin:0;}
 /* active/inactive css element manip */
 #menu-header {position:absolute;top:env(safe-area-inset-top);transform:translate(-50%);left:50%;font-weight:600;font-size:1.1rem;overflow:hidden;max-width:50%;text-overflow:ellipsis;white-space:nowrap;color:var(--adapttext);cursor:pointer;}
+#menu-header span {text-transform:capitalize;}
 #playback-panel #playback-controls {display:none;}
 #playback-panel.active #playback-controls, #playback-panel.active #playbtns, #playback-panel.active #togglebtns {display:block;}
 #playback-panel.active .btnlist.btnlist-top.btnlist-top-pl {display:inline-flex;}
@@ -507,7 +514,7 @@ input[type='range'].vslide2::-webkit-slider-thumb {background:#fff;background-im
 #timeline {width:65%;margin:.5em auto .3em;z-index:100;height:15px;display:none;}
 .timeline-thm {width:100%;height:15px;}
 #playbar-timetrack {display:flex;width:100%;padding:0px;margin:0;color:inherit;height:15px;z-index:999;}
-#playbar-timeline {width:20%;z-index:999;position:absolute;bottom:.4em;;left:50%;transform:translate(-50%);font-size:.8rem;display:flex;flex-flow:column;height:15px;display:none;}
+#playbar-timeline {width:20%;z-index:999;position:absolute;bottom:.75em;;left:50%;transform:translate(-50%);font-size:.8rem;display:flex;flex-flow:column;height:15px;display:none;}
 .timeline-progress {background-color:var(--trackfill);height:1px;position:relative;margin-top:-1px;top:50%;width:0;}
 .inner-progress {background-color:var(--trackfill);height:1px;width:0%;}
 .timeline-bg {background-color:var(--timecolor);height:1px;top:50%;width:100%;position:relative;min-height:1px;margin-top:-1px;}
@@ -522,9 +529,9 @@ input[type='range'].vslide2::-webkit-slider-thumb {background:#fff;background-im
 #playbar-total.long-time, #m-total.long-time {left:3.5rem!important;}
 #playback-switch {position:absolute;height:2.5rem;width:20%;top:0;top:env(safe-area-inset-top);left:50%;transform:translate(-50%);text-align:center;font-size:1.2em;color:var(--adapttext);display:none;cursor:pointer;}
 #playback-switch div {background-color:transparent;height:.25rem;width:2rem;margin:1em auto;border-radius:1em;overflow:hidden;}
-#playbar {display:flex;align-items:center;height:4.8rem;position:absolute;bottom:0;width:100%;color:var(--adapttext);box-shadow: 0px -1px 3px rgba(0,0,0,0.1);} /* was 9.25vh*/
-#playbar-cover {height:4.8rem;width:4.8rem;position:absolute;-webkit-mask-image: linear-gradient(to right, rgba(0,0,0,1), rgba(0,0,0,0) 100%);}
-#playbar-title {overflow:hidden;text-overflow:ellipsis;width:calc(50vw - 8.5rem);/* Was 5.5rem */;height:auto;position:absolute;font-size:.9em;left:50%;top:50%;transform:translate(-50%, -50%);text-align:center;/*padding-bottom:1rem;*/line-height:1.5em;cursor:pointer;}
+#playbar {display:flex;align-items:center;height:5.3rem;position:absolute;bottom:0;width:100%;color:var(--adapttext);box-shadow: 0px -1px 3px rgba(0,0,0,0.1);} /* was 9.25vh*/
+#playbar-cover {height:5.3rem;width:5.3rem;position:absolute;-webkit-mask-image: linear-gradient(to right, rgba(0,0,0,1), rgba(0,0,0,0) 100%);}
+#playbar-title {overflow:hidden;text-overflow:ellipsis;width:calc(50vw - 8.5rem);/* Was 5.5rem */;height:auto;position:absolute;font-size:.9em;left:50%;top:50%;transform:translate(-50%, -50%);text-align:center;/*padding-bottom:1rem;*/line-height:1.75em;cursor:pointer;}
 #playbar-title a {padding:0;margin:0;display:unset;text-align:unset;font-size:.9rem;color:var(--adapttext) !important;}
 /*#playbar-title span {opacity:.55;}
 #playbar-title span:first-child {opacity:1.0;}*/
@@ -619,7 +626,7 @@ input[type='range'].vslide2::-moz-range-track {height:10em;width:2px;border-radi
 #content.visacc #togglebtns .btn-primary {color:var(--adapttext);text-shadow: 0px 0px 4px var(--adapttext);}
 #content.visacc .playlist li.active:before {color:var(--adapttext);opacity:1;font-weight:600;}
 #content.visacc .playlist .active .pll1 {color:var(--adapttext);}
-#content.visacc .viewswitch .btn {color:var(--textvariant);}
+/*#content.visacc .viewswitch .btn {color:var(--textvariant);}*/
 #content.visacc .viewswitch .btn.active {color:var(--adapttext);}
 #content.visacc #lib-content li.active, #content.visacc #radiocovers .active {background-color: var(--btnshade4);box-shadow:none;}
 #playbar.visacc .ralbum svg {fill:var(--textvariant);}
@@ -627,6 +634,9 @@ input[type='range'].vslide2::-moz-range-track {height:10em;width:2px;border-radi
 #playbar.visacc #playbar-title a {color:var(--textvariant) !important;}
 #playbar.visacc #playbar-toggles .btn {color:var(--textvariant);}
 #playbar.visacc #playbar-toggles .btn-primary {color:var(--adapttext);text-shadow: 0px 0px 4px var(--adapttext);}
+
+#content.fancy #container-playlist {-webkit-mask-image: linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,1) 1%, rgba(0,0,0,1) 99%, rgba(0,0,0,0) 100%);}
+#content.fancy #lib-album, #content.fancy #lib-artist, #content.fancy #lib-genre {-webkit-mask-image: linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,1) 1%, rgba(0,0,0,1) 99%, rgba(0,0,0,0) 100%);top:calc(1.5em + 1px);height:calc(100% - 1.5em);}
 
 @keyframes fadeIn {0% {opacity: 0;} 100% {opacity: 1;}}
 @keyframes spin {from {transform:rotate(0def);} to {transform:rotate(360deg);}}
@@ -653,7 +663,7 @@ input[type='range'].vslide2::-moz-range-track {height:10em;width:2px;border-radi
 #ss-hd-badge {filter:brightness(90%);display:none;position:absolute;line-height:1.2em;margin:.3rem 0 0 1em;padding:.1em .2em 0 .3em;color:gold;background:#000;border:2px solid gold;border-radius:10%;font-size:.65em;font-style:normal;font-weight:700;}
 #playback-hd-badge {filter:brightness(90%);display:none;position:relative;height:1.2em;top:1.75rem;margin:0 0 0 1em;padding:.1em .2em 0 .3em;color:gold;background:#000;border:2px solid gold;border-radius:10%;font-size:.65em;font-style:normal;font-weight:700;}
 /* Radio manager */
-.modal-button-style {display:inline-block;margin-bottom:.5em;/*margin-top:-1px*/}
+.modal-button-style {display:inline-block;/*margin-bottom:.5em;margin-top:-1px*/}
 /* Radio view */
 .radioview-metadata-text {color:var(--textvariant);font-weight:500}
 /* First use help */

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -719,7 +719,7 @@ function renderUI() {
             // Original for Playback
      		$('#coverart-url').html('<img class="coverart" ' + 'src="' + MPD.json['coverurl'] + '" ' + 'data-adaptive-background="1" alt="Cover art not found"' + '>');
             // Thumbnail for Playbar
-            if (MPD.json['file'] && !RegExp('/tidal/').test(MPD.json['file'])) {
+            if (MPD.json['file'] && MPD.json['coverurl'].indexOf('wimpmusic') == -1 && MPD.json['coverurl']) {
                 var image_url = MPD.json['artist'] == 'Radio station' ?
                     encodeURIComponent(MPD.json['coverurl'].replace('imagesw/radio-logos', 'imagesw/radio-logos/thumbs')) :
                     '/imagesw/thmcache/' + encodeURIComponent($.md5(MPD.json['file'].substring(0,MPD.json['file'].lastIndexOf('/')))) + '.jpg'
@@ -727,7 +727,7 @@ function renderUI() {
             }
             else {
 	     		$('#coverart-url').html('<img class="coverart" ' + 'src="' + UI.defCover + '" data-adaptive-background="1" alt="Cover art not found"' + '>');
-                $('#playbar-cover').html('<img src="' + 'images/default-cover-v6.png' + '">');
+                $('#playbar-cover').html('<img src="images/default-cover-v6.svg">');
             }
     		// Cover backdrop or bgimage
     		if (SESSION.json['cover_backdrop'] == 'Yes') {
@@ -1060,7 +1060,7 @@ function renderPlaylist(state) {
 				}
 				// Song file or upnp url
 				else {
-					var thumb = RegExp('/tidal/').test(data[i].file) ? 'images/default-cover-v6.png' : 'imagesw/thmcache/' + encodeURIComponent($.md5(data[i].file.substring(0,data[i].file.lastIndexOf('/')))) + '_sm.jpg';
+					var thumb = data[i].file.indexOf('/tidal/') != -1 ? 'images/default-cover-v6.png' : 'imagesw/thmcache/' + encodeURIComponent($.md5(data[i].file.substring(0,data[i].file.lastIndexOf('/')))) + '_sm.jpg';
 					output += option_show_playlistart ? '<span class="pl-thumb">' + playlistLazy + '"' + thumb + '"/></span>' : '';
 					//output += option_show_playlistart ? '<span class="pl-thumb">' + playlistLazy + '"imagesw/thmcache/' + encodeURIComponent($.md5(data[i].file.substring(0,data[i].file.lastIndexOf('/')))) + '_sm.jpg"/></span>' : '';
 	                // Line 1 title
@@ -2137,9 +2137,7 @@ $('.context-menu a').click(function(e) {
 		var temp = SESSION.json['preferences_modal_state'].split(',');
 		for (var x = 0; x < 5; x++) {
 			if (temp[x] == '1') {
-				$('#preferences-modal div.control-group').eq(x).show();
-				$('#preferences-modal .accordian .dtopen').eq(x).show();
-				$('#preferences-modal .accordian .dtclose').eq(x).hide();
+				$('#preferences-modal .accordian').eq(x).addClass('active');
 			}
 		}
 
@@ -3329,8 +3327,7 @@ $('#context-backdrop').click(function(e){
 });
 
 $('#preferences-modal .h5').click(function(e) {
-	$(this).parent().children('div.control-group').slideToggle(100);
-	$(this).parent().children('.dtclose, .dtopen').toggle();
+	$(this).parent('div.accordian').toggleClass('active');
 });
 
 // Synchronize times to/from playbar so we don't have to keep countdown timers running which = ugly idle perf
@@ -3473,11 +3470,11 @@ function setLibMenuAndHeader () {
             }
             // Two arg filter with emoty second arg
             else if (GLOBAL.twoArgFilters.includes(SESSION.json['library_flatlist_filter']) && SESSION.json['library_flatlist_filter_str'] == '') {
-                headerText = 'Filtered by Any: (' + filterCapitilized + ')';
+                headerText = 'Filtered by Any: ' + filterCapitilized;
             }
             // Two arg filter with second arg
             else {
-                headerText = 'Filtered by '+ filterCapitilized + ': (' + SESSION.json['library_flatlist_filter_str'] + ')';
+                headerText = 'Filtered by '+ filterCapitilized + ': ' + SESSION.json['library_flatlist_filter_str'];
             }
         }
 	}

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -528,8 +528,9 @@
 		<form class="form-horizontal" action="" method="">
 
 			<!-- APPEARANCE -->
-			<div class="accordian"><span class="h5">Appearance</span><span class="dtclose">&nbsp;&#x25b8;</span><span class="dtopen">&nbsp;&#x25be;</span>
-				<div class="control-group">
+			<div class="accordian"><span class="h5">Appearance</span>
+				<div class="kontrol">
+					<div class="control-group">
    	                <label class="control-label" for="theme-name">Theme</label>
 	                <div class="controls">
    						<div class="btn-group bootstrap-select select-medium">
@@ -782,11 +783,13 @@
 						</span>
 					</div>
 				</div>
+				</div>
 			</div>
 
 			<!-- PLAYBACK -->
-			<div class="accordian"><span class="h5">Playback</span><span class="dtclose">&nbsp;&#x25b8;</span><span class="dtopen">&nbsp;&#x25be;</span>
-				<div class="control-group">
+			<div class="accordian"><span class="h5">Playback</span>
+				<div class="kontrol">
+					<div class="control-group">
 					<label class="control-label" for="playlist-art-enabled">Show Queue thumbs</label>
 					<div class="controls">
 						<div class="btn-group bootstrap-select bootstrap-select-mini">
@@ -842,11 +845,13 @@
 					</div>
 
 				</div>
+				</div>
 			</div>
 
 			<!-- LIBRARY (STANDARD SETTINGS)-->
-			<div class="accordian"><span class="h5">Library</span><span class="dtclose">&nbsp;&#x25b8;</span><span class="dtopen">&nbsp;&#x25be;</span>
-				<div class="control-group">
+			<div class="accordian"><span class="h5">Library</span>
+				<div class="kontrol">
+					<div class="control-group">
 					<label class="control-label" for="instant-play-action">One touch action</label>
 	                <div class="controls">
    						<div class="btn-group bootstrap-select select-medium">
@@ -1053,11 +1058,13 @@
  	                </div>
 
 				</div>
+				</div>
 			</div>
 
 			<!-- LIBRARY (ADVANCED)-->
-			<div class="accordian"><span class="h5">Library (Advanced)</span><span class="dtclose">&nbsp;&#x25b8;</span><span class="dtopen">&nbsp;&#x25be;</span>
-				<div class="control-group">
+			<div class="accordian"><span class="h5">Library (Advanced)</span>
+				<div class="kontrol">
+					<div class="control-group">
 					<label class="control-label" for="tag-view-artist">Tag view artist</label>
 	                <div class="controls">
 						<div class="btn-group bootstrap-select select-medium2">
@@ -1253,11 +1260,13 @@
  	                    </span>
  	                </div>
 				</div>
+				</div>
 			</div>
 
 			<!-- COVERVIEW -->
-			<div class="accordian"><span class="h5">CoverView</span><span class="dtclose">&nbsp;&#x25b8;</span><span class="dtopen">&nbsp;&#x25be;</span>
-				<div class="control-group">
+			<div class="accordian"><span class="h5">CoverView</span>
+				<div class="kontrol">
+					<div class="control-group">
    	                <label class="control-label" for="scnsaver-timeout">Automatic display</label>
 	                <div class="controls">
    						<div class="btn-group bootstrap-select select-medium">
@@ -1315,6 +1324,7 @@
 							<b>Pure Black:</b> Solid black overlay.
 	                    </span>
 	                </div>
+				</div>
 				</div>
 			</div>
 		</form>


### PR DESCRIPTION
This is a bunch of mostly css changes that started out primarily to make menus / menu fonts the same size and to make it easier for people with limited motor function to use.

1) starting with indextpl.html because it has nothing to do with that: remove dtopen/close elements, add an enclosing div to the control-groups so they can be scrolled for future use (redo of the landscape preferences dialog to not be accordian based)

2) fix tidal non-cover support to screen cover for wimpmusic (old tidal api) instead of tidal so apps like bubble upnp and mconnect can show covers, there's no real way to compensate for lack of thumbs though so they still get the moode image.

3) add "active" class to the accordian of disclosed preference sections, this removes the need for the dtclose/open as we can use css to show the triangle and will be useful for a landscape preferences refresh.

4) removed the parenthesis from the "filtered by:" text because they only make sense in the context of it being additional information added to something else, now that filtered is the whole thing they aren't needed.

5) change various menu settings in panels.css and moode.css to make the different menus use the same size font and/or menu width as the main menu, this should approximate a system context menu but only does that on mobile at the moment.

6) change library search placeholder text color to textvariant

7) set height for albums list thumbnail and add object-fit:contain so weird sized album art maintains aspect ratio, this adds a visible box while the image loads but was a noticeable perf improvement iirc.

8) add height to playlist thumbs for same reason, but we can't maintain aspect ratio without making it more complicated here.

9) make library search input field use up more of the menu width

10) css support for active class on accordians

11) consolidate the tag column css and change to give a .25em top & bottom margin for more separation between elements

12) #content.fancy version of the above uses fading to provide the separation, this is noticeably slower hence only in fancy

13) change the tracklist padding to be the height of the playbar, I don't remember why it was anything else

14) make tracklist li element padding larger so it's easier to select one

15) change padding and font size of disc label

16) make landscape playbar .5em taller, use extra room to give track name, timeline, etc more space

17) remove bottom margin from modal button style.

moode.css

18) clear some unused rules out of the .modal rule set

19) make modal header padding the same top & bottom

20) switch em to rem in a few places for font size / measurements

21) change to max-height 75vw instead of calculated value for .modal-body

22) remove some unused rules from .modal-bottom rule set

23) remove bottom margin from modal and set it on the .controls div instead

24) change popup menu from outline to solid background (btnshade2)

25) make #lib-file .songname a bit narrower to accomodate larger font size

26) remove rew button from playbar on mobile, give the space to the track info

27) give the playbar buttons bigger hit targers

28) add a media query for 360px wide devices to adjust the modal label / controls balance a la iphone se

29) change how the info toggle is positioned so it's more vertically centered in the controls div