### PR TITLE
Combine track info and audio info into one dialog

### DIFF
--- a/www/audioinfo.php
+++ b/www/audioinfo.php
@@ -214,20 +214,20 @@ else {
 // Renderers
 if ($_SESSION['airplayactv'] == '1' || $_SESSION['spotactive'] == '1' || $_SESSION['slactive'] == '1' || $_SESSION['inpactive'] == '1' || $btactive === true) {
 	$resample_rate = '';
-	$resample_quality = 'n/a';
-	$polarity_inv = 'n/a';
-	$crossfade = 'n/a';
-	$crossfeed = 'n/a';
-	$replaygain = 'n/a';
-	$vol_normalize = 'n/a';
+	$resample_quality = 'off';
+	$polarity_inv = 'off';
+	$crossfade = 'off';
+	$crossfeed = 'off';
+	$replaygain = 'off';
+	$vol_normalize = 'off';
 
 	if ($_SESSION['airplayactv'] == '1' || $_SESSION['spotactive'] == '1') {
 		$peq = $_SESSION['eqfa12p'] == 'Off' ? 'off' : $_SESSION['eqfa12p'];
 		$geq = $_SESSION['alsaequal'] == 'Off' ? 'off' : $_SESSION['alsaequal'];
 	}
 	else {
-		$peq = 'n/a';
-		$geq = 'n/a';
+		$peq = 'off';
+		$geq = 'off';
 	}
 }
 // MPD
@@ -242,11 +242,11 @@ else {
 		$resample_rate = $cfg_mpd['audio_output_depth'] . ' bit, ' . $cfg_mpd['audio_output_rate'] . ' kHz, ' . $cfg_mpd['audio_output_chan'];
 		$patch_id = explode('_p0x', $_SESSION['mpdver'])[1];
 		$resample_modes = array('0' => 'disabled',
-			SOX_UPSAMPLE_ALL => 'Upsample if source &lt; target rate',
-			SOX_UPSAMPLE_ONLY_41K => 'Upsample only 44.1K source rate',
-			SOX_UPSAMPLE_ONLY_4148K => 'Upsample only 44.1K and 48K source rates',
-			SOX_ADHERE_BASE_FREQ => 'Resample (adhere to base freq)',
-			(SOX_UPSAMPLE_ALL + SOX_ADHERE_BASE_FREQ) => 'Upsample if source &lt; target rate (adhere to base freq)'
+			SOX_UPSAMPLE_ALL => 'source > target rate',
+			SOX_UPSAMPLE_ONLY_41K => 'only 44.1K source rate',
+			SOX_UPSAMPLE_ONLY_4148K => 'only 44.1K and 48K source rates',
+			SOX_ADHERE_BASE_FREQ => 'resample (adhere to base freq)',
+			(SOX_UPSAMPLE_ALL + SOX_ADHERE_BASE_FREQ) => 'source > target rate (adhere to base freq)'
 		);
 		if ($patch_id & PATCH_SELECTIVE_RESAMPLING) {
 			$_selective_resampling_hide = '';

--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -211,7 +211,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#togglebtns .btn-group .btn i {min-width:1.25rem;}
 	#playbtns, #togglebtns/*, .volume-popup-btn-*/ {display:block;}
 	.coverview {display:none;}
-	#currentsong {font-size:1.5em;font-weight:bold;padding-top:0}
+	#currentsong {font-size:1.5em;font-weight:bold;}
 	#currentalbum, #currentartist {font-size:1.35em;margin-bottom:1.25em;}
 	#timeline {display:block;width:74vw;}
 	#mobile-time {display:block;}

--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -212,7 +212,8 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#playbtns, #togglebtns/*, .volume-popup-btn-*/ {display:block;}
 	.coverview {display:none;}
 	#currentsong {font-size:1.5em;font-weight:bold;}
-	#currentalbum, #currentartist {font-size:1.35em;margin-bottom:1.25em;}
+	#currentalbum {font-size:1.35em;}
+	#currentartist {font-size:1.35em;margin-bottom:1.35em;}
 	#timeline {display:block;width:74vw;}
 	#mobile-time {display:block;}
 	.btn btn-cmd btn-toggle {font-size:.75em;}

--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -25,14 +25,16 @@ a:focus {color:var(--accentxts);} /* fixes blue outline on control after closing
 a.btn.btn-medium.btn-primary {font-size:16px;}
 #config-tabs {position:absolute;top:0;top:env(safe-area-inset-top);color:inherit;display:flex;z-index:1001;line-height:normal;font-size:inherit;height:2.75em;align-items:center;display:none;}
 #config-tabs a {font-size:.9rem;color:#ddd;display:inline-flex;}
-#config-tabs .btn {padding: .35rem .6rem;}
+#config-tabs .btn {padding: .35rem .6rem;border-right:1px solid rgba(128,128,128,.35)}
+#config-tabs .btn:last-child, #config-tabs .btn.active {border:none;}
 .viewswitch-cfgs {position:absolute;top:0;top:env(safe-area-inset-top);left:50%;box-sizing:border-box;background-color:transparent;color:inherit;display:none;z-index:1001;line-height:normal;font-size:inherit;transform:translate(-50%, 0%);height:2.75em;align-items:center;}
-.viewswitch-cfgs .btn {position:relative;align-items:center;border-radius:0px;width:50%;/*height:65%;*/line-height:normal;font-size:1rem;padding:.35rem 1rem;color:inherit;border-top:1px solid var(--btnbarcolor);border-bottom:1px solid var(--btnbarcolor);border-right:1px solid var(--btnbarcolor);background: var(--btnshade3);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);}
-.viewswitch-cfgs .btn:first-child {border-top-left-radius:.25em;border-bottom-left-radius:.25em;border-left:1px solid var(--btnbarcolor);}
-.viewswitch-cfgs .btn:last-child {border-top-right-radius:.25em;border-bottom-right-radius:.25em;border-right:1px solid var(--btnbarcolor);border-left:none !important;}
-.viewswitch-cfgs .btn.active {background:rgba(128,128,128,.35);border:1px solid transparent;color:inherit;}
+.viewswitch-cfgs .btn {position:relative;align-items:center;border-radius:0px;width:50%;/*height:65%;*/line-height:normal;font-size:1rem;padding:.35rem 1rem;color:inherit;border:none;background: var(--btnshade3);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);}
+.viewswitch-cfgs .btn:first-child {border-top-left-radius:.25em;border-bottom-left-radius:.25em;}
+.viewswitch-cfgs .btn:last-child {border-top-right-radius:.25em;border-bottom-right-radius:.25em;}
+.viewswitch-cfgs .btn.active {background:rgba(128,128,128,.35);color:inherit;}
 .viewswitch-cfgs a {color:var(--btnbarcolor);box-sizing:border-box;}
 .viewswitch-cfgs .active a {color:inherit;}
