### PR TITLE
makeActive changes

### DIFF
--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -100,7 +100,7 @@ html {background-color:inherit;}
 #currentsong, #currentalbum, #format-bitrate, #elapsed, #countdown-display {display:block;}
 #extra-tags-display {font-size:1rem;color:var(--textvariant);padding-top:.5em;text-align:center;display:block;}
 #currentsong {font-size:1.35em;padding-top:1.65rem;font-weight:bold;color:var(--accentxts);word-wrap:break-word;cursor:pointer;}
-#currentalbum {font-size:1.25em;padding-top:1.65rem;cursor:pointer;}
+#currentalbum {font-size:1.25em;padding-top:1.65rem;cursor:pointer;font-weight:500;}
 #currentalbum-div {display:inline-flex;}
 #playlist-position, #format-bitrate {color:inherit;opacity:.55;}
 .container-playback {padding:0px;color:inherit;margin-top:env(safe-area-inset-top);}
@@ -292,7 +292,19 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .reconnect-btn:hover {background-color:var(--btnshade4);} /* Mask hover effect */
 .reconnect-msg {transform: translate(-50%,-50%);position: absolute;top: 50%;margin: 3em 0 0 0;text-transform: uppercase;transform: translate(-50%,-50%);position: absolute;top: 50%;margin: 3em 0 0 0;z-index: 9999;text-transform: uppercase;}
 .viewswitch {position:fixed;top:0;top:env(safe-area-inset-top);background-color:transparent;color:inherit;display:none;z-index:1001;line-height:2.75rem;font-size:inherit;transform:translate(-50%, 0%);height:2.75rem;align-items:center;left:1rem;transform:none;}
-.viewswearch {height:2.25rem;padding:1.5rem 0 1.5rem 1rem !important;}
+
+#viewswitch-search {height:2.25rem;padding:1.5rem 0 1.5rem 1rem !important;display:none;}
+#viewswitch .view-all, #viewswitch .view-recents {display:none;}
+
+#viewswitch.lib #viewswitch .view-all, #viewswitch.lib #viewswitch .view-recents, #viewswitch.lib #viewswitch .adv-searchbtn, #viewswitch.lib .view-all, #viewswitch-lib .view-recents, #viewswitch-lib #viewswitch-search {display:block;}
+#viewswitch.lib .view-all, #viewswitch.lib .view-recents, #viewswitch.lib #viewswitch-search {display:block;}
+#viewswitch.lib .album-view.btn {border-bottom: 1px solid rgba(128,128,128,0.2);}
+
+#viewswitch.va .album-view-btn .pane {display:block;}
+#viewswitch.vt .tag-view-btn .pane {display:block;}
+#viewswitch.vr .radio-view-btn .pane {display:block;}
+#viewswitch.vf .folder-view-btn .pane {display:block;}
+
 #viewswitch span {float:right;display:none;}
 #searchResetLib {padding:.75rem .25em;position:relative;transform:translate(0, -50%);line-height:normal;}
 #viewswitch a {color:inherit;}
