### PR TITLE
[gulp] fix broken deploy --all

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -447,7 +447,7 @@ gulp.task('deploymoodeutl', function (done) {
 gulp.task('deployvarlocalwww', function (done) {
     return gulp.src([  pkg.app.src+'/../var/local/www/**' ])
         .pipe($.size({showFiles: true, total: true}))
-        .pipe(gulp.dest(DEPLOY_LOCATION+'/../var/local/www'))
+        .pipe(gulp.dest(DEPLOY_LOCATION+'/../local/www'))
         .on('end', done);
 });
 


### PR DESCRIPTION
The moode/var/local/www stuff was deployed to /var/var/local/www instead of /var/local/www.