+#audioinfo-tabs {display:flex;position:relative;width:25em;max-width:50%;margin-bottom:1em;}
 #config-back {position:absolute;float:left;left:0;top:0;top:calc(env(safe-area-inset-top) + 0);padding-left:1em;display:none;}
 #config-back a {color:#ddd;font-size:1.35rem;margin-right:.5em}
 .horiz-rule-light {border-bottom: 1px solid #333;margin-bottom:1.15em;font-size: 1.15em;font-style:italic;color: #888;}
@@ -210,7 +212,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#playbtns, #togglebtns/*, .volume-popup-btn-*/ {display:block;}
 	.coverview {display:none;}
 	#currentsong {font-size:1.5em;font-weight:bold;padding-top:0}
-	#currentalbum {font-size:1.35em;margin-bottom:1.25em;}
+	#currentalbum, #currentartist {font-size:1.35em;margin-bottom:1.25em;}
 	#timeline {display:block;width:74vw;}
 	#mobile-time {display:block;}
 	.btn btn-cmd btn-toggle {font-size:.75em;}
@@ -239,7 +241,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#lib-album-search input, #lib-album-search input, #current-tab, #menu-header {font-size:1.11rem;}
 	.dropdown-menu > li > a, .viewswitch .btn {font-size:1.16rem;line-height:2.75em;}
 	#playback-panel, #content {position:relative;}
-	.modal-body{padding:0 .5rem;max-height:80vh;}
+	.modal-body{padding:0 .75rem;max-height:80vh;}
 	.modal-footer .btn {width:40%;}
 	.modal .h5 {width:42%;}
 	.modal-body .form-horizontal .control-label {width:42%;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -96,7 +96,7 @@ html {background-color:inherit;}
 .configure-renderer, .disconnect-renderer {font-size:.7em!important;cursor:pointer;border-radius:5rem;background-color:var(--btnshade4);margin-top:1em;width:10em;color:inherit;}
 .configure-renderer:hover, .disconnect-renderer:hover {background-color:var(--btnshade4);} /* Mask hover effect */
 /* main ui */
-.playback-controls {display:none;position:absolute;top:0;left:50%;width:184px;margin:-1px 0 0 -92px;text-align:center;z-index:9;}
+/*.playback-controls {display:none;position:absolute;top:0;left:50%;width:184px;margin:-1px 0 0 -92px;text-align:center;z-index:9;}*/
 #currentsong, #currentalbum, #currentartist, #format-bitrate, #elapsed, #countdown-display {display:block;}
 #extra-tags-display {font-size:1rem;color:var(--textvariant);padding-top:.5em;text-align:center;display:block;cursor:pointer;}
 #currentsong {font-size:1.35em;padding-top:1.65rem;font-weight:bold;color:var(--accentxts);word-wrap:break-word;cursor:pointer;}
@@ -180,7 +180,7 @@ html {background-color:inherit;}
 a.btn-cmd {width:18px;}
 .btn2 {color:inherit;display:inline-block;}
 .btn-cmd:focus {outline:none;}
-img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(32, 32, 32, 0.25);width:100%;height:100%;cursor:pointer;}
+img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(32, 32, 32, 0.25);width:100%;height:100%;cursor:pointer;max-width:66vh;}
 .covers {padding:.75em 1em 0 1em}
 #coverart-url {position:relative;}
 #container-browse {width:100%;padding:0;top:2.75rem;top:calc(2.75rem + env(safe-area-inset-top));overflow:hidden;position:absolute;}