@@ -533,7 +545,7 @@ input[type='range'].vslide2::-webkit-slider-thumb {background:#fff;background-im
 #playbar-mtime {display:none;}
 #playbar-countdown.radio {float:right;left:3em;}
 #mobile-time {margin-top:-13px;}
-#m-countdown, #m-total {font-size:.75em;}
+#m-countdown, #m-total {font-weight:500;letter-spacing:-.2px;}
 #playbar-countdown.long-time, #m-countdown.long-time {left:-3.5rem!important;}
 #playbar-total.long-time, #m-total.long-time {left:3.5rem!important;}
 #playback-switch {position:absolute;height:2.5rem;width:20%;top:0;top:env(safe-area-inset-top);left:50%;transform:translate(-50%);text-align:center;font-size:1.2em;color:var(--adapttext);display:none;cursor:pointer;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -296,12 +296,9 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #viewswitch-search {height:2.25rem;padding:1.5rem 0 1.5rem 1rem !important;display:none;}
 #viewswitch .view-all, #viewswitch .view-recents {display:none;}
 
-#viewswitch.lib #viewswitch .view-all, #viewswitch.lib #viewswitch .view-recents, #viewswitch.lib #viewswitch .adv-searchbtn, #viewswitch.lib .view-all, #viewswitch-lib .view-recents, #viewswitch-lib #viewswitch-search {display:block;}
-#viewswitch.lib .view-all, #viewswitch.lib .view-recents, #viewswitch.lib #viewswitch-search {display:block;}
-#viewswitch.lib .album-view.btn {border-bottom: 1px solid rgba(128,128,128,0.2);}
-
-#viewswitch.va .album-view-btn .pane {display:block;}
-#viewswitch.vt .tag-view-btn .pane {display:block;}
+#viewswitch.va .view-all, #viewswitch.va .view-recents, #viewswitch.va .adv-searchbtn, #viewswitch.va #viewswitch-search, #viewswitch.va .album-view-btn .pane {display:block;}
+#viewswitch.vt .view-all, #viewswitch.vt .view-recents, #viewswitch.vt .adv-searchbtn, #viewswitch.vt #viewswitch-search, #viewswitch.vt .tag-view-btn .pane {display:block;}
+#viewswitch.va .album-view-btn, #viewswitch.vt .album-view-btn {border-bottom: 1px solid rgba(128,128,128,0.2);}
 #viewswitch.vr .radio-view-btn .pane {display:block;}
 #viewswitch.vf .folder-view-btn .pane {display:block;}
 

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -3304,8 +3304,6 @@ $('#playbar-switch, #playbar-cover, #playbar-title').click(function(e){
 		$('#menu-header').text('');
 		$('#container-playlist').css('visibility','');
 		$('#menu-bottom, .viewswitch').css('display', 'none');
-		$('#folder-panel, #radio-panel, #library-panel').removeClass('active');
-		$('#playback-panel').addClass('active');
 		$('#playback-controls').css('display', '');
         $('#addfav-li').hide();
 		if (UI.mobile) {
@@ -3319,6 +3317,8 @@ $('#playbar-switch, #playbar-cover, #playbar-title').click(function(e){
         else {
 			customScroll('playlist', parseInt(MPD.json['song']), 0);
 		}
+		$('#folder-panel, #radio-panel, #library-panel').removeClass('active');
+		$('#playback-panel').addClass('active');
 	}
 });
 
@@ -3374,7 +3374,7 @@ function makeActive (vswitch, panel, view) {
 	}
 
 	$('#content .tab-pane, .viewswitch button').removeClass('active');
-	$('#viewswitch').removeClass('lib oth vr vf vt va');
+	$('#viewswitch').removeClass('vr vf vt va');
     $.post('command/moode.php?cmd=updcfgsystem', {'current_view': view});
 	currentView = view;
 	setColors();
@@ -3387,16 +3387,16 @@ function makeActive (vswitch, panel, view) {
 
 	switch (view) {
 		case 'radio':
-			$('#viewswitch').addClass('oth vr');
+			$('#viewswitch').addClass('vr');
 			$('#playbar-toggles .addfav').show();
 			lazyLode('radio');
 			break;
 		case 'folder':
-			$('#viewswitch').addClass('oth vf');
+			$('#viewswitch').addClass('vf');
 			$('#playbar-toggles .addfav').show();
 			break;
 		case 'album':
-			$('#viewswitch').addClass('lib va');
+			$('#viewswitch').addClass('va');
             $('#playbar-toggles .addfav').hide();
 			$('#library-panel').addClass('covers').removeClass('tag');
             //SESSION.json['library_flatlist_filter'] == 'full_lib' ? $('#searchResetLib').hide() : $('#searchResetLib').show();
@@ -3413,7 +3413,7 @@ function makeActive (vswitch, panel, view) {
 			lazyLode('album');
 			break;
 		case 'tag':
-			$('#viewswitch').addClass('lib vt');
+			$('#viewswitch').addClass('vt');
             $('#playbar-toggles .addfav').hide();
 			$('#library-panel').addClass('tag').removeClass('covers');
             //SESSION.json['library_flatlist_filter'] == 'full_lib' ? $('#searchResetLib').hide() : $('#searchResetLib').show();
@@ -3422,10 +3422,10 @@ function makeActive (vswitch, panel, view) {
 			if (SESSION.json['library_tagview_covers']) lazyLode('tag');
 			break;
 	}
-	//const duration = performance.now() - startTime;
-    //console.log(duration + 'ms');
 	setLibMenuAndHeader();
 	$(vswitch + ',' + panel).addClass('active');
+	//const duration = performance.now() - startTime;
+    //console.log(duration + 'ms');
 }
 
 // Set the Library menu and header
@@ -3491,6 +3491,7 @@ function setLibMenuAndHeader () {
 }
 
 function lazyLode(view, skip, force) {
+    //const startTime = performance.now();
 	//console.log(view);
     // If browser does not support native lazy load then fall back to JQuery lazy load
     if (!GLOBAL.nativeLazyLoad) {
@@ -3525,26 +3526,28 @@ function lazyLode(view, skip, force) {
  		}
 
         if (selector && container) {
-			$.ensure(container + ' li').then(function(){
-				if (!$(container + ' ' + selector).attr('src') || force) {
-					$(container + ' ' + selector).lazyload({
-						container: $(container),
-						skip_invisible: skip
-					});
-				}
-				if (UI.libPos[1] >= 0 && currentView == 'album') {
-					customScroll('albumcovers', UI.libPos[1], 0);
-					$('#albumcovers .lib-entry').eq(UI.libPos[1]).addClass('active');
-				}
-				if (UI.libPos[0] >= 0 && currentView == 'tag') {
-					customScroll('albums', UI.libPos[0], 0);
-					$('#albumsList .lib-entry').eq(UI.libPos[0]).addClass('active');
-    				$('#albumsList .lib-entry').eq(UI.libPos[0]).click();
-				}
-				if (UI.radioPos >= 0 && currentView == 'radio') {customScroll('radio', UI.radioPos, 0);}
-			});
-        }
+			if (!$(container + ' ' + selector).attr('src') || force) {
+				$.ensure(container + ' li').then(function(){
+						$(container + ' ' + selector).lazyload({
+							container: $(container),
+							skip_invisible: skip
+						});
+					if (UI.libPos[1] >= 0 && currentView == 'album') {
+						customScroll('albumcovers', UI.libPos[1], 0);
+						$('#albumcovers .lib-entry').eq(UI.libPos[1]).addClass('active');
+					}
+					if (UI.libPos[0] >= 0 && currentView == 'tag') {
+						customScroll('albums', UI.libPos[0], 0);
+						$('#albumsList .lib-entry').eq(UI.libPos[0]).addClass('active');
+	    				$('#albumsList .lib-entry').eq(UI.libPos[0]).click();
+					}
+					if (UI.radioPos >= 0 && currentView == 'radio') {customScroll('radio', UI.radioPos, 0);}
+				});
+	        }		
+		}
  	}
+	//const duration = performance.now() - startTime;
+    //console.log(duration + 'ms');
 }
 
 function setFontSize() {
@@ -3614,6 +3617,7 @@ function getRootElementFontSize() {
 
 // jquery.ensure.js - https://stackoverflow.com/a/48191803 - Matheus Dal'Pizzol
 $.ensure = function (selector) {
+    //const startTime = performance.now();
     var promise = $.Deferred();
     var interval = setInterval(function () {
         if ($(selector)[0]) {
@@ -3621,8 +3625,9 @@ $.ensure = function (selector) {
             promise.resolve();
         }
     }, 1);
+	//const duration = performance.now() - startTime;
+    //console.log(duration + 'ms');
     return promise;
-    clearInterval(interval);
 };
 
 function applyLibFilter(filterType, filterStr = '') {

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -1737,7 +1737,7 @@ function updKnobAndTimeTrack() {
 	else {
 		if (UI.mobile) {
 			$('#timeline').show();
-            $('#playbar-mcount').text($('#countdown-display').text());
+            $('#playbar-mcount, #m-countdown').text($('#countdown-display').text());
 		}
 		else {
 			$('#playbar-timeline').show();
@@ -1754,14 +1754,16 @@ function updKnobAndTimeTrack() {
         UI.knob = setInterval(function() {
 			if (UI.mobile || $('#menu-bottom').css('display') == 'flex') {
 				if (!timeSliderMove) {
+
 					syncTimers();
+
 					if (UI.mobile) {
 						tt.val(GLOBAL.initTime * 10).trigger('change');
 					}
 				}
 			}
             delta === 0 ? GLOBAL.initTime = GLOBAL.initTime + 0.5 : GLOBAL.initTime = GLOBAL.initTime + 0.1; // fast paint when radio station playing
-			if (!UI.mobile) {
+			if (!UI.mobile && $('#menu-bottom').css('display') != 'flex') {
 	            if (delta === 0 && GLOBAL.initTime > 100) { // stops painting when radio (delta = 0) and knob fully painted
 					window.clearInterval(UI.knob)
 					UI.knobPainted = true;
@@ -3348,8 +3350,7 @@ function syncTimers() {
     var a = $('#countdown-display').text();
     if (a != GLOBAL.lastTimeCount) { // Only update if time has changed
         if (UI.mobile) { // Only change when needed to save work
-            $('#m-countdown').text(a);
-            $('#playbar-mcount').text(a);
+            $('#m-countdown, #playbar-mcount').text(a);
         }
         else if (coverView || currentView.indexOf('playback') == -1) {
             $('#playbar-countdown').text(a);
@@ -3373,38 +3374,32 @@ function makeActive (vswitch, panel, view) {
 	}
 
 	$('#content .tab-pane, .viewswitch button').removeClass('active');
-	$(vswitch + ',' + panel).addClass('active');
+	$('#viewswitch').removeClass('lib oth vr vf vt va');
     $.post('command/moode.php?cmd=updcfgsystem', {'current_view': view});
 	currentView = view;
 	setColors();
-	setLibMenuAndHeader();
-	$('#viewswitch span.pane').hide();
 
-    if (view == 'tag' || view == 'album') {
+    /*if (view == 'tag' || view == 'album') {
         if (SESSION.json['library_flatlist_filter'] != 'full_lib' && SESSION.json['library_flatlist_filter'] != 'tags') {
             $('#lib-album-filter').val(SESSION.json['library_flatlist_filter'] + ' ' + SESSION.json['library_flatlist_filter_str']);
         }
-    }
+    }*/
 
 	switch (view) {
 		case 'radio':
-			$('#viewswitch-search, #viewswitch .view-all, #viewswitch .view-recents, #viewswitch .adv-search-btn, #addfav-li, #random-album').hide();
-			$('#viewswitch .album-view-btn').removeClass('menu-separator');
-			$('.radio-view-btn .pane, #playbar-toggles .addfav').show();
+			$('#viewswitch').addClass('oth vr');
+			$('#playbar-toggles .addfav').show();
 			lazyLode('radio');
 			break;
 		case 'folder':
-			$('#viewswitch-search, #viewswitch .view-all, #viewswitch .view-recents, #viewswitch .adv-search-btn, #addfav-li, #random-album').hide();
-			$('#viewswitch .album-view-btn').removeClass('menu-separator');
-			$('.folder-view-btn .pane, #playbar-toggles .addfav').show();
+			$('#viewswitch').addClass('oth vf');
+			$('#playbar-toggles .addfav').show();
 			break;
 		case 'album':
-			$('#viewswitch-search, #viewswitch .view-all, #viewswitch .view-recents, #viewswitch .adv-search-btn, #addfav-li, #random-album').show();
-			$('#viewswitch .album-view-btn').addClass('menu-separator');
-			$('.album-view-btn .pane').show();
+			$('#viewswitch').addClass('lib va');
             $('#playbar-toggles .addfav').hide();
 			$('#library-panel').addClass('covers').removeClass('tag');
-            SESSION.json['library_flatlist_filter'] == 'full_lib' ? $('#searchResetLib').hide() : $('#searchResetLib').show();
+            //SESSION.json['library_flatlist_filter'] == 'full_lib' ? $('#searchResetLib').hide() : $('#searchResetLib').show();
             if ($('#tracklist-toggle').text().trim() == 'Hide tracks') {
                 $('#bottom-row').css('display', 'flex')
                 $('#lib-albumcover').css('height', 'calc(50% - env(safe-area-inset-top) - 2.75rem)'); // Was 1.75em
@@ -3418,12 +3413,10 @@ function makeActive (vswitch, panel, view) {
 			lazyLode('album');
 			break;
 		case 'tag':
-			$('#viewswitch-search, #viewswitch .view-all, #viewswitch .view-recents, #viewswitch .adv-search-btn, #addfav-li, #random-album').show();
-			$('#viewswitch .album-view-btn').addClass('menu-separator');
-			$('.tag-view-btn .pane').show();
+			$('#viewswitch').addClass('lib vt');
             $('#playbar-toggles .addfav').hide();
 			$('#library-panel').addClass('tag').removeClass('covers');
-            SESSION.json['library_flatlist_filter'] == 'full_lib' ? $('#searchResetLib').hide() : $('#searchResetLib').show();
+            //SESSION.json['library_flatlist_filter'] == 'full_lib' ? $('#searchResetLib').hide() : $('#searchResetLib').show();
             $('#index-albumcovers').hide();
 			SESSION.json['library_show_genres'] == 'Yes' ? $('#top-columns').removeClass('nogenre') : $('#top-columns').addClass('nogenre');
 			if (SESSION.json['library_tagview_covers']) lazyLode('tag');
@@ -3431,6 +3424,8 @@ function makeActive (vswitch, panel, view) {
 	}
 	//const duration = performance.now() - startTime;
     //console.log(duration + 'ms');
+	setLibMenuAndHeader();
+	$(vswitch + ',' + panel).addClass('active');
 }
 
 // Set the Library menu and header

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -156,7 +156,7 @@
 				<button aria-label="Radio" class="btn radio-view-btn" href="#radio-panel"><i class="fas fa-microphone"></i> Radio<span class="pane"><i class="fal fa-check"></i></span></button>
 				<button aria-label="Folder" class="btn folder-view-btn" href="#library-panel"><i class="fas fa-folder"></i> Folder<span class="pane"><i class="fal fa-check"></i></span></button>
 				<button aria-label="Tag" class="btn tag-view-btn" href="#library-panel"><i class="fas fa-columns"></i> Tag<span class="pane"><i class="fal fa-check"></i></span></button>
-				<button aria-label="Album" class="btn album-view-btn menu-separator" href="#library-panel"><i class="fas fa-th"></i> Album<span class="pane"><i class="fal fa-check"></i></span></button>
+				<button aria-label="Album" class="btn album-view-btn" href="#library-panel"><i class="fas fa-th"></i> Album<span class="pane"><i class="fal fa-check"></i></span></button>
 				<button aria-label="Clear Library cache" class="btn clear-libcache-btn menu-separator hide" data-toggle="modal" href="#clear-libcache"><i class="far fa-trash"></i> Clear Library cache</button>
 				<button aria-label="All Music" class="btn view-all no-icon" data-cmd="allmusic">All Music<span><i class="fal fa-check"></i></span></button>
 				<button aria-label="Recently Added" class="btn view-recents no-icon" data-cmd="recentmusic">Recently Added<span><i class="fal fa-check"></i></span></button>


### PR DESCRIPTION
This does two main things:

1) move the addClass/removeClass to the bottom of the function so the javascript in the function doesn't hit it while the page is rendering, this removes the forced reflow whatever (unrelated to the countdown library) from the console when switching from playback to the library, at least in desktop chrome on my system.

2) moves most of the show/hide functions previously done in js to css by adding classes lib/oth and vr/vf/vt/va.

also...

3) bumps the font weight for the currentalbum div (artist/album in playback)

4) bumps the font size of the mobile countdown/total clocks

5) adds m-countdown to the list of elements that get the countdown-display value (was left blank on reload if mpd was in a paused state)

6) (possibly controversially so can be omitted) removed the previously entered search term on reload, which lets us remove the code that shows the search reset in makeActive. the previous value is still shown unless cleared or the page is refreshed.