### PR TITLE
fixed forum url link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ RaspiOS: https://www.raspbian.org/RaspbianRepository<br/>
 Moode OS Builder: https://github.com/moode-player/mosbuild<br/>
 moodeaudio.org: http://moodeaudio.org<br/>
 moOde Twitter feed: http://twitter.com/MoodeAudio</br>
-moOde Forum http://moodeaudio.org/Forum
+moOde Forum http://moodeaudio.org/forum


### PR DESCRIPTION
The link to the forum was wrong, it was:
 http://moodeaudio.org/Forum/

should be:
 http://moodeaudio.org/forum/

small thing, but hey, it's fixed! Love and use Moode daily here, thanks for the amazing project!