@@ -695,9 +695,14 @@ input[type='range'].vslide2::-moz-range-track {height:10em;width:2px;border-radi
 /* Library filter */
 #lib-flatlist-filter {font-size:.5em;}
 /* Audio info */
-.container-iteminfo li {list-style:none;line-height:normal;padding:.25rem .5rem;overflow:auto;}
-.container-iteminfo .h5 {margin:.6rem 0 .4rem 0;width:unset;}
-.container-iteminfo .h5:first-child{margin:0 0 .4rem 0;}
-.container-iteminfo .left {float:left;width:33%;}
-.container-iteminfo .right {float:right;width:67%;}
-.container-iteminfo .ralign {float:right;width:67%;text-align:right}
+.container-iteminfo li {list-style:none;line-height:normal;padding:.5rem;overflow:auto;}
+.container-iteminfo .h5 {margin:.6rem 0 .4rem 0;width:unset!important;}
+.container-iteminfo .left {float:left;color:var(--textvariant);font-weight:500;width:30%;}
+.container-iteminfo .right {float:right;width:70%;}
+.container-iteminfo .ralign {float:right;width:70%;text-align:right}
+.container-iteminfo .off, .container-iteminfo .None {display:none;}
+#audioinfo, #trackinfo {display:none;}
+#audioinfo-modal.hardware #audioinfo {display:block;}
+#audioinfo-modal.track #trackinfo {display:block;}
+#audioinfo-modal.hardware #audioinfo-hardware, #audioinfo-modal.track #audioinfo-track {background-color:var(--btnshade4);}
+#trackinfo li:nth-child(odd) {background-color:rgba(128,128,128,.05);}

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -1386,9 +1386,7 @@ $('#context-menu-lib-item a').click(function(e) {
 		$('#pl-saveName').val(''); // Clear saved playlist name if any
 	}
     else if ($(this).data('cmd') == 'track_info_lib') {
-        $.post('command/moode.php?cmd=track_info', {'path': filteredSongs[UI.dbEntry[0]].file}, function(result) {
-            itemInfoModal('track_info', result);
-        }, 'json');
+        audioinfo('track_info', filteredSongs[UI.dbEntry[0]].file);
 	}
 });
 

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -639,6 +639,7 @@ jQuery(document).ready(function($) { 'use strict';
     $('#savepl-modal').on('shown.bs.modal', function(e) {
         $('#pl-saveName').focus();
     });
+	
 	// Set favorites
     $('#pl-btnSetFav').click(function(e){
 		var favname = $('#pl-favName').val();
@@ -1276,12 +1277,18 @@ jQuery(document).ready(function($) { 'use strict';
     $('#extra-tags-display').click(function(e) {
         if ($('#currentsong').html() != '') {
             var cmd = MPD.json['artist'] == 'Radio station' ? 'station_info' : 'track_info';
-            $.post('command/moode.php?cmd=' + cmd, {'path': MPD.json['file']}, function(result) {
-                itemInfoModal(cmd, result);
-            }, 'json');
+            audioinfo(cmd, MPD.json['file']);
         }
     });
+	
+	$('#audioinfo-track').live('click', function(e) {
+		$('#audioinfo-modal').removeClass('hardware').addClass('track');
+	});
 
+	$('#audioinfo-hardware').live('click', function(e) {
+		$('#audioinfo-modal').removeClass('track').addClass('hardware');
+	});
+	
     // CoverView screen saver reset
     $('#screen-saver, #playback-panel, #library-panel, #folder-panel, #radio-panel, #menu-bottom').click(function(e) {
         //console.log('resetscnsaver: timeout (' + SESSION.json['scnsaver_timeout'] + ', currentView: ' + currentView + ')');

--- a/www/templates/audioinfo.html
+++ b/www/templates/audioinfo.html
@@ -21,80 +21,84 @@
  */
 -->
 <div class="container-iteminfo">
-	<div class="audioinfo">
+	<div id="audioinfo-tabs" class="viewswitch-cfgs hide">
+		<button id="audioinfo-track" class="btn">Track</button>
+		<button id="audioinfo-hardware" class="btn">Hardware</button>
+	</div>
+	<div id="audioinfo">
 		<div class="h5">Input / Output</div>
-		<li>
-			<span class="left">Source</span>
-			<span class="right">$file</span>
-		</li>
-		<li>
-			<span class="left">Encoded at</span>
-			<span class="right">$encoded_at</span>
-		</li>
-		<li>
-			<span class="left">Decoded to</span>
-			<span class="right">$decoded_to$decode_rate</span>
-		</li>
-		<li>
-			<span class="left">Destination</span>
-			<span class="right">$output_destination</span>
-		</li>
-		<li>
-			<span class="left">Output rate</span>
-			<span class="right">$hwparams_format$hwparams_calcrate</span>
-		</li>
+			<li>
+				<span class="left">Source</span>
+				<span class="right">$file</span>
+			</li>
+			<li>
+				<span class="left">Encoded at</span>
+				<span class="right">$encoded_at</span>
+			</li>
+			<li>
+				<span class="left">Decoded to</span>
+				<span class="right">$decoded_to$decode_rate</span>
+			</li>
+			<li>
+				<span class="left">Destination</span>
+				<span class="right">$output_destination</span>
+			</li>
+			<li>
+				<span class="left">Output rate</span>
+				<span class="right">$hwparams_format$hwparams_calcrate</span>
+			</li>
 
 		<div class="h5">DSP operations</div>
-		<li>
-			<span class="left">Resample rate</span>
-			<span class="right">$resample_rate</span>
-		</li>
-		<li class="$_selective_resampling_hide">
-			<span class="left">Selective rate</span>
-			<span class="right">$selective_resample</span>
-		</li>
-		<li>
-			<span class="left">Rsample quality</span>
-			<span class="right">$resample_quality</span>
-		</li>
-		<li>
-			<span class="left">Polarity inv</span>
-			<span class="right">$polarity_inv</span>
-		</li>
-		<li>
-			<span class="left">Crossfade</span>
-			<span class="right">$crossfade</span>
-		</li>
-		<li>
-			<span class="left">Crossfeed</span>
-			<span class="right">$crossfeed</span>
-		</li>
-		<li>
-			<span class="left">Parametric EQ</span>
-			<span class="right">$peq</span>
-		</li>
-		<li>
-			<span class="left">Graphic EQ</span>
-			<span class="right">$geq</span>
-		</li>
-		<li>
-			<span class="left">Replaygain</span>
-			<span class="right">$replaygain</span>
-		</li>
-		<li>
-			<span class="left">Normalize vol</span>
-			<span class="right">$vol_normalize</span>
-		</li>
-		<li>
-			<span class="left">Chip options</span>
-			<span class="right">$chip_options</span>
-		</li>
-		<li>
-			<span class="left">Volume mixer</span>
-			<span class="right">$volume_mixer</span>
-		</li>
+			<li>
+				<span class="left">Resample rate</span>
+				<span class="right">$resample_rate</span>
+			</li>
+			<li class="$_selective_resampling_hide">
+				<span class="left">Selective rate</span>
+				<span class="right">$selective_resample</span>
+			</li>
+			<li>
+				<span class="left">Resample quality</span>
+				<span class="right">$resample_quality</span>
+			</li>
+			<li class="$polarity_inv">
+				<span class="left">Polarity inv</span>
+				<span class="right">$polarity_inv</span>
+			</li>
+			<li class="$crossfade">
+				<span class="left">Crossfade</span>
+				<span class="right">$crossfade</span>
+			</li>
+			<li class="$crossfeed">
+				<span class="left">Crossfeed</span>
+				<span class="right">$crossfeed</span>
+			</li>
+			<li class="$peq">
+				<span class="left">Parametric EQ</span>
+				<span class="right">$peq</span>
+			</li>
+			<li class="$geq">
+				<span class="left">Graphic EQ</span>
+				<span class="right">$geq</span>
+			</li>
+			<li class="$replaygain">
+				<span class="left">Replaygain</span>
+				<span class="right">$replaygain</span>
+			</li>
+			<li class="$vol_normalize">
+				<span class="left">Normalize vol</span>
+				<span class="right">$vol_normalize</span>
+			</li>
+			<li class="$chip_options">
+				<span class="left">Chip options</span>
+				<span class="right">$chip_options</span>
+			</li>
+			<li>
+				<span class="left">Volume mixer</span>
+				<span class="right">$volume_mixer</span>
+			</li>
 
-	<div class="h5">Audio Device</div>
+		<div class="h5">Audio Device</div>
 		<li>
 			<span class="left">Device</span>
 			<span class="right">$devname</span>
@@ -119,5 +123,8 @@
 			<span class="left">Platform</span>
 			<span class="right">$hdwr_rev</span>
 		</li>
+	</div>
+	<div id="trackinfo">
+		<div id="trackdata"></div>
 	</div>
 </div>


### PR DESCRIPTION
This adds a tab bar to the audio info dialog with one showing track info and the other the hardware related info.

Changes:

audioinfo.php

make "n/a" items (e.g. for crossfade if airplay is active) say "off"

simplify resample list to better fit on one line. Upsampling is implied, but I left the resample text as it's the only one that can go in either direction.

audioinfo.html

add tabs for track/station & hardware

add div for track info

only show active info by adding class of the php var to the li of items that might have "off" or "None" as their data so they can be hidden.

moode.css

remove borders from viewswitch-cfg tabs

add audioinfo-tabs rule

fix no bottom margin on currentartist for mobile

bump mobile modal-body l/r padding a bit

panels.css

commented out .playback-controls as it isn't used

add a max-width to img.coverart so we can support smaller landscape sizes easier but i think we should have a minimum supported screen size (raspbery pi touchscreen maybe?)

modify/add audio info dialog rules

scripts-library.js

switch to new style track info call

scripts-panels.js

switch to new style track info call

add click handlers for the audio info tab bar

playerlib.js

switch to new style track info call

bump modal backdrop opacity a bit

add audiohardware function to handle the menu item from header.php

add audioinfo function that handles the display of the audio info dialog

generalize the itemInfoModal function so it can work with different elements, this is only called by audioinfo right now but might be useful elsewhere down the road. Possible enhancement would be to detect an empty list (e.g. if no track is playing or paused) and report something like "no information" as the output but the other half of the audio info dialog has empty strings so ¯\_(ツ)_/¯.
