### PR TITLE
Minor HTML corrections

### DIFF
--- a/www/audioinfo.php
+++ b/www/audioinfo.php
@@ -242,11 +242,11 @@ else {
 		$resample_rate = $cfg_mpd['audio_output_depth'] . ' bit, ' . $cfg_mpd['audio_output_rate'] . ' kHz, ' . $cfg_mpd['audio_output_chan'];
 		$patch_id = explode('_p0x', $_SESSION['mpdver'])[1];
 		$resample_modes = array('0' => 'disabled',
-			SOX_UPSAMPLE_ALL => 'Upsample if source < target rate',
+			SOX_UPSAMPLE_ALL => 'Upsample if source &lt; target rate',
 			SOX_UPSAMPLE_ONLY_41K => 'Upsample only 44.1K source rate',
 			SOX_UPSAMPLE_ONLY_4148K => 'Upsample only 44.1K and 48K source rates',
 			SOX_ADHERE_BASE_FREQ => 'Resample (adhere to base freq)',
-			(SOX_UPSAMPLE_ALL + SOX_ADHERE_BASE_FREQ) => 'Upsample if source < target rate (adhere to base freq)'
+			(SOX_UPSAMPLE_ALL + SOX_ADHERE_BASE_FREQ) => 'Upsample if source &lt; target rate (adhere to base freq)'
 		);
 		if ($patch_id & PATCH_SELECTIVE_RESAMPLING) {
 			$_selective_resampling_hide = '';

--- a/www/mpd-config.php
+++ b/www/mpd-config.php
@@ -142,11 +142,11 @@ $patch_id = explode('_p0x', $_SESSION['mpdver'])[1];
 if ($patch_id & PATCH_SELECTIVE_RESAMPLING) {
 	$_selective_resampling_hide = '';
 	$_mpd_select['selective_resample_mode'] .= "<option value=\"0\" " . (($mpdconf['selective_resample_mode'] == '0') ? "selected" : "") . " >Disabled</option>\n";
-	$_mpd_select['selective_resample_mode'] .= "<option value=\"" . SOX_UPSAMPLE_ALL . "\" " . (($mpdconf['selective_resample_mode'] == SOX_UPSAMPLE_ALL) ? "selected" : "") . " >Upsample if source < target rate</option>\n";
+	$_mpd_select['selective_resample_mode'] .= "<option value=\"" . SOX_UPSAMPLE_ALL . "\" " . (($mpdconf['selective_resample_mode'] == SOX_UPSAMPLE_ALL) ? "selected" : "") . " >Upsample if source &lt; target rate</option>\n";
 	$_mpd_select['selective_resample_mode'] .= "<option value=\"" . SOX_UPSAMPLE_ONLY_41K . "\" " . (($mpdconf['selective_resample_mode'] == SOX_UPSAMPLE_ONLY_41K) ? "selected" : "") . " >Upsample only 44.1K source rate</option>\n";
 	$_mpd_select['selective_resample_mode'] .= "<option value=\"" . SOX_UPSAMPLE_ONLY_4148K . "\" " . (($mpdconf['selective_resample_mode'] == SOX_UPSAMPLE_ONLY_4148K) ? "selected" : "") . " >Upsample only 44.1K and 48K source rates</option>\n";
 	$_mpd_select['selective_resample_mode'] .= "<option value=\"" . SOX_ADHERE_BASE_FREQ . "\" " . (($mpdconf['selective_resample_mode'] == SOX_ADHERE_BASE_FREQ) ? "selected" : "") . " >Resample (adhere to base freq)</option>\n";
-	$_mpd_select['selective_resample_mode'] .= "<option value=\"" . (SOX_UPSAMPLE_ALL + SOX_ADHERE_BASE_FREQ) . "\" " . (($mpdconf['selective_resample_mode'] == (SOX_UPSAMPLE_ALL + SOX_ADHERE_BASE_FREQ)) ? "selected" : "") . " >Upsample if source < target rate (adhere to base freq)</option>\n";
+	$_mpd_select['selective_resample_mode'] .= "<option value=\"" . (SOX_UPSAMPLE_ALL + SOX_ADHERE_BASE_FREQ) . "\" " . (($mpdconf['selective_resample_mode'] == (SOX_UPSAMPLE_ALL + SOX_ADHERE_BASE_FREQ)) ? "selected" : "") . " >Upsample if source &lt; target rate (adhere to base freq)</option>\n";
 }
 else {
 	$_selective_resampling_hide = 'hide';

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -96,7 +96,7 @@
 					</div>
 					<div id="togglebtns">
 						<div class="btn-group">
-							<button aria-label="Context Menu" class="btn playback-context-menu" data-toggle="context" data-target="#context-menu-playback" class="btn btn-cmd"><i class="far fa-ellipsis-h"></i></button>
+							<button aria-label="Context Menu" class="btn btn-cmd playback-context-menu" data-toggle="context" data-target="#context-menu-playback"><i class="far fa-ellipsis-h"></i></button>
 							<button href="#notarget" class="btn btn-cmd toggle-song hide" data-cmd="toggle-song"><i class="fal fa-exchange-alt"></i></button>
 							<button aria-label="Random" class="btn btn-cmd btn-toggle random" data-cmd="random"><i class="fal fa-random"></i></button>
 							<button aria-label="Cover View" class="btn btn-cmd coverview"><i class="fal fa-tv"></i></button>
@@ -971,7 +971,7 @@
  						</div>
  						<a aria-label="Help" class="info-toggle" data-cmd="info-show-encoded-at" href="#notarget"><i class="fas fa-info-circle"></i></a>
  						<span id="info-show-encoded-at" class="help-block hide">
-	                    	The bit depth and sample rate can be displayed in one of several formats on or below the cover art. The "HD only" selection displays an HD badge when for Song files the bit depth > 16 or sample rate > 44.1 kHz, and for Radio stations the bit rate is > 128 kbps.
+	                    	The bit depth and sample rate can be displayed in one of several formats on or below the cover art. The "HD only" selection displays an HD badge when for Song files the bit depth &gt; 16 or sample rate &gt; 44.1 kHz, and for Radio stations the bit rate is &gt; 128 kbps.
  	                    </span>
  	                </div>
 
@@ -1454,7 +1454,7 @@
 								</ul>
 							</div>
 						</div>
-						<a aria-label="Help" class="info-toggle" data-cmd="info-action" href="#notarget"><i class="fas fa-info-circle"></i></a></span>
+						<a aria-label="Help" class="info-toggle" data-cmd="info-action" href="#notarget"><i class="fas fa-info-circle"></i></a>
 						<span id="info-action" class="help-block hide">
 							NOTE: The Restart action is initiated 45 seconds after the specified stop time.
 						</span>

--- a/www/templates/mpd-config.html
+++ b/www/templates/mpd-config.html
@@ -183,7 +183,7 @@
 								01 ROLLOFF_MEDIUM 0.35 dB<br>
 								02 ROLLOFF_NONE For Chebyshev bandwidth.<br>
 								08 HI_PREC_CLOCK Increase "irrational" ratio accuracy.<br>
-								16 DOUBLE_PRECISION Use DP calcs even if precision <= 20<br>
+								16 DOUBLE_PRECISION Use DP calcs even if precision &lt;= 20<br>
 								32 SOXR_VR Variable-rate resampling.
 		                    </span>
 		                </div>

--- a/www/templates/snd-config.html
+++ b/www/templates/snd-config.html
@@ -89,7 +89,7 @@
 			<div class="control-group">
 				<label class="control-label" for="mpdver">MPD version</label>
 				<div class="controls">
-					<select id="cpugov" class="input-large" name="mpdver">
+					<select id="mpdver" class="input-large" name="mpdver">
 						$_select[mpdver]
 					</select>
 					<button class="btn btn-primary btn-small set-button btn-submit" type="submit" name="update_mpdver" value="novalue">Set</button>
@@ -151,7 +151,7 @@
 			<div class="control-group">
 				<label class="control-label" for="ashuffle_mode">Mode</label>
 				<div class="controls">
-					<select id="cpugov" class="input-large" name="ashuffle_mode">
+					<select id="ashuffle_mode" class="input-large" name="ashuffle_mode">
 						$_select[ashuffle_mode]
 					</select>
 					<button class="btn btn-primary btn-small set-button btn-submit" type="submit" name="update_ashuffle_mode" value="novalue">Set</button>


### PR DESCRIPTION
Escaped html < and > characters where applicable.

indextpl.html - consolidated 2 "class" attributes into 1 & removed spurious </span> tag.

snd-config.html - corrected 2 id's.