### PR TITLE
Folder view gentrification

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -198,7 +198,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#maddfav i {font-size:1.1em;}
 	#mvol-bg {background-color:rgba(96,96,96,0.25);height:2px;}
 	#pl-search, #lib-album-search, #pl-save, #ra-search {margin-left: 0px;}
-	.database li {margin-left:2px;margin-right:5px;}
+	/*.database li {margin-left:2px;margin-right:5px;}*/
 	/* display:flex & playback stuff */
 	.no-fluid {flex-direction:column-reverse;}
 	.covers {padding:0;margin:0;}
@@ -228,11 +228,14 @@ li.modal-dropdown-text:focus {color:#eee;}
 }
 /* smaller portrait for small screens */
 @media (max-width:479px) and (orientation:portrait) {
+	#content.fancy #container-playlist {-webkit-mask-image:unset;}
+	.database .db-entry {margin-left:3.5em;padding:1em 0;font-size:1.1em;}
+	.database .db-action {font-size:1.3em;}
 	/*.dropdown-menu {min-width:180px;}*/
 	#menu-top .dropdown-menu, .viewswitch .dropdown-menu {min-width:16rem;} /* Make this one a bit wider */
 	#context-menu-playback .dropdown-menu {min-width:15rem;} /* Make this one a bit wider */
-	#lib-album-search input, #current-tab, #menu-header {font-size:1.11rem;}
-	.dropdown-menu > li > a, .viewswitch .btn, #lib-album-search input {font-size:1.11rem;line-height:2.75em;}
+	#lib-album-search input, #lib-album-search input, #current-tab, #menu-header {font-size:1.11rem;}
+	.dropdown-menu > li > a, .viewswitch .btn {font-size:1.16rem;line-height:2.75em;}
 	#playback-panel, #content {position:relative;}
 	.modal-body{padding:0 .5rem;max-height:80vh;}
 	.modal-footer .btn {width:40%;}
@@ -287,7 +290,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	/* playbar */
 	#playbar-div {display:block;}
 	#playbar-mtime {display:flex;position:relative;}
-	#playbar-title {text-align:left;top:0;margin-left:1em;width:67vw;height:auto;position:relative;transform:none;font-size:1.4em;line-height:2.2em;left:0;padding:0;text-shadow:0 0 1px var(--btnbarback);}
+	#playbar-title {text-align:left;top:0;margin-left:1em;width:67vw;height:auto;position:relative;transform:none;font-size:1.5em;line-height:2.2em;left:0;padding:0;text-shadow:0 0 1px var(--btnbarback);}
 	#playbar-controls {right:.25rem;transform:none;top:0;left:unset;opacity:1;}
 	#playbar-time, #playbar-total {line-height:1.5rem;}
 	#playbar-controls .btn {padding:.5em;font-size:2.5rem;-webkit-tap-highlight-color:transparent;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -192,15 +192,16 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 
 #playlist, #database, #database-radio {padding:0;background:none;}
 .playlist, .cv-playlist, .database, .database-radio {display:block;margin:0;padding:0;list-style:none;counter-reset:item;word-break: break-word;}
-.database {padding:0 0 12rem 0;width:calc(100vw - 2.5em);margin-left:1.75rem;overflow-x:hidden;position:relative;}
+.database {padding:0 0 12rem 0;width:100%;overflow-x:hidden;position:relative;margin:0;top:.5em;}
 .playlist .cv-playlist {padding:0 1em 4em 0;}
 #database-radio {height:calc(100vh - 2.75em);}
 .database-radio {text-align:center;padding:0 0 14rem 0;}
 .playlist li, .cv-playlist li, .database li, .database-radio li {display:block;position:relative;margin:0;cursor:pointer;text-align:left;padding-left:.75em;}
+.database li:first-child .db-entry {border-top:1px solid var(--btnshade);}
 .playlist li:before, .cv-playlist li:before {float:left;width:2.9em;letter-spacing:-1px;text-align:right;line-height:normal;counter-increment:item;content:counter(item) ' ';font-size:1em;margin-top:2px;}
 .database-radio li {width:var(--thumbcols);text-align:center;font-size:.95em;margin:0 .1em;display:inline-block;vertical-align:top;height:auto;padding:0 0 .5em 0;}
 .station-name {font-weight:600;}
-.database li {margin-left:2px;margin-right:5px;padding:0;}
+.database li {padding:0 2rem 0 1.35rem;}
 .database span {display:block;font-weight:normal;color:inherit;opacity:.60;}
 .playlist span, .cv-playlist span {line-height:normal;margin-left:calc(3em + 1vmin);display:block;}
 .pll1 {font-size:1em;}
@@ -224,20 +225,21 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #albumsList .album-year {margin-left:0;margin-left:.3em;}
 #library-panel.limited .artist-name-art, #library-panel.limited #albumcovers .artist-name {max-width:67%;}
 #library-panel.limited .lib-entry span, #radio-panel.limited .station-name span {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
-.database .active {font-size:inherit;font-weight:700;}
+.database .active {background-color:var(--btnshade);}
 .playlist .active .pll1, .cv-playlist .active .pll1 {color:var(--accentxts);font-weight:700;}
 .playlist li.active:before, .cv-playlist li.active:before, .lib-track-highlight {color:transparent!important;background:var(--npicon) no-repeat right;background-size:1.25em;}
 .playlist li.paused:before, .cv-playlist li.paused:before {color:unset!important;background:unset;}
 .playlist .pll1, .cv-playlist .pll1 {font-weight:400;opacity:1;text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
 .playlist .pl-entry, .cv-playlist .pl-entry {padding:0px;}
 .playlist .pl-thumb, .cv-playlist .pl-thumb {float:left;width:2.4em;height:2.4em;margin-left:1.2vmin!important;margin-right:1.2vmin;border-radius:.2em;filter:brightness(80%);overflow:hidden;}
-.database .db-entry {margin-left:2.5em;padding:1em 0;max-width:calc(100vw - 10px);overflow:hidden;}
-.database .db-song {padding:0 0 .5em 0;}
-.database .db-icon {display:block;float:left;height:19px;line-height:19px;width:1.875em;padding:0;color:inherit;}
-.database .db-icon .btn {font-size:1em;padding:1em .4em 1em .4em;}
-.database .db-icon .btn img {margin-top:-.5em;}
-/*.db-icon.db-song.db-browse.db-action img, .db-icon.db-radiofolder-icon.db-browse.db-action img {width:90%;}*/
-.db-song.db-action a {width:100vw;height:2em;/*padding-top:.75em !important;*/}
+.database .db-entry {margin-left:4rem;padding:1em 0;max-width:calc(100vw - 10px);overflow:hidden;font-size:1.1rem;line-height:normal;border-bottom:1px solid var(--btnshade);}
+.database .db-song {padding:1em 0;}
+.database .db-icon {display:block;height:2.4em !important;width:2.4em !important;position:absolute !important;top:50%;transform:translate(0, -50%);padding:0;color:inherit;}
+.database .db-icon .btn {font-size:1em;padding:0;width:100%;}
+.database .db-icon .btn img {height:100%;width:100%;border-radius:.2em;/*margin-top:-.5em;*/}
+.database .db-action a {position:absolute;transform:translate(0, -50%);top:50%;}
+	/*.db-icon.db-song.db-browse.db-action img, .db-icon.db-radiofolder-icon.db-browse.db-action img {width:90%;}*/
+.db-song.db-action a {width:100vw;/*height:2em;padding-top:.75em !important;*/}
 #lib-file .songtrack {left:0px;text-align:right;width:2em;float:left;display:table-cell;}
 #lib-file .songname {overflow:hidden;width:40%;height:auto;float:left;margin-left:1em;display:table-cell;}
 #lib-file .songartist {margin-left:1em;float:left;width:35%;display:table-cell;}
@@ -245,11 +247,13 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #lib-file .songtime {font-style:normal;margin-left:1em;float:left;display:table-cell;}
 #lib-file .songyear {font-style:normal;position:absolute;right:1em;float:right;display:table-cell;}
 #playlist .songtime {font-size:.8em;font-style:normal;font-weight:normal;word-break:normal;color:var(--textvariant);}
+.db-song .songtime {position:absolute;top:1em;right:1.5em;opacity:1;}
 .icon-root {color:inherit;}
 .playlist .pl-action, .cv-playlist .pl-action {float:right;padding:0;text-align:center;}
 .cv-playlist .pl-action {display:none;}
-.database .db-action {float:left;width:3.2rem;padding:0;position:relative;}
+.database .db-action, .database .db-album-action {float:left;width:3.2rem;padding:0;position:relative;font-size:1.25em;line-height:normal;}
 .database .db-action i {width:2.2rem;}
+.database .db-entry div {padding-left:.25em;max-width:68vw;}
 .playlist .pl-action, .playlist .db-action a {position:relative;width:4.5em;margin-left:1em;font-weight:normal;text-decoration:none;z-index:3;font-size:.9em;line-height:.625em;padding:.318em 0;float:right;}
 .cv-playlist .pl-action, .cv-playlist .db-action a {position:relative;width:4.5em;margin-left:1em!important;font-weight:normal;text-decoration:none;z-index:3;font-size:.9em;line-height:.625em;padding:.318em 0;float:right;}
 #db-search-results {font-style:italic;padding:.5em;font-size:1em;display:none;top:0;right:0;position:absolute;}
@@ -258,7 +262,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .btnlist {position:fixed;left:0;right:0;display:block;width:auto;height:2.5em;padding:0;background:none;-webkit-border-radius:0px;-moz-border-radius:0px;border-radius:0px;z-index:999;}
 .btnlist:focus {outline:none;}
 .btnlist.pl-prevPage, .btnlist.db-prevPage, .btnlist.pl-firstPage, .btnlist.db-firstPage {padding:0 .3em;}
-.btnlist-top-db, .btnlist-top-ra {position:relative;background-color:rgba(128,128,128,.1);;color:var(--adapttext);border-radius:.25em;border:1px solid var(--btnshade);width:calc(100vw - 2.5em);height:2.4rem;padding:0 !important;margin:0 auto;}
+.btnlist-top-db, .btnlist-top-ra {position:relative;background-color:var(--btnshade3);top:.25em;color:var(--adapttext);border-radius:.25em;width:calc(100vw - 2.5em);height:2.5rem;padding:0 !important;margin:0 auto;}
 #pl-filter, #lib-album-filter, #ra-filter {padding:0}
 #db-browse .dropdown {display:block;height:40px;line-height:40px;margin:0 20px 0 0;}
 #db-browse .dropdown-menu {background:transparent;border:none;border-radius:0px;box-shadow:none;list-style:none outside none;margin:0;/*min-width:100px;*/padding:0;border-top:1px solid #000;border-left:1px solid #000;border-right:1px solid #000;position:absolute;top:100%;z-index:1000;}
@@ -273,15 +277,15 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #savepl-modal, #setfav-modal .modal-body {padding:1em .25em 0 .25em;}
 #pl-save {display:block;float:left;margin-right:0;margin-left:0;z-index:1001;width:100%;text-align:center;}
 #pl-search input, #ra-search input, #lib-album-search input {margin:0;border:none;box-shadow:none;min-height:initial;height:2.75rem;font-size:1em;padding:0;}
-#ra-search input, #dbfs {margin-left:.5em;padding:0;height:2.1rem;border:none;font-size:inherit;}
+#ra-search input, #dbfs {margin-left:.5em;padding:0;height:2.5rem;border:none;font-size:inherit;width:40vw;}
 #searchResetPl {font-size:1rem;top:0;margin-top:.5em;float:left;padding-left:0;}
 #db-browse {margin:0;width:200px;}
-.db-browse-icon {float:left;}
+/*.db-browse-icon {float:left;}*/
 #pl-controls {float:left;margin:6px 0 0 10px;}
 #folder-panel .btn.disabled, #folder-panel .btn[disabled] {background-color:#34495E;color:white;}
 #folder-panel, #radio-panel {width:100%;height:100vh;position:fixed;top:0;overflow:hidden;}
 #library-panel {height:100vh;}
-.btnlist-top-db button, .btnlist-top-ra button {margin:0;line-height:normal;height:2.4rem;width:2.2rem;font-size:1.1rem;border-radius:0;float:left;display:inline-block;padding:.25rem .5rem;border-right: 1px solid var(--btnshade);}
+.btnlist-top-db button, .btnlist-top-ra button {margin:0;line-height:normal;height:2.5rem;width:2.5rem;font-size:1.1rem;border-radius:0;float:left;display:inline-block;padding:.25rem .5rem;border-right: 1px solid var(--btnshade);}
 #reconnect, #restart, #shutdown {position:fixed;top:0;left:0;margin:0;padding:0;text-align:center;width:100%;height:100%;z-index:9999;}
 .reconnect-bg {position:absolute;top:0;left:0;margin:0;padding:0;text-align:center;background-color:var(--modalbkdr);width:100%;height:100%;z-index:9999;}
 .reconnect-btn {position:fixed;padding:.75rem;transform: translate(-50%,-50%);top: 50%;left: 50%;width: 10em;text-transform:uppercase;z-index:9999;font-size:1.25em;cursor:pointer;border-radius:5rem;color:var(--themetext);background-color:var(--btnshade4);}
@@ -290,7 +294,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .viewswitch {position:fixed;top:0;top:env(safe-area-inset-top);background-color:transparent;color:inherit;display:none;z-index:1001;line-height:2.75rem;font-size:inherit;transform:translate(-50%, 0%);height:2.75rem;align-items:center;left:1rem;transform:none;}
 .viewswearch {height:2.25rem;padding:1.5rem 0 1.5rem 1rem !important;}
 #viewswitch span {float:right;display:none;}
-#searchResetLib {padding:.25em;position:relative;top:50%;transform:translate(0, -50%);font-size:1.2rem;}
+#searchResetLib {padding:.75rem .25em;position:relative;transform:translate(0, -50%);line-height:normal;}
 #viewswitch a {color:inherit;}
 .viewswitch div {display:flex;color:var(--adapttext);}
 #viewswitch .btn {width:100%;}
@@ -383,7 +387,7 @@ img.lib-artistart {float:left;width:calc(20vw - 1rem);height: calc(20vw - 1rem);
 #lib-genre li, #lib-artist li {padding: 0.4em 0.5em;}
 #lib-content #lib-file li {;padding:.75em 0 .85em 0;}
 #lib-content #lib-file li:nth-child(odd) {background:rgba(128,128,128,0.1);}
-#lib-content #lib-file li:nth-child(odd).active {font-weight:600;}
+/*#lib-content #lib-file li:nth-child(odd).active {font-weight:600;}*/
 #lib-content li div.active {color:var(--accentxts);}
 #lib-content li.active, .albumslist .active, #radiocovers li.active {background-color:var(--accentxta);color:#eee;}
 .lib-entry {padding:0 .5em;margin:0 .1rem;}
@@ -393,7 +397,7 @@ img.lib-artistart {float:left;width:calc(20vw - 1rem);height: calc(20vw - 1rem);
 .lib-disc a {font-size:1em;opacity:.75;padding:.75em;}
 .lib-album-heading {font-size:.9em;opacity:.75;padding:.75em;margin:0;text-transform:uppercase;background-color:rgba(128,128,128,0.1);box-shadow:0 .04em .025em rgba(0,0,0,0.15);display:none;}
 #songsList .lib-disc a.active {font-weight:700;color:unset;}
-#songsList li.active {font-weight:700;background-color:unset;}
+/*#songsList li.active {font-weight:700;background-color:unset;}*/
 #trackscontainer {width:calc(80vw - var(--sbw));float:right;} /* Was 81vw */
 #m-countdown {padding-right:5px;font-size:10px;}
 #m-total {font-size:10px;padding-left:5px;}

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -1243,23 +1243,36 @@ function renderFolderView(data, path, searchstr) {
 	}
 
 	// Output the list
-    $('ul.database').html('');
+	var output = '';
+	var element = document.getElementById('folderlist');
+	element.innerHTML = '';
+	console.log(data);
 	for (i = 0; i < data.length; i++) {
-        $('ul.database').append(formatFolderViewEntries(data, path, i))
+		if (data[i].file && data[i > 1 ? i - 1 : 0].Album != data[i].Album || data[i].file && i == 0 && data[i].Album) { // new album not playlist but ugh
+			output += '<li id="db-' + i + '" data-path="' + data[i].file.substr(0, data[i].file.lastIndexOf('/')) + '">'
+			output += '<div class="db-icon db-action">';
+			output += '<a class="btn" href="#notarget" data-toggle="context" data-target="#context-menu-folder">';
+		    output += '<img src="' + 'imagesw/thmcache/' + encodeURIComponent($.md5(data[i].file.substring(0,data[i].file.lastIndexOf('/')))) + '_sm.jpg' + '"></img></a></div>';
+			output += '<div class="db-entry db-album"><div>' + data[i].Artist + ' - ' + data[i].Album + '</div></div></li>';
+		}
+       	 	output += formatFolderViewEntries(output, data, path, i);
+		
 	}
+	element.innerHTML = output;
+	
 
 	// Scroll and highlight
     // NOTE: Don't highlight if at root or only 1 item in list
 	if (currentView == 'folder') {
 		customScroll('folder', UI.dbPos[UI.dbPos[10]], 100);
-		if (path != '' && UI.dbPos[UI.dbPos[10]] > 1) {
+		/*if (path != '' && UI.dbPos[UI.dbPos[10]] > 1) {
 			$('#db-' + UI.dbPos[UI.dbPos[10]].toString()).addClass('active');
-		}
+		}*/
 	}
 }
 // Format entries for Folder view
-function formatFolderViewEntries(data, path, i) {
-	var output = '';
+function formatFolderViewEntries(output, data, path, i) {
+	//var output = '';
 
 	if (path == '' && typeof(data[i].file) != 'undefined') {
 		var pos = data[i].file.lastIndexOf('/');
@@ -1275,9 +1288,9 @@ function formatFolderViewEntries(data, path, i) {
 			output = '<li id="db-' + (i + 1) + '" data-path="' + data[i].file + '">'
 			output += '<div class="db-icon db-song db-action">'; // Hack to enable entire line click for context menu
 			output += '<a class="btn" href="#notarget" data-toggle="context" data-target="#context-menu-folder-item">';
-            output += '<i class="fas fa-music sx db-browse db-browse-icon"></i></a></div>';
-			output += '<div class="db-entry db-song">' + data[i].Title + ' <em class="songtime">' + data[i].TimeMMSS + '</em>';
-			output += ' <span>' + data[i].Artist + ' - ' + data[i].Album + '</span></div></li>';
+            output += '<i class="fas fa-music db-browse db-browse-icon"></i></a></div>';
+			output += '<div class="db-entry db-song" data-toggle="context" data-target="#context-menu-folder-item"><div>' + data[i].Title + ' <span class="songtime">' + data[i].TimeMMSS + '</span></div>';
+			//output += ' <span>' + data[i].Artist + ' - ' + data[i].Album + '</span></div></li>';
 		}
 		// Saved Playlist items
         // NOTE: File extensions are removed except for url's
@@ -1298,17 +1311,17 @@ function formatFolderViewEntries(data, path, i) {
 			// CUE sheet
             var itemType = '';
 			if (fileExt == 'cue') {
-				output += '"><div class="db-icon db-song db-browse db-action"><a class="btn" href="#notarget" data-toggle="context" data-target="#context-menu-folder-item"><i class="fas fa-list-ul icon-root sx db-browse-icon"></i></a></div><div class="db-entry db-song db-browse">';
+				output += '"><div class="db-icon db-song db-browse db-action"><a class="btn" href="#notarget" data-toggle="context" data-target="#context-menu-folder-item"><i class="fas fa-list-ul icon-root db-browse-icon"></i></a></div><div class="db-entry db-song db-browse">';
 				itemType = 'CUE sheet';
 			}
 			// Different icon for song file vs radio station in saved playlist
 			else {
 				if (data[i].file.substr(0,4) == 'http') {
-					output += '"><div class="db-icon db-song db-browse db-action"><a class="btn" href="#notarget" data-toggle="context" data-target="#context-menu-savedpl-item" style="width:100vw;height:2em;"><i class="fas fa-microphone sx db-browse db-browse-icon"></i></a></div><div class="db-entry db-song db-browse">';
+					output += '"><div class="db-icon db-song db-browse db-action"><a class="btn" href="#notarget" data-toggle="context" data-target="#context-menu-savedpl-item"><i class="fas fa-microphone db-browse db-browse-icon"></i></a></div><div class="db-entry db-song db-browse" data-toggle="context" data-target="#context-menu-savedpl-item">';
 					itemType = typeof(RADIO.json[data[i].file]) === 'undefined' ? 'Radio station' : RADIO.json[data[i].file]['name'];
 				}
                 else {
-					output += '"><div class="db-icon db-song db-browse db-action"><a class="btn" href="#notarget" data-toggle="context" data-target="#context-menu-savedpl-item" style="width:100vw;height:2em;"><i class="fas fa-music sx db-browse db-browse-icon"></i></a></div><div class="db-entry db-song db-browse">';
+					output += '"><div class="db-icon db-song db-browse db-action"><a class="btn" href="#notarget" data-toggle="context" data-target="#context-menu-savedpl-item"><i class="fas fa-music db-browse db-browse-icon"></i></a></div><div class="db-entry db-song db-browse" data-toggle="context" data-target="#context-menu-savedpl-item">';
 					itemType = 'Song file';
 				}
 			}
@@ -1328,26 +1341,30 @@ function formatFolderViewEntries(data, path, i) {
 			output = '<li id="db-' + (i + 1) + '" data-path="' + data[i].playlist + '">';
 			output += '<div class="db-icon db-action">';
 			output += '<a class="btn" href="#notarget" data-toggle="context" data-target="#context-menu-savedpl-root">';
-			output += '<i class="fas fa-list-ul icon-root sx"></i></a></div>';
-			output += '<div class="db-entry db-savedplaylist db-browse">' + data[i].playlist;
-			output += '</div></li>';
+			output += '<i class="fas fa-list-ul icon-root"></i></a></div>';
+			output += '<div class="db-entry db-savedplaylist db-browse"><div>' + data[i].playlist;
+			output += '</div></div></li>';
 		}
 	}
 	// Directories
 	else {
 		output = '<li id="db-' + (i + 1) + '" data-path="';
 		output += data[i].directory;
+		//console.log(("USB/Music".match(/\//g) || []).length); //logs 3
+		if ( (data[i].directory.match(/\//g) || []).length == 1) {
+			data[i].cover_url = UI.defCover;
+		}
 		if (path == '') { // At the root
-            output += '"><div class="db-icon db-action"><a class="btn" href="#notarget" data-toggle="context" data-target="#context-menu-folder"><i class="fas fa-hdd icon-root sx"></i></a></div><div class="db-entry db-folder db-browse">';
+            output += '"><div class="db-icon db-action"><a class="btn" href="#notarget" data-toggle="context" data-target="#context-menu-folder"><i class="fas fa-hdd icon-root"></i></a></div><div class="db-entry db-folder db-browse"><div>';
 		}
 		else {
             output += '"><div class="db-icon db-browse db-action"><a class="btn" href="#notarget" data-toggle="context" data-target="#context-menu-folder">';
-            output += data[i].cover_url != '' ? '<img src="' + data[i].cover_url + '">' : '<i class="fas fa-folder sx"></i>';
+            output += data[i].cover_url != '' ? '<img src="' + data[i].cover_url + '">' : '<i class="fas fa-folder"></i>';
             output += '</a></div>';
-            output += '<div class="db-entry db-folder db-browse">'
+            output += '<div class="db-entry db-folder db-browse"><div>'
 		}
 		output += data[i].directory.replace(path + '/', '');
-		output += '</div></li>';
+		output += '</div></div></li>';
 	}
 
 	return output;
@@ -2940,6 +2957,7 @@ function str2hex(tempcolor) {
 function dbFastSearch() {
 	$('#dbsearch-alltags').val($('#dbfs').val());
 	$('#db-search-submit').click();
+	$('#dbfs').blur();
 	return false;
 }
 
@@ -2964,7 +2982,7 @@ function btnbarfix(temp1,temp2) {
 	document.body.style.setProperty('--btnshade2', tempcolor);
 	tempcolor = rgbaToRgb(.3, '1.0', temprgba, temprgb); // textvariant
 	document.body.style.setProperty('--textvariant', tempcolor);
-	tempcolor = rgbaToRgb(.6, '.7', temprgba, temprgb); // textvariant
+	tempcolor = rgbaToRgb(.65 - tempx, '.15', temprgba, temprgb);
 	document.body.style.setProperty('--btnshade3', tempcolor);
 	document.body.style.setProperty('--btnshade4', getYIQ(temp1) > 127 ? 'rgba(32,32,32,0.10)' : 'rgba(208,208,208,0.17)');
 	$('#content').hasClass('visacc') ? op = .95 : op = .9;

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -730,13 +730,30 @@ jQuery(document).ready(function($) { 'use strict';
 			mpdDbCmd(cmd, $(this).parent().data('path'));
 		}
 	});
+	
+    // play album item on click/tap
+	$('.database').on('click', '.db-album', function(e) {
+    	var files = [];
+		for (var i = $(this).parent().index() + 1; i < $('#folderlist li').length; i++) {
+			if ($('#folderlist li').eq(i).children('div').hasClass('db-song')) {
+				files.push($('#folderlist li').eq(i).attr('data-path'));
+			} else {
+				break;
+			}
+		}
+        var cmd = SESSION.json['library_instant_play'] == 'Clear/Play' ? 'clear_play_group' : 'play_group';
+		mpdDbCmd(cmd, files);
+		notify(cmd);
+	});
+	
     // Folder view context menu click
-	$('.database').on('click', '.db-action', function(e) {
+	$('.database').on('click', '.db-action, .db-song', function(e) {
         //console.log('Folder menu click');
+		$('#db-' + UI.dbPos[UI.dbPos[10]].toString()).removeClass('active');
 		UI.dbEntry[0] = $(this).parent().attr('data-path');
 		UI.dbEntry[3] = $(this).parent().attr('id'); // Used in .context-menu a click handler to remove highlight
 		$('#db-search-results').css('font-weight', 'normal');
-		$('.database li').removeClass('active');
+		//$('.database li').removeClass('active');
 		$(this).parent().addClass('active');
 	});
 	$('#db-back').click(function(e) {

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -259,7 +259,7 @@
 				<div id="db-search-results"></div>
 			</div>
 			<div id="database">
-				<ul class="database"></ul>
+				<ul id="folderlist" class="database"></ul>
 			</div>
 			<div id ="index-browse" class="alphabits">
 				<ul>


### PR DESCRIPTION
This is a refresh so there's a bunch of css but changes aren't too extensive lest we scare off the folderites, also:

1) accumulate the folder list elements into a string and then output it in one go insted of appending one li at a time which makes it a lot faster

2) the first item of an album list now shows the cover art and artist - album, clicking on the text part plays the album, context-clicking the cover art acts on the whole album

3) add the above concept to search results so it shows the album the track(s) came from in addition to the tracks, clicking the album text plays the tracks, clicking the cover for the context menu acts on the album as a whole

4) clicking the text part of a song or radio station shows the context menu as well, non-ghetto version

Things to do in a future age

1) make playlists not suck

2) maybe make clicking the album cover of a search result album act on the tracks from the album shown instead of the whole album? i couldn't decide which i liked more.