### PR TITLE
Move filter reset from input clear button to menu-header

### DIFF
--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -900,12 +900,18 @@ var renderSongs = function(albumPos) {
 
 // Click genre or menu header (reset all)
 $('#genreheader, #menu-header').on('click', function(e) {
-	LIB.filters.genres.length = 0;
-	LIB.filters.artists.length = 0;
-	LIB.filters.albums.length = 0;
-	if (currentView == 'tag' || currentView == 'album') {
+    if (SESSION.json['library_flatlist_filter'] != 'full_lib' && $(e.target).parent('#genreheader').length == 0 && GLOBAL.musicScope == 'all') {
+		applyLibFilter('full_lib');
+		return;
+	}
+	else if (currentView == 'tag' || currentView == 'album') {
+		LIB.filters.genres.length = 0;
+		LIB.filters.artists.length = 0;
+		LIB.filters.albums.length = 0;
 		LIB.artistClicked = false;
         LIB.albumClicked = false;
+		$("#searchResetLib").hide();
+		showSearchResetLib = false;
         $('#tracklist-toggle').html('<i class="fal fa-list sx"></i> Show tracks');
 		if (GLOBAL.musicScope == 'recent') {
 			GLOBAL.musicScope = 'all';
@@ -917,7 +923,7 @@ $('#genreheader, #menu-header').on('click', function(e) {
 		}
 		setLibMenuAndHeader();
 	}
-	if (currentView == 'radio') {
+	else if (currentView == 'radio') {
 		GLOBAL.searchRadio = '';
 		$('#searchResetRa').click();
 		setLibMenuAndHeader();

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -997,12 +997,20 @@ jQuery(document).ready(function($) { 'use strict';
 	});
 
 	$('#searchResetLib').click(function(e) {
+		e.preventDefault();
+		document.getElementById("lib-album-filter").focus();
+        $('#lib-album-filter').val('');
+        $('#searchResetLib').hide();
+		return false;
+	});
+
+/*	$('#searchResetLib').click(function(e) {
         $('#lib-album-filter').val('');
         $('#searchResetLib').hide();
         if (SESSION.json['library_flatlist_filter'] != 'full_lib') {
             applyLibFilter('full_lib');
         }
-	});
+	});*/
 
 	// Playback history search
 	$('#ph-filter').keyup(function(e){


### PR DESCRIPTION
1) restore old reset function in scripts-panels, this keeps the menu open, etc.

2) add a check to menu-header click handler to see if library is full_lib (and if the genre header wasn't what was clicked and if musicScope is all) and resets if not.