### PR TITLE
Change DOMSubtreeModified to MutationObserver

### DIFF
--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -135,15 +135,32 @@ jQuery(document).ready(function($) { 'use strict';
     	if (SESSION.json['adaptive'] == "No") {document.body.style.setProperty('--adaptmbg', themeBack);}
     	blurrr == true ? themeOp = .85 : themeOp = .95;
 
+
+		function mutate(mutations) {
+		  mutations.forEach(function(mutation) {
+      		$('#alpha-blend span').text() < 1 ? $('#cover-options').show() : $('#cover-options').css('display', '');
+  		  });
+		}
+
+		jQuery(document).ready(function() {
+
+		  var target = document.querySelector('#alpha-blend span')
+		  var observer = new MutationObserver( mutate );
+		  var config = { characterData: true, attributes: false, childList: true, subtree: false };
+
+		  observer.observe(target, config);
+		});
+
+
     	// Only display transparency related theme options if alphablend is < 1
-    	$('#alpha-blend').on('DOMSubtreeModified',function(){
+    	/*$('#alpha-blend').on('DOMSubtreeModified',function(){
     		if ($('#alpha-blend span').text() < 1) {
     			$('#cover-options').show();
     		}
             else {
     			$('#cover-options').css('display', '');
     		}
-    	});
+    	});*/
 
     	tempcolor = (THEME.json[SESSION.json['themename']]['mbg_color']).split(",")
     	themeMback = 'rgba(' + tempcolor[0] + ',' + tempcolor[1] + ',' + tempcolor[2] + ',' + themeOp + ')';

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -177,9 +177,7 @@
 							</li>
 						</div>
 						<div id="index-genres" class="alphabits">
-							<ul>
-								<li>a</li><li>c</li><li>e</li><li>g</li><li>i</li><li>k</li><li>m</li><li>o</li><li>p</li><li>r</li><li>s</li><li>t</li><li>v</li><li>w</li><li>z</li>
-							</ul>
+							<ul><li>#</li><li>a</li><li>c</li><li>e</li><li>g</li><li>i</li><li>k</li><li>m</li><li>o</li><li>p</li><li>r</li><li>s</li><li>t</li><li>v</li><li>w</li><li>z</li></ul>
 						</div>
 						<div id="lib-genre" class="lib-genre-sm">
 							<ul id="genresList"></ul>
@@ -190,9 +188,7 @@
 							</li>
 						</div>
 						<div id="index-artists" class="alphabits">
-							<ul>
-								<li>#</li><li>a</li><li>c</li><li>e</li><li>g</li><li>i</li><li>k</li><li>m</li><li>o</li><li>p</li><li>r</li><li>s</li><li>t</li><li>v</li><li>w</li><li>z</li>
-							</ul>
+							<ul><li>#</li><li>a</li><li>c</li><li>e</li><li>g</li><li>i</li><li>k</li><li>m</li><li>o</li><li>p</li><li>r</li><li>s</li><li>t</li><li>v</li><li>w</li><li>z</li></ul>
 						</div>
 						<div id="lib-artist" class="lib-artist-sm">
 							<ul id="artistsList" class="artistslist"></ul>
@@ -203,9 +199,7 @@
 							</li>
 						</div>
 						<div id="index-albums" class="alphabits">
-							<ul>
-								<li>#</li><li>a</li><li>c</li><li>e</li><li>g</li><li>i</li><li>k</li><li>m</li><li>o</li><li>p</li><li>r</li><li>s</li><li>t</li><li>v</li><li>w</li><li>z</li>
-							</ul>
+							<ul><li>#</li><li>a</li><li>c</li><li>e</li><li>g</li><li>i</li><li>k</li><li>m</li><li>o</li><li>p</li><li>r</li><li>s</li><li>t</li><li>v</li><li>w</li><li>z</li></ul>
 						</div>
 						<div id="lib-album">
 							<ul id="albumsList" class="albumslist"></ul>
@@ -213,9 +207,7 @@
 					</div>
 					<!-- ALBUM VIEW -->
 					<div id="index-albumcovers" class="alphabits">
-						<ul>
-							<li>#</li><li>a</li><li>b</li><li>c</li><li>d</li><li>e</li><li>f</li><li>g</li><li>h</li><li>i</li><li>j</li><li>k</li><li>l</li><li>m</li><li>n</li><li>o</li><li>p</li><li>q</li><li>r</li><li>s</li><li>t</li><li>u</li><li>v</li><li>w</li><li>x</li><li>y</li><li>z</li>
-						</ul>
+						<ul><li>#</li><li>a</li><li>b</li><li>c</li><li>d</li><li>e</li><li>f</li><li>g</li><li>h</li><li>i</li><li>j</li><li>k</li><li>l</li><li>m</li><li>n</li><li>o</li><li>p</li><li>q</li><li>r</li><li>s</li><li>t</li><li>u</li><li>v</li><li>w</li><li>x</li><li>y</li><li>z</li></ul>
 					</div>
 					<div id="lib-albumcover">
 						<ul id="albumcovers" class="albumcovers"></ul>
@@ -262,9 +254,7 @@
 				<ul id="folderlist" class="database"></ul>
 			</div>
 			<div id ="index-browse" class="alphabits">
-				<ul>
-					<li>#</li><li>a</li><li>b</li><li>c</li><li>d</li><li>e</li><li>f</li><li>g</li><li>h</li><li>i</li><li>j</li><li>k</li><li>l</li><li>m</li><li>n</li><li>o</li><li>p</li><li>q</li><li>r</li><li>s</li><li>t</li><li>u</li><li>v</li><li>w</li><li>x</li><li>y</li><li>z</li>
-				</ul>
+				<ul><li>#</li><li>a</li><li>b</li><li>c</li><li>d</li><li>e</li><li>f</li><li>g</li><li>h</li><li>i</li><li>j</li><li>k</li><li>l</li><li>m</li><li>n</li><li>o</li><li>p</li><li>q</li><li>r</li><li>s</li><li>t</li><li>u</li><li>v</li><li>w</li><li>x</li><li>y</li><li>z</li></ul>
 			</div>
 		</div>
 	</div>
@@ -287,9 +277,7 @@
 				<ul id="radiocovers" class="database-radio"></ul>
 			</div>
 			<div id ="index-radio" class="alphabits">
-				<ul>
-					<li>#</li><li>a</li><li>b</li><li>c</li><li>d</li><li>e</li><li>f</li><li>g</li><li>h</li><li>i</li><li>j</li><li>k</li><li>l</li><li>m</li><li>n</li><li>o</li><li>p</li><li>q</li><li>r</li><li>s</li><li>t</li><li>u</li><li>v</li><li>w</li><li>x</li><li>y</li><li>z</li>
-				</ul>
+				<ul><li>#</li><li>a</li><li>b</li><li>c</li><li>d</li><li>e</li><li>f</li><li>g</li><li>h</li><li>i</li><li>j</li><li>k</li><li>l</li><li>m</li><li>n</li><li>o</li><li>p</li><li>q</li><li>r</li><li>s</li><li>t</li><li>u</li><li>v</li><li>w</li><li>x</li><li>y</li><li>z</li></ul>
 			</div>
 		</div>
 	</div>
@@ -624,28 +612,6 @@
 	                    </span>
 	                </div>
 
-   	                <label class="control-label" for="adaptive-enabled">Adaptive coloring</label>
-	                <div class="controls">
-   						<div class="btn-group bootstrap-select bootstrap-select-mini">
-							<button type="button" class="btn btn-inverse dropdown-toggle" data-toggle="dropdown">
-								<div id="adaptive-enabled" class="filter-option pull-left">
-									<span></span>
-								</div>&nbsp;
-								<div class="caret"></div>
-							</button>
-							<div class="dropdown-menu open">
-								<ul class="dropdown-menu custom-select inner" role="menu">
-									<li class="modal-dropdown-text"><a href="#notarget" data-cmd="adaptive-enabled-sel"><span class="text">Yes</span></a></li>
-									<li class="modal-dropdown-text"><a href="#notarget" data-cmd="adaptive-enabled-sel"><span class="text">No</span></a></li>
-								</ul>
-							</div>
-						</div>
-						<a aria-label="Help" class="info-toggle" data-cmd="info-adaptive" href="#notarget"><i class="fas fa-info-circle"></i></a>
-						<span id="info-adaptive" class="help-block hide">
-	                    	Sets the Playback panel color scheme based on the dominant color in the album artwork.
-	                    </span>
-	                </div>
-
 					<div id="cover-options">
 						<label class="control-label bgimglabel">Image backdrop</label>
 						<div class="controls">
@@ -734,6 +700,28 @@
 		                    </span>
 		                </div>
 					</div>
+
+   	                <label class="control-label" for="adaptive-enabled">Adaptive coloring</label>
+	                <div class="controls">
+   						<div class="btn-group bootstrap-select bootstrap-select-mini">
+							<button type="button" class="btn btn-inverse dropdown-toggle" data-toggle="dropdown">
+								<div id="adaptive-enabled" class="filter-option pull-left">
+									<span></span>
+								</div>&nbsp;
+								<div class="caret"></div>
+							</button>
+							<div class="dropdown-menu open">
+								<ul class="dropdown-menu custom-select inner" role="menu">
+									<li class="modal-dropdown-text"><a href="#notarget" data-cmd="adaptive-enabled-sel"><span class="text">Yes</span></a></li>
+									<li class="modal-dropdown-text"><a href="#notarget" data-cmd="adaptive-enabled-sel"><span class="text">No</span></a></li>
+								</ul>
+							</div>
+						</div>
+						<a aria-label="Help" class="info-toggle" data-cmd="info-adaptive" href="#notarget"><i class="fas fa-info-circle"></i></a>
+						<span id="info-adaptive" class="help-block hide">
+	                    	Sets the Playback panel color scheme based on the dominant color in the album artwork.
+	                    </span>
+	                </div>
 
 					<label class="control-label" for="renderer-backdrop">Renderer backdrop</label>
 					<div class="controls">


### PR DESCRIPTION
Chrome complains about a DOMSubtreeModified method so change to use MutationObserver instead.

This also changes the position of the adaptive background preference item so it goes after the controls that get exposed by the #alpha-blend value, changes the genre quick jump index to be like the other columns, and puts the indexes on one <ul><li>...</ul> line for neatness.