### PR TITLE
Redo view systen

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -74,9 +74,9 @@ h6 {font-size: large;font-weight: 500;text-transform: capitalize;text-align: cen
 .bootstrap-select.select-large:not([class*="span"]) {width:250px;}
 .bootstrap-select.select-large2:not([class*="span"]) {width: 282px;}
 /* stuff */
-#playback-queue {width:38%;}
-#playback-cover {padding:0;width:38%;}
-#playback-controls {width:24%;margin-left:0px;}
+#playback-queue {width:38vw;}
+#playback-cover {padding:0;width:38vw;}
+#playback-controls {width:24vw;margin-left:0px;}
 #playback-panel.newui #playback-queue, #playback-panel.cv #playback-queue {position:relative;width:44%;left:-10000px;;margin:0 auto;}
 #playback-panel.newui #playback-cover, #playback-panel.cv #playback-cover {padding:0;width:33vw;position:absolute;left:50%;transform:translate(-50%);}
 #playback-panel.newui #playback-controls, #playback-panel.cv #playback-controls {margin-left:0px;width:100%;height:calc(100vh - 2.75rem);position:absolute;}
@@ -189,7 +189,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	.lib-artistname-meta, .lib-albumyear-meta, .lib-numtracks-meta, .lib-encoded-at-meta {text-align:left;}
 	#trackscontainer {width:100%;max-width:100%;}
 	.container-playback {padding: 0;}
-	#playback-controls {display:flex;flex-direction:column;position:fixed;width:100%;bottom:1vh;bottom:calc(env(safe-area-inset-bottom) - 1vh);left:0;z-index:10;/*padding-top:10vh;*/}
+	#playback-controls {flex-direction:column;position:fixed;width:100%;bottom:1vh;bottom:calc(env(safe-area-inset-bottom) - 1vh);left:0;z-index:10;/*padding-top:10vh;*/}
 	#mt1, #mt2, #mt3 {font-size:inherit;}
 	#mt1 {margin:4rem 1.5rem 0rem 1.5rem;}
 	#mt3 {margin-right:5px;float:right;margin-top:25vh;}
@@ -217,10 +217,10 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#currentsong {font-size:1.5em;font-weight:bold;}
 	#currentalbum {font-size:1.35em;}
 	#currentartist {font-size:1.35em;margin-bottom:1.35em;}
-	#timeline {display:block;width:74vw;}
 	#mobile-time {display:block;}
 	.btn btn-cmd btn-toggle {font-size:.75em;}
-	img.coverart {width:50vh;height:auto;max-width:90vw;max-height:90vw;border:none;}
+	img.coverart {width:90vw;height:90vw;}	
+	/*img.coverart {width:50vh;height:auto;max-width:90vw;max-height:90vw;border:none;}*/
 	#playback-firstuse-help {height:50vh;width:50vh;max-height:90vw;max-width:90vw;left:50%;transform:translate(-50%);}
 	img.libart {width:90%;}
 	.modal-sm2 {min-width:80%;}
@@ -237,6 +237,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 /* smaller portrait for small screens */
 @media (max-width:479px) and (orientation:portrait) {
 	#content.fancy #container-playlist {-webkit-mask-image:unset;}
+	#container-playlist {visibility:hidden;}
 	.database .db-entry {margin-left:3.5em;padding:1em 0;font-size:1.1em;}
 	.database .db-action {font-size:1.3em;}
 	/*.dropdown-menu {min-width:180px;}*/
@@ -244,7 +245,20 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#context-menu-playback .dropdown-menu {min-width:15rem;} /* Make this one a bit wider */
 	#lib-album-search input, #lib-album-search input, #current-tab, #menu-header {font-size:1.11rem;}
 	.dropdown-menu > li > a, .viewswitch .btn {font-size:1.16rem;line-height:2.75em;}
-	#playback-panel, #content {position:relative;}
+	body.playback #playback-panel {position:relative;}
+	body.playback #content {height:unset;position:relative;}
+	body.playback #container-playlist {visibility:hidden;}
+	body.playback #timeline {width:90vw;display:block;}
+	body.playback #coverart-url {min-height:90vw;}
+	body.playback #playbar-toggles .addfav {display:block;}
+	body.playback #playback-panel .playlist li.active:before {color:unset!important;background:unset;background-size:unset;}
+	body.playback #timeline.radio #m-countdown {float:unset;right:unset;width:unset;text-align:center;}
+	body.playback #timeline.radio #progress {display:none;}
+	body.scrolling #playback-queue .playlist li.active:before {color:transparent!important;background:var(--npicon) no-repeat right;background-size:1.25em;}
+	body.scrolling #playback-controls {display:none;}
+	body.scrolling #container-playlist {visibility:visible;}
+	body.scrolling #menu-bottom {display:flex;}
+	body.scrolling #menu-top {height:2.75rem;backdrop-filter:blur(20px);}
 	.modal-body{padding:0 .75rem;max-height:80vh;}
 	.modal-footer .btn {width:40%;}
 	.modal .h5 {width:42%;}
@@ -253,14 +267,12 @@ li.modal-dropdown-text:focus {color:#eee;}
 	.input-xlarge {width:150px;} /* same as medium */
 	#timezone, #volzone {display:none;}
 	#playback-cover {position:relative;}
-	#playback-queue {z-index:unset;}
 	.ralbum svg {height:1.2rem;width:1.2rem;}
 	#togglebtns .btn-group {width:unset;}
-	.tab-content {height:unset;}
 	.covers {width:100%;}
 	#menu-bottom, #playbar {height:8.5rem;}
 	#playbar-cover {height:8.5rem;width:8.5rem;position:absolute;-webkit-mask-image: linear-gradient(to right, rgba(0,0,0,.5), rgba(0,0,0,0) 100%);}
-	#playbar-controls .prev {display:none;}
+	/*#playbar-controls .prev {display:none;}*/
 	#songsList {padding-bottom:8.5rem;}
 	.lib-artistname-meta, .lib-albumyear-meta, .lib-numtracks-meta {font-size:calc(0.65em + 1vmin);}
 	#playbtns .btn {font-size:3em;padding:.5em 1em;}
@@ -297,11 +309,11 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#menu-top .dropdown.open {background-color:transparent;border-radius:unset;box-shadow:none;backdrop-filter:none;padding-left:0}
 	/* playbar */
 	#playbar-div {display:block;}
-	#playbar-mtime {display:flex;position:relative;}
-	#playbar-title {text-align:left;top:0;margin-left:1em;width:67vw;height:auto;position:relative;transform:none;font-size:1.5em;line-height:2.2em;left:0;padding:0;text-shadow:0 0 1px var(--btnbarback);}
+	#playbar-mtime {display:flex;position:relative;width:unset;}
+	#playbar-title {text-align:left;top:0;margin-left:1em;width:59vw;height:auto;position:relative;transform:none;font-size:1.4em;line-height:2.2em;left:0;padding:0;text-shadow:0 0 1px var(--btnbarback);}
 	#playbar-controls {right:.25rem;transform:none;top:0;left:unset;opacity:1;}
 	#playbar-time, #playbar-total {line-height:1.5rem;}
-	#playbar-controls .btn {padding:.5em;font-size:2.5rem;-webkit-tap-highlight-color:transparent;}
+	#playbar-controls .btn {padding:.56em .6em;font-size:2rem;-webkit-tap-highlight-color:transparent;}
 	#playbar-toggles {position:absolute;right:1rem;right:calc(env(safe-area-inset-right) + 1rem);bottom:.4em;height:unset;width:unset;top:unset;left:unset;transform:none;}
 	#playbar-toggles .btn {transition:none;border-radius:50%;padding:1rem .7rem;margin-bottom:0;width:unset;height:unset;line-height:11px;}
 	#playbar-timeline {display:none;}
@@ -481,6 +493,14 @@ li.modal-dropdown-text:focus {color:#eee;}
 	#playback-panel.newui#albumcovers .lib-entry img, #playback-panel.newui.database-radio img {max-height: calc(31vw * .9);}
 	#playback-panel.newui#albumcovers li, #playback-panel.newui.database-radio li {width:31vw;}
 	#playback-panel.newui #volcontrol, #playback-panel.newui #volcontrol-2, #playback-panel.newui #countdown {height:12.5rem;width:12.5rem;}
+}
+@media (orientation:portrait) and (min-aspect-ratio:9/16) {
+	#ss-coverart-url img.coverart {width:80vw;padding-top:3.5rem;}
+	#ss-currentsong, #ss-currentalbum-div {margin-top:2em;}
+	body.cv #playbar-toggles .btn {margin:0 .25rem}
+}
+@media (orientation:portrait) and (min-aspect-ratio:9/15) {
+	body.cv #playbar-toggles .btn {margin:0 .45rem}
 }
 @media (orientation: portrait) and (min-aspect-ratio:2/3) {
 	#playback-panel.newui #timezone {left:12.5%;top:59%;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -43,6 +43,7 @@ html, body {background-attachment:fixed;background-size:cover;height:100%;color:
 	--adapttext:rgb(240,240,240);
 	--adaptmbg:rgba(50,50,50,0.75);
 	--adaptbg:rgba(128,128,128,0.75);
+	--adaptShade:rgba(128,128,128,0.75);
 	--sbw: 0px;
 	--shiftybg:rgba(0,0,0,0.85);
 	--pbfont:calc(0.45em + 1vmin);
@@ -96,10 +97,9 @@ html {background-color:inherit;}
 .configure-renderer, .disconnect-renderer {font-size:.7em!important;cursor:pointer;border-radius:5rem;background-color:var(--btnshade4);margin-top:1em;width:10em;color:inherit;}
 .configure-renderer:hover, .disconnect-renderer:hover {background-color:var(--btnshade4);} /* Mask hover effect */
 /* main ui */
-/*.playback-controls {display:none;position:absolute;top:0;left:50%;width:184px;margin:-1px 0 0 -92px;text-align:center;z-index:9;}*/
-#currentsong, #currentalbum, #currentartist, #format-bitrate, #elapsed, #countdown-display {display:block;}
-#extra-tags-display {font-size:1rem;color:var(--textvariant);padding-top:.5em;text-align:center;display:block;cursor:pointer;}
-#currentsong {font-size:1.35em;padding-top:1.65rem;font-weight:bold;color:var(--accentxts);word-wrap:break-word;cursor:pointer;}
+/*#currentsong, #currentalbum, #currentartist, #format-bitrate, #elapsed, #countdown-display {display:block;}*/
+#extra-tags-display {font-size:1rem;color:var(--textvariant);padding-top:.35em;text-align:center;display:block;cursor:pointer;}
+#currentsong {font-size:1.35em;padding-top:1.65rem;display:inherit;font-weight:bold;color:var(--accentxts);word-wrap:break-word;cursor:pointer;}
 #currentalbum, #currentartist {font-size:1.25em;padding-top:1.65rem;cursor:pointer;font-weight:500;}
 #currentalbum-div, #currentartist-div {display:inline-flex;}
 #playlist-position, #format-bitrate {color:inherit;opacity:.55;}
@@ -128,7 +128,7 @@ html {background-color:inherit;}
 #volzone, #timezone, #volbtns-2 {font-family:'SF Mono', 'Roboto Mono', monospace;} /* 'Letter Gothic Std', */
 #volbtns, #volbtns-2 {display:flex;position:absolute;transform:translate(-50%,-50%);top:50%;left:50%;height:70%;margin:0 auto;flex-direction:column;}
 #volumedn, #volumedn-2, #volumeup, #volumeup-2 {font-size:2.5vw;font-weight:400;margin:0 auto;padding:.25rem 1rem;height:33%;color:var(--adapttext);}
-#songsand {width:98%;margin:0 auto;}
+#songsand {width:98%;margin:0 auto;display:none;}
 #volume-popup {display:none;height:100vh;width:100vw;background-color:var(--modalbkdr);}
 #volpad {position:fixed;top:calc(50% - 2.75rem - env(safe-area-inset-bottom));left:50%;width:30%;transform:translate(-50%, -50%);z-index:10001;}
 #volume-popup .modal-footer {position:absolute;bottom:calc(env(safe-area-inset-bottom) + 5vh);width:inherit;border:none;}
@@ -137,7 +137,7 @@ html {background-color:inherit;}
 #volumeup-2, #volumedn-2 {font-size:3.1vw;}
 #volume-popup .volume-display {font-size:3.5vw;font-weight:500;margin-top:0;}
 #volbtns-2 {z-index:10002;}
-#playbtns .addfav, #playbtns {display:none;}
+#playbtns .addfav {display:none;}
 #cover-options {display:none;}
 #choose-bgimage, #remove-bgimage, #new-radiologo, #edit-radiologo, #choose-station-pkg, #export-stations {font-size:1em;color:inherit;margin-top:.1em;padding-top:.3em;}
 #current-bgimage {max-height:calc(1.5rem + 6px);overflow:hidden;max-width:50px;margin:5px 0 0 5px;position:absolute;display:inline-block;border-radius:3px;}
@@ -157,7 +157,7 @@ html {background-color:inherit;}
 #togglebtns .coverview i {font-size: .85em;}
 #togglebtns .btn-primary {color:var(--accentxts);border-radius:.25em;}
 #menu-top, #menu-bottom {position:fixed;left:0;right:0;color:inherit;}
-.btnlist.btnlist-top.btnlist-top-pl {top:0px;top:env(safe-area-inset-top);width:35%;z-index:1004;display:none;}
+.btnlist-top-pl {top:0px;top:env(safe-area-inset-top);width:35%;z-index:1004;}
 .btn.btn-primary.btn-small, .btn.btn-primary.btn-medium {background:rgba(128,128,128,0.2);margin-top:-4px;}
 #menu-top {line-height:2.75rem;padding-top:0;padding-top:env(safe-area-inset-top);height:0;z-index:1002;display:flex;}
 #menu-top .dropdown {top:0;top:calc(env(safe-area-inset-top) + 0);right:0;position:absolute;}
@@ -171,10 +171,10 @@ html {background-color:inherit;}
 #mbrand {color:var(--adapttext);text-shadow: 0 0 0.25rem rgba(0,0,0,0.5);transform:translate(-50%);}
 #mblur {letter-spacing:-.56em;color:transparent;text-shadow:0 0 2px var(--btnshade4);transform:translate(calc(-50% - .28em));opacity:.75;}
 #menu-settings i {color:var(--accentxts);font-size:.65em;}
-#menu-bottom {display:flex;bottom:.2rem;bottom:calc(env(safe-area-inset-bottom) + .2rem);width:40%;margin:0 auto;background-color:transparent;color:inherit;z-index:990;line-height:normal;font-size:inherit;backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);}
+#menu-bottom {display:none;bottom:.2rem;bottom:calc(env(safe-area-inset-bottom) + .2rem);width:40%;margin:0 auto;background-color:transparent;color:inherit;z-index:990;line-height:normal;font-size:inherit;backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);}
 #menu-bottom ul {display:flex;margin:0;width:100%;}
-#playback-panel {padding:2.75em 0 0 0;min-height:calc(100vh - 2.75em);position:relative;}
-#content {position:fixed;height:inherit;width:100vw;min-height:100vh;overflow:hidden;font-size:var(--pbfont);color:var(--adapttext);background-color:var(--adaptbg);}
+#playback-panel {padding:0;margin:2.75em 0 0 0;min-height:calc(100vh - 2.75em);position:relative;visibility:hidden;}
+#content {position:fixed;left:0;height:inherit;width:100vw;min-height:100vh;overflow:hidden;font-size:var(--pbfont);color:var(--adapttext);background-color:var(--adaptbg);}
 #timeknob, #timeflow {background-color:transparent;}
 #timeknob.pulse, #timeflow.pulse {box-shadow:0 0 0 0 rgba(255,255,255,0.3);background-color:#222;}
 a.btn-cmd {width:18px;}
@@ -183,19 +183,18 @@ a.btn-cmd {width:18px;}
 img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(32, 32, 32, 0.25);width:100%;height:100%;cursor:pointer;/*max-width:66vh;*/}
 .covers {padding:.75em 1em 0 1em}
 #coverart-url {position:relative;}
-#container-browse {width:100%;padding:0;top:2.75rem;top:calc(2.75rem + env(safe-area-inset-top));overflow:hidden;position:absolute;}
-#container-radio {width:100%;padding:0;top:2.75rem;top:calc(2.75rem + env(safe-area-inset-top));overflow:hidden;position:absolute;}
-#database, #database-radio {overflow:auto;position:relative;width:100%;top:.5em;bottom:0px;height:calc(100vh - 5.15em);-webkit-overflow-scrolling:touch;}
+#container-browse, #container-radio {width:100vw;padding:0;top:2.75rem;top:calc(2.75rem + env(safe-area-inset-top));overflow:hidden;position:absolute;}
+#database, #database-radio {overflow:auto;position:relative;width:100%;top:.5em;height:calc(100vh - 5.3rem - env(safe-area-inset-bottom));-webkit-overflow-scrolling:touch;}
 .input-append input::placeholder {color:var(--textvariant);}
 #pl-filter::placeholder {color:var(--textvariant);}
 #lib-album-filter::placeholder {color:var(--textvariant);font-size:.9em;}
 
 #playlist, #database, #database-radio {padding:0;background:none;}
 .playlist, .cv-playlist, .database, .database-radio {display:block;margin:0;padding:0;list-style:none;counter-reset:item;word-break: break-word;}
-.database {padding:0 0 12rem 0;width:100%;overflow-x:hidden;position:relative;margin:0;top:.5em;}
+.database {padding:0 0 7rem 0;width:100%;overflow-x:hidden;position:relative;margin:0;top:.5em;}
 .playlist .cv-playlist {padding:0 1em 4em 0;}
-#database-radio {height:calc(100vh - 2.75em);}
-.database-radio {text-align:center;padding:0 0 14rem 0;}
+/*#database-radio {height:calc(100vh - 2.75em);}*/
+.database-radio {text-align:center;padding:0 0 7rem 0;}
 .playlist li, .cv-playlist li, .database li, .database-radio li {display:block;position:relative;margin:0;cursor:pointer;text-align:left;padding-left:.75em;}
 .database li:first-child .db-entry {border-top:1px solid var(--btnshade);}
 .playlist li:before, .cv-playlist li:before {float:left;width:2.9em;letter-spacing:-1px;text-align:right;line-height:normal;counter-increment:item;content:counter(item) ' ';font-size:1em;margin-top:2px;}
@@ -216,18 +215,14 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 #albumsList .tag-cover-text {display:inline-block;vertical-align:middle;transform:translate(0, .2em);min-width:50%;max-width:calc(100% - 3.6rem);/*line-height:1.6rem;*/}
 #library-panel .lib-entry span {max-width:100%;display:inline;}
 #library-panel.limited .lib-entry span {display:inline-block;}
-#library-panel.limited #artistsList li, #library-panel.limited #artistsList li {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
 #top-columns .lib-entry {font-size: 1em;}
 #top-columns .album-name-art, #top-columns .album-name {display:block !important;vertical-align:middle;min-width:25vw;}
 #top-columns .album-name-art {line-height:1.25em;}
 #albumsList .lib-entry span.artist-name {display:none}
 #albumsList .artist-name-art, #albumsList .album-year {vertical-align:top;line-height:normal;font-size:.85em;color:var(--textvariant);}
 #albumsList .album-year {margin-left:0;margin-left:.3em;}
-#library-panel.limited .artist-name-art, #library-panel.limited #albumcovers .artist-name {max-width:67%;}
-#library-panel.limited .lib-entry span, #radio-panel.limited .station-name span {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
 .database .active {background-color:var(--btnshade);}
 .playlist .active .pll1, .cv-playlist .active .pll1 {color:var(--accentxts);font-weight:700;}
-.playlist li.active:before, .cv-playlist li.active:before, .lib-track-highlight {color:transparent!important;background:var(--npicon) no-repeat right;background-size:1.25em;}
 .playlist li.paused:before, .cv-playlist li.paused:before {color:unset!important;background:unset;}
 .playlist .pll1, .cv-playlist .pll1 {font-weight:400;opacity:1;text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
 .playlist .pl-entry, .cv-playlist .pl-entry {padding:0px;}
@@ -262,18 +257,18 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .btnlist {position:fixed;left:0;right:0;display:block;width:auto;height:2.5em;padding:0;background:none;-webkit-border-radius:0px;-moz-border-radius:0px;border-radius:0px;z-index:999;}
 .btnlist:focus {outline:none;}
 .btnlist.pl-prevPage, .btnlist.db-prevPage, .btnlist.pl-firstPage, .btnlist.db-firstPage {padding:0 .3em;}
-.btnlist-top-db, .btnlist-top-ra {position:relative;background-color:var(--btnshade3);top:.25em;color:var(--adapttext);border-radius:.25em;width:calc(100vw - 2.5em);height:2.5rem;padding:0 !important;margin:0 auto;}
+.btnlist-top-db, .btnlist-top-ra {display:none;position:relative;background-color:var(--btnshade3);top:.25em;color:var(--adapttext);border-radius:.25em;width:calc(100vw - 2.5em);height:2.5rem;padding:0 !important;margin:0 auto;}
 #pl-filter, #lib-album-filter, #ra-filter {padding:0}
 #db-browse .dropdown {display:block;height:40px;line-height:40px;margin:0 20px 0 0;}
 #db-browse .dropdown-menu {background:transparent;border:none;border-radius:0px;box-shadow:none;list-style:none outside none;margin:0;/*min-width:100px;*/padding:0;border-top:1px solid #000;border-left:1px solid #000;border-right:1px solid #000;position:absolute;top:100%;z-index:1000;}
 #db-browse .dropdown-menu > li > a {line-height:40px;margin:0;padding:0 10px;background:#34495E;border-bottom:0px solid #000;color:#fff;}
 #db-browse .dropdown-menu > li > a:hover, #db-browse .dropdown-menu > li > a:focus, #db-browse .dropdown-menu > li.active > a {background-color:var(--accentxta);}
 .btnlist a {font-size:1em;text-decoration:none;color:inherit;}
-#pl-search, #lib-album-search, #ra-search {display:block;float:left;margin:0;z-index:1001;position:relative;}
-#lib-album-search {top:50%; transform:translate(0, -50%);width:8rem;}
+#pl-search, #lib-album-search, #ra-search {float:left;margin:0;z-index:1001;position:relative;}
+#lib-album-search {top:50%; transform:translate(0, -50%);width:8rem;display:block;}
 #lib-album-filter {width:11.5rem;}
 /*#pl-search {top:50%; transform:translate(0, -50%);width:11rem;}*/
-#pl-search {left:1rem}
+#pl-search {left:1rem;}
 #savepl-modal, #setfav-modal .modal-body {padding:1em .25em 0 .25em;}
 #pl-save {display:block;float:left;margin-right:0;margin-left:0;z-index:1001;width:100%;text-align:center;}
 #pl-search input, #ra-search input, #lib-album-search input {margin:0;border:none;box-shadow:none;min-height:initial;height:2.75rem;font-size:1em;padding:0;}
@@ -283,24 +278,23 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 /*.db-browse-icon {float:left;}*/
 #pl-controls {float:left;margin:6px 0 0 10px;}
 #folder-panel .btn.disabled, #folder-panel .btn[disabled] {background-color:#34495E;color:white;}
-#folder-panel, #radio-panel {width:100%;height:100vh;position:fixed;top:0;overflow:hidden;}
-#library-panel {height:100vh;}
+#folder-panel, #radio-panel {width:100%;position:fixed;top:0;left:0;overflow:hidden;}
+#library-panel {position:fixed;top:0;left:0;}
 .btnlist-top-db button, .btnlist-top-ra button {margin:0;line-height:normal;height:2.5rem;width:2.5rem;font-size:1.1rem;border-radius:0;float:left;display:inline-block;padding:.25rem .5rem;border-right: 1px solid var(--btnshade);}
 #reconnect, #restart, #shutdown {position:fixed;top:0;left:0;margin:0;padding:0;text-align:center;width:100%;height:100%;z-index:9999;}
 .reconnect-bg {position:absolute;top:0;left:0;margin:0;padding:0;text-align:center;background-color:var(--modalbkdr);width:100%;height:100%;z-index:9999;}
 .reconnect-btn {position:fixed;padding:.75rem;transform: translate(-50%,-50%);top: 50%;left: 50%;width: 10em;text-transform:uppercase;z-index:9999;font-size:1.25em;cursor:pointer;border-radius:5rem;color:var(--themetext);background-color:var(--btnshade4);}
 .reconnect-btn:hover {background-color:var(--btnshade4);} /* Mask hover effect */
 .reconnect-msg {transform: translate(-50%,-50%);position: absolute;top: 50%;margin: 3em 0 0 0;text-transform: uppercase;transform: translate(-50%,-50%);position: absolute;top: 50%;margin: 3em 0 0 0;z-index: 9999;text-transform: uppercase;}
-.viewswitch {position:fixed;top:0;top:env(safe-area-inset-top);background-color:transparent;color:inherit;display:none;z-index:1001;line-height:2.75rem;font-size:inherit;transform:translate(-50%, 0%);height:2.75rem;align-items:center;left:1rem;transform:none;}
-
+.viewswitch {position:fixed;display:none;top:0;top:env(safe-area-inset-top);background-color:transparent;color:inherit;z-index:1001;line-height:2.75rem;font-size:inherit;transform:translate(-50%, 0%);height:2.75rem;align-items:center;left:1rem;transform:none;}
 #viewswitch-search {height:2.25rem;padding:1.5rem 0 1.5rem 1rem !important;display:none;}
 #viewswitch .view-all, #viewswitch .view-recents {display:none;}
 
-#viewswitch.va .view-all, #viewswitch.va .view-recents, #viewswitch.va .adv-searchbtn, #viewswitch.va #viewswitch-search, #viewswitch.va .album-view-btn .pane {display:block;}
-#viewswitch.vt .view-all, #viewswitch.vt .view-recents, #viewswitch.vt .adv-searchbtn, #viewswitch.vt #viewswitch-search, #viewswitch.vt .tag-view-btn .pane {display:block;}
-#viewswitch.va .album-view-btn, #viewswitch.vt .album-view-btn {border-bottom: 1px solid rgba(128,128,128,0.2);}
-#viewswitch.vr .radio-view-btn .pane {display:block;}
-#viewswitch.vf .folder-view-btn .pane {display:block;}
+body.album #viewswitch .view-all, body.album #viewswitch .view-recents, body.album #viewswitch .adv-searchbtn, body.album #viewswitch #viewswitch-search, body.album #viewswitch .album-view-btn .pane {display:block;}
+body.tag #viewswitch .view-all, body.tag #viewswitch .view-recents, body.tag #viewswitch .adv-searchbtn, body.tag #viewswitch #viewswitch-search, body.tag #viewswitch .tag-view-btn .pane {display:block;}
+body.album #viewswitch .album-view-btn, body.tag  .album-view-btn {border-bottom: 1px solid rgba(128,128,128,0.2);}
+body.radio #viewswitch .radio-view-btn .pane {display:block;}
+body.folder #viewswitch .folder-view-btn .pane {display:block;}
 
 #viewswitch span {float:right;display:none;}
 #searchResetLib {padding:.75rem .25em;position:relative;transform:translate(0, -50%);line-height:normal;}
@@ -361,9 +355,9 @@ legend {border-color:-moz-use-text-color -moz-use-text-color #34495E;color:inher
 code, pre {background-color:inherit;color:inherit;border:none;font-size:.8em;}
 #lib-load {color:#ddd;font-size:18px;font-weight:bold;margin-left:-72px;position:absolute;top:50%;left:50%;}
 #content-position {height:100%;width:100%;display:flex;position:absolute;overflow:hidden;} /* prevents horiz scrollbar from apprearing on pi touch lib panel */
-#top-columns {height:calc(50% - 2.75rem - env(safe-area-inset-top));width:100%;display:flex;flex-direction:row;top:2.75rem;top:calc(env(safe-area-inset-top) + 2.75rem);left:0%;position:fixed;}
-#bottom-row {height:50%;width:100%;display:flex;flex-direction:row;top:50%;top:50%;left:0%;position:fixed;border-top:1px solid var(--btnshade);}
-#lib-content {display:none;position:absolute;top:0;left:0;right:0;bottom:0;background-color:inherit;}
+#top-columns {height:calc(50% - 2.75rem - env(safe-area-inset-top));width:100%;display:none;flex-direction:row;top:2.75rem;top:calc(env(safe-area-inset-top) + 2.75rem);left:0%;position:fixed;}
+#bottom-row {height:50%;width:100%;display:none;flex-direction:row;top:50%;left:0%;position:fixed;border-top:1px solid var(--btnshade);}
+#lib-content {display:none;position:absolute;top:0;left:0;z-index:10;background-color:inherit;}
 #lib-genre-header, #lib-genre, #lib-artist-header, #lib-artist, #lib-album-header, #lib-album {position:absolute;box-sizing:border-box;width:33.33%;overflow:auto;overflow-x:hidden;}
 #lib-genre-header {border-top:1px solid var(--btnshade);border-bottom:1px solid var(--btnshade);border-right:1px solid var(--btnshade);}
 #lib-artist-header {left:33.33%;border-top:1px solid var(--btnshade);border-bottom:1px solid var(--btnshade);}
@@ -374,7 +368,7 @@ code, pre {background-color:inherit;color:inherit;border:none;font-size:.8em;}
 #lib-album {left:66.66%;}
 #lib-file {overflow-y:scroll;overflow-x:hidden;margin:1px 0 0 0;height:100%;width:100%;-webkit-overflow-scrolling:touch;}
 #lib-coverart-meta-area {width:20vw;line-height:normal;padding:0;float:left;position:fixed;}
-#lib-coverart-img {margin:.5em .25em 0 .5em;}
+#lib-coverart-img {margin:.5em .25em 0 .5em;display:none;}
 #lib-coverart-img a {display:inline-block;}
 #lib-meta-summary {margin-left:.5em;line-height:normal;font-size:.9em;}
 img.lib-coverart {float:left;width:calc(20vw - 1em);box-shadow:0px 0px .2em rgba(0,0,0,0.2);}
@@ -405,8 +399,6 @@ img.lib-artistart {float:left;width:calc(20vw - 1rem);height: calc(20vw - 1rem);
 #songsList .lib-disc a.active {font-weight:700;color:unset;}
 /*#songsList li.active {font-weight:700;background-color:unset;}*/
 #trackscontainer {width:calc(80vw - var(--sbw));float:right;} /* Was 81vw */
-#m-countdown {padding-right:5px;font-size:10px;}
-#m-total {font-size:10px;padding-left:5px;}
 .recently-added {margin-top:-1.5em;float:left;position:relative;padding:.25em .5em 0em .5em;}
 .recently-added i {color:var(--adapttext);opacity:.35}
 .span5, .span4 {margin-left:0px;margin-right:0px;}
@@ -414,7 +406,7 @@ img.lib-artistart {float:left;width:calc(20vw - 1rem);height: calc(20vw - 1rem);
 .controls.controls-tog {line-height:30px;}
 .form-horizontal .help-block {line-height:normal;margin-top:0px;padding-top:0px;margin-bottom:.5em;}
 /* album cover panel */
-#lib-albumcover {height:100%;width:100%;position:fixed;box-sizing:border-box;left:0%;top:2.75rem;top:calc(env(safe-area-inset-top) + 2.75rem);overflow:auto;overflow-x:hidden;-webkit-overflow-scrolling:touch;}
+#lib-albumcover {visibility:hidden;height:100%;width:100%;position:fixed;box-sizing:border-box;left:0%;top:2.75rem;top:calc(env(safe-area-inset-top) + 2.75rem);overflow:auto;overflow-x:hidden;-webkit-overflow-scrolling:touch;}
 #albumcovers {text-align:center;margin:0;padding-bottom:12em;}
 #albumcovers .lib-entry, .database-radio .lib-entry {width:var(--thumbcols);text-align:center;display:inline-block;vertical-align:top;height:auto;font-size:.95em;padding:0 0 .4em 0;}
 #albumcovers .lib-entry img, .database-radio img {position:absolute;left:var(--thumbmargin);bottom:0;object-fit:contain;width:var(--thumbimagesize);max-height:var(--thumbimagesize);}
@@ -431,25 +423,13 @@ img.lib-artistart {float:left;width:calc(20vw - 1rem);height: calc(20vw - 1rem);
 #screen-saver {color:#eee;text-shadow:0px 0px .25em rgba(0,0,0,0.3);height:100vh;width:100vw;cursor:pointer;text-align:center;}
 #ss-backdrop {height:100vh;filter:blur(20px);overflow:hidden;position:fixed;top:0;left:0;transform:scale(1.2);}
 #ss-style {position:fixed;top:0;left:0;height:100vh;width:100vw;animation:none;transform:translateZ(0);}
-#ss-coverart-url img {width:75vh;}
+#ss-coverart-url img.coverart {width:75vh;max-width:unset;height:unset;}
 #ss-currentsong {font-weight:600;}
 #ss-currentsong, #ss-currentalbum-div {margin-top:1em;}
 .ss-backdrop {min-width:100vw;min-height:100vh;max-width:unset;transform:translate(-50%, -50%);background-position:center center;position:relative;top:50vh;left:50vw;}
 .ss-coverart {position:fixed;top:1.5em;width:100%;}
-body.cv #menu-bottom {display:flex !important;background-color:transparent;backdrop-filter:none;-webkit-backdrop-filter:none;}
-body.cv #menu-top, body.cv #viewswitch, body.cv #playbar-toggles .coverview, body.cv #playbar-cover, body.cv #playbar-hd-badge {display:none !important;}
-body.cv #content .tab-pane.active {visibility:hidden !important;}
-body.cv #playbar {box-shadow:none;color:#eee;}
-body.cv #playbar-title {font-size:1.4em;/*top:-25%;transform:translate(-50%, -50%);padding-bottom:0;*/}
-body.cv #playbar-currentsong, body.cv #playbar-currentalbum {display:none;padding-bottom:.5em;}
-body.cv #ss-currentsong, body.cv #ss-currentalbum {font-size:1.4em;}
-body.cv #playbar-timeline {top:50%;width:35%;transform:translate(-50%, -50%);}
-body.cv #screen-saver/*, body.cv #menu-bottom*/ {display:block !important;}
-body.cv #cv-playlist-btn {display:block;}
-body.cv #addfav-li {display:none;}
-body.cv #random-album {display:none!important;}
-body.cv #playbar-toggles .addfav {display:block!important;}
-#cv-playlist {display:none;position:absolute;top:1.5em;right:.1em;width:40vmin;z-index:2;height:calc(100% - 2.75em - 45px);overflow:auto;-webkit-overflow-scrolling:touch;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);background:rgba(32,32,32,.25);}
+#cv-playlist {display:none;position:absolute;top:0;right:0;width:40vmin;z-index:2;height:calc(100% - 2.75em - 45px);overflow:auto;-webkit-overflow-scrolling:touch;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);background:rgba(32,32,32,.75);}
+#cv-playlist ul {padding-top:1.25em;}
 /* misc */
 #searchResetRa {display:none;}
 #splash {height:100vh;width:100vw;z-index:11111;position:fixed;background:rgba(32,32,32,0.95);backdrop-filter:blur(5px);-webkit-backdrop-filter:blur(5px);display:none;}
@@ -477,7 +457,7 @@ input[type="range"].vslide2 {height:10em;width:2.5em;-webkit-appearance: slider-
 input[type='range'].vslide2::-webkit-slider-thumb {background:#fff;background-image:'';height:1.25em;width:1.25em;}
 .vslide3 {width:9%;display:inline-block;}
 
-#menu-bottom {bottom:0;height:5.3rem;width:100%;z-index:9997;background-color:var(--btnbarback);/*border-top:1px solid var(--btnshade2);*/display:none;}
+#menu-bottom {bottom:0;height:5.3rem;width:100%;z-index:9997;background-color:var(--btnbarback);/*border-top:1px solid var(--btnshade2);*/}
 #menu-bottom .btn:first-child, #menu-bottom .btn:last-child, #menu-bottom .btn.active {border-radius:0;border:none;background-color:transparent;background:transparent;}
 #menu-bottom ul {display:none;color:var(--adapttext);}
 #menu-bottom .btn.active {background-color:transparent;}
@@ -489,14 +469,13 @@ input[type='range'].vslide2::-webkit-slider-thumb {background:#fff;background-im
 #index-genres {right:calc(66.85% + var(--sbw));top:calc(1.55rem + 3px);height:calc(100% - 1.5rem - 3px);}
 #index-artists {right:calc(33.33% + var(--sbw));top:calc(1.55rem + 3px);height:calc(100% - 1.5rem - 3px);}
 #index-albums {right:var(--sbw);top:calc(1.55rem + 3px);height:calc(100% - 1.5rem - 3px);}
-#index-albumcovers {position:fixed;right:var(--sbw);top:calc(3.5rem + 1px);top:calc(3.5rem + 1px + env(safe-area-inset-top));height:calc(100% - 9rem - env(safe-area-inset-top) - env(safe-area-inset-bottom));}
-#index-browse {right:var(--sbw);top:calc(3rem + 1px);height:calc(100% - 10rem);height:calc(100% - 10rem - env(safe-area-inset-top) - env(safe-area-inset-bottom));}
-#index-radio {right:var(--sbw);top:calc(3rem + 1px);height:calc(100% - 12rem - env(safe-area-inset-top) - env(safe-area-inset-bottom));}
+#index-albumcovers {position:fixed;right:var(--sbw);top:calc(3.5rem + 1px);top:calc(3.5rem + 1px + env(safe-area-inset-top));height:calc(100% - 9.25rem - env(safe-area-inset-top) - env(safe-area-inset-bottom));}
+#index-browse, #index-radio {right:var(--sbw);top:3.25rem;height:calc(100% - 8.75rem);height:calc(100% - 8.75rem - env(safe-area-inset-top) - env(safe-area-inset-bottom));}
 /**/
 .alphabits {position:absolute;/*background:var(--btnshade);*/z-index:999;}
-.alphabits ul {display:table;height:100%;margin:0 !important;border-spacing:.2em;}
+.alphabits ul {display:flex !important;height:100%;margin:0 !important;flex-flow:column;}
 /* index improvements */
-.alphabits ul li {display:table-row !important;font-size:.8em;text-transform:uppercase;line-height:normal;font-weight:600;color:var(--textvariant);text-align:center;}
+.alphabits ul li {font-size:.8em;text-transform:uppercase;height:6.25%;line-height:normal !important;list-style:none;font-weight:600;color:var(--textvariant);text-align:center;}
 /**/
 /* playback ellipsis context menu */
 /*#context-menu-playback .dropdown-menu {min-width:15rem;white-space:nowrap;}*/
@@ -505,43 +484,72 @@ input[type='range'].vslide2::-webkit-slider-thumb {background:#fff;background-im
 /* active/inactive css element manip */
 #menu-header {position:absolute;top:env(safe-area-inset-top);transform:translate(-50%);left:50%;font-weight:600;font-size:1.1rem;overflow:hidden;max-width:50%;text-overflow:ellipsis;white-space:nowrap;color:var(--adapttext);cursor:pointer;}
 #menu-header span {text-transform:capitalize;}
-#playback-panel #playback-controls {display:none;}
-#playback-panel.active #playback-controls, #playback-panel.active #playbtns, #playback-panel.active #togglebtns {display:block;}
-#playback-panel.active .btnlist.btnlist-top.btnlist-top-pl {display:inline-flex;}
-#library-panel {display:none;}
-#library-panel.active {height:100vh;display:block;}
-#lib-albumcover, #top-columns, #bottom-row {display:none;}
-#library-panel.active.covers #lib-albumcover {display:block;}
-#library-panel.active.covers #index-albumcovers {display:block;}
-#library-panel.active.tag #top-columns {display:block}
-#library-panel.active.tag #bottom-row {display:flex;}
-#library-panel.active.tag #index-genres, #library-panel.active.tag #index-artists, #library-panel.active.tag #index-albums {display:block;}
-#folder-panel {display:none;}
-#folder-panel.active {height:100vh;display:block;}
-#folder-panel.active #index-browse {display:block;}
-#folder-panel.active #btnlist-top-db {display:block;}
-#radio-panel {display:none;}
-#radio-panel.active {height:100vh;display:block;}
-#radio-panel.active #index-radio {display:block;}
-#radio-panel.active #btnlist-top-ra {display:block;}
+
+#playback-controls, #library-panel, #radio-panel, #folder-panel {display:none;}
+
+body.playback #content {background:linear-gradient(to bottom, var(--adaptbg) 15vh, var(--adaptShade) 100vh);}
+body.playback #menu-header, body.playback #random-album {display:none;}
+body.playback #playback-controls, body.playback #songsand {display:block;}
+body.playback #playback-panel {visibility:visible;}
+body.playback #playback-panel .playlist li.active:before {color:transparent!important;background:var(--npicon) no-repeat right;background-size:1.25em;}
+body.radios .viewswitch, body.folder .viewswitch, body.tag .viewswitch, body.album .viewswitch, body.radios #menu-bottom, body.folder #menu-bottom, body.tag #menu-bottom, body.album #menu-bottom {display:flex;}
+body.album #random-album, body.album #index-albumcovers, body.album #library-panel {display:block;}
+body.album #playbar-toggles .addfav {display:none;}
+body.album #library-panel, body.album #lib-albumcover {visibility:visible;}
+body.album #library-panel.limited .album-name, body.album #library-panel.limited .artist-name {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
+body.album #library-panel.limited .album-year {vertical-align:top;}
+body.tag #playbar-toggles .addfav {display:none;}
+body.tag #index-genres, body.tag #index-artists, body.tag #index-albums, body.tag #random-album, body.tag #bottom-row, body.tag #lib-coverart-img, body.tag #library-panel {display:block;}
+body.tag #top-columns {display:flex;}
+body.tag .lib-track-highlight {color:transparent!important;background:var(--npicon) no-repeat right;background-size:1.25em;}
+body.tag #library-panel.limited .album-name-art, body.tag #library-panel.limited .artist-name-art, body.tag #library-panel.limited .album-name, body.tag #library-panel.limited .album-name {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
+body.tag #library.limited #artistList li, body.tag #library.limited #genreList li {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
+body.tag #library-panel.limited .album-year {vertical-align:top;}
+body.folder #index-browse, body.folder .btnlist-top-db {display:block;}
+body.folder #folder-panel {visibility:visible;display:block;height:100vh;}
+body.radios #index-radio, body.radios .btnlist-top-ra {display:block;}
+body.radios #radio-panel {display:block;visibility:visible;height:100vh;}
+body.radios #radio-panel.limited .station-name span {text-overflow:ellipsis;white-space:nowrap;overflow:hidden;}
+
+#library-panel.limited .artist-name-art, #library-panel.limited #albumcovers .artist-name {max-width:67%;}
+
+body.cv #menu-bottom {display:flex !important;background-color:transparent;backdrop-filter:none;-webkit-backdrop-filter:none;}
+body.cv #menu-top, body.cv #viewswitch, body.cv #playbar-toggles .coverview, body.cv #playbar-cover, body.cv #playbar-hd-badge {display:none !important;}
+body.cv #playback-panel, body.cv #library-panel, body.cv #folder-panel, body.cv #radio-panel, body.cv #top-columns, body.cv #lib-albumcover {visibility:hidden !important;}
+body.cv #playbar {box-shadow:none;color:#eee;}
+body.cv #playbar-title {font-size:1.4em;/*top:-25%;transform:translate(-50%, -50%);padding-bottom:0;*/}
+body.cv #playbar-currentsong, body.cv #playbar-currentalbum {display:none;padding-bottom:.5em;}
+body.cv #ss-currentsong, body.cv #ss-currentalbum {font-size:1.4em;}
+body.cv #playbar-timeline {top:50%;width:40%;transform:translate(-50%, -50%);}
+body.cv #screen-saver/*, body.cv #menu-bottom*/ {display:block !important;}
+body.cv #cv-playlist-btn {display:block;}
+body.cv #addfav-li {display:none;}
+body.cv #random-album {display:none!important;}
+body.cv #playbar-toggles .addfav {display:block!important;}
+body.cv .cv-playlist li.active:before {color:transparent!important;background:var(--npicon) no-repeat right;background-size:1.25em;}
+
 /* playbar */
 #timetrack {display:flex;width:100%;padding:0;color:inherit;height:15px;z-index:10;position:relative;}
-#timeline {width:65%;margin:.5em auto .3em;z-index:100;height:15px;display:none;}
+#timeline {width:65%;margin:.65em auto 0;z-index:100;height:15px;display:none;}
 .timeline-thm {width:100%;height:15px;}
 #playbar-timetrack {display:flex;width:100%;padding:0px;margin:0;color:inherit;height:15px;z-index:999;}
-#playbar-timeline {width:20%;z-index:999;position:absolute;bottom:.75em;;left:50%;transform:translate(-50%);font-size:.8rem;display:flex;flex-flow:column;height:15px;display:none;}
+#playbar-timeline {width:30vw;z-index:999;position:absolute;bottom:.75em;;left:50%;transform:translate(-50%);font-size:.8rem;display:none;flex-flow:column;height:15px;display:none;}
+#progress {width:70vw;display:inline-block;position:relative;height:15px;top:-1.5px;}
+#playbar-pro {width:80%;display:inline-block;position:relative;height:15px;}
 .timeline-progress {background-color:var(--trackfill);height:1px;position:relative;margin-top:-1px;top:50%;width:0;}
 .inner-progress {background-color:var(--trackfill);height:1px;width:0%;}
 .timeline-bg {background-color:var(--timecolor);height:1px;top:50%;width:100%;position:relative;min-height:1px;margin-top:-1px;}
-#playbar-time {width:100%;z-index:100;font-size:.8rem;margin-top:-15px;line-height:15px;}
-#playbar-countdown, #m-countdown {position:relative;float:left;left:-3rem;}
-#playbar-total, #m-total {position:relative;float:right;left:3rem;}
+#m-countdown, #playbar-countdown {position:relative;float:left;font-size:10px;width:10vw;text-align:right;right:5px;}
+#m-total, #playbar-total {font-size:10px;position:relative;float:right;width:10vw;text-align:left;left:5px;}
+#playbar-countdown, #playbar-total {width:10%;}
+#m-countdown, #m-total {font-weight:500;color:var(--textvariant);}
+/*#playbar-time {width:100%;z-index:100;font-size:.8rem;margin-top:-15px;line-height:15px;}
+#playbar-countdown {position:relative;float:left;width:10%;}
+#playbar-total {position:relative;float:right;width:10%;left:5px;text-algin:left;;}*/
 #playbar-mtime {display:none;}
-#playbar-countdown.radio {float:right;left:3em;}
-#mobile-time {margin-top:-13px;}
-#m-countdown, #m-total {font-weight:500;letter-spacing:-.2px;}
-#playbar-countdown.long-time, #m-countdown.long-time {left:-3.5rem!important;}
-#playbar-total.long-time, #m-total.long-time {left:3.5rem!important;}
+#playbar-countdown.radio {float:right;}
+#playbar-countdown.long-time {left:-3.5rem!important;}
+#playbar-total.long-time {left:3.5rem!important;}
 #playback-switch {position:absolute;height:2.5rem;width:20%;top:0;top:env(safe-area-inset-top);left:50%;transform:translate(-50%);text-align:center;font-size:1.2em;color:var(--adapttext);display:none;cursor:pointer;}
 #playback-switch div {background-color:transparent;height:.25rem;width:2rem;margin:1em auto;border-radius:1em;overflow:hidden;}
 #playbar {display:flex;align-items:center;height:5.3rem;position:absolute;bottom:0;width:100%;color:var(--adapttext);box-shadow: 0px -1px 3px rgba(0,0,0,0.1);} /* was 9.25vh*/
@@ -552,7 +560,6 @@ input[type='range'].vslide2::-webkit-slider-thumb {background:#fff;background-im
 #playbar-title span:first-child {opacity:1.0;}*/
 #playbar-currentsong, #playbar-currentalbum {overflow:hidden;text-overflow:ellipsis;word-wrap:break-word;}
 #playbar-currentsong {font-weight:600;}
-#playbar-time, #playbar-total {font-size:.9rem;}
 #playbar-controls {position:absolute;left:.5rem;top:50%;transform:translate(0, -50%);opacity:1;}
 #playbar-controls .btn {font-size:1.8rem;/*padding:.25rem;margin:0 .75rem;*/padding:1rem;}
 #playbar-controls .next, #playbar-controls .prev {font-size:1.6rem;}
@@ -636,7 +643,7 @@ input[type='range'].vslide2::-moz-range-track {height:10em;width:2px;border-radi
 #content.visacc #mvol-progress {background-color:var(--textvariant);border-radius:1px;}
 #content.visacc .ralbum svg {fill:var(--textvariant);}
 #content.visacc #currentsong, #content.visacc #currentsong a {color:var(--adapttext);}
-#content.visacc #currentalbum {color:var(--textvariant);}
+#content.visacc #currentalbum, #content.visacc #currentartist {color:var(--textvariant);}
 #content.visacc #togglebtns .btn-group {color:var(--textvariant);}
 #content.visacc #togglebtns .btn-primary {color:var(--adapttext);text-shadow: 0px 0px 4px var(--adapttext);}
 #content.visacc .playlist li.active:before {color:var(--adapttext);opacity:1;font-weight:600;}
@@ -650,7 +657,7 @@ input[type='range'].vslide2::-moz-range-track {height:10em;width:2px;border-radi
 #playbar.visacc #playbar-toggles .btn {color:var(--textvariant);}
 #playbar.visacc #playbar-toggles .btn-primary {color:var(--adapttext);text-shadow: 0px 0px 4px var(--adapttext);}
 
-#content.fancy #container-playlist {-webkit-mask-image: linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,1) 1%, rgba(0,0,0,1) 99%, rgba(0,0,0,0) 100%);}
+/*#content.fancy #container-playlist {-webkit-mask-image: linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,1) 1%, rgba(0,0,0,1) 99%, rgba(0,0,0,0) 100%);}*/
 #content.fancy #lib-album, #content.fancy #lib-artist, #content.fancy #lib-genre {-webkit-mask-image: linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,1) 1%, rgba(0,0,0,1) 99%, rgba(0,0,0,0) 100%);top:calc(1.5em + 1px);height:calc(100% - 1.5em);}
 
 @keyframes fadeIn {0% {opacity: 0;} 100% {opacity: 1;}}
@@ -694,7 +701,7 @@ input[type='range'].vslide2::-moz-range-track {height:10em;width:2px;border-radi
 #import-export-msg {line-height:24px;color:var(--adapttext);}
 /* Library filter */
 #lib-flatlist-filter {font-size:.5em;}
-/* Audio info */
+/* onta info */
 .container-iteminfo li {list-style:none;line-height:normal;padding:.5rem;overflow:auto;}
 .container-iteminfo .h5 {margin:.6rem 0 .4rem 0;width:unset!important;}
 .container-iteminfo .left {float:left;color:var(--textvariant);font-weight:500;width:30%;}

--- a/www/js/jquery.adaptive-backgrounds.js
+++ b/www/js/jquery.adaptive-backgrounds.js
@@ -27,12 +27,8 @@
 		selector: '[data-adaptive-background]',
 		parent: '#playback-panel',
 		exclude: ['rgb(0,0,0)', 'rgb(255,255,255)'],
-		shadeVariation: 'blend',
-		shadePercentage: .15,
-		shadeColors: {light: 'rgb(128,128,128)', dark: 'rgb(224,224,224)'},
 		normalizeTextColor: true,
 		normalizedTextColors: {light: "#eee", dark: "#333"},
-		lumaClasses: {light: "ab-light", dark: "ab-dark"},
 		transparent: null
 	};
 
@@ -74,13 +70,12 @@
 		r = 5,
 		i = 10,
 		c = {};
-
 		c.colors = function (n, t) {
 			t = t || {};
 			var c = t.exclude || [],
 			u = t.paletteSize || i;
 			e(n, function (e) {
-				for (var i = n.width * n.height || e.length, m = {}, s = "", d = [], f = {
+				for (var i = n.width * n.height || e.length, m = {}, s = "", dk = [], d = [], f = {
 					dominant: {
 						name: "",
 						count: 0
@@ -92,37 +87,20 @@
 							return {name: "0,0,0", count: 0}
 						})
 				}, l = 0; i > l;) {
-					if (d[0] = e[l], d[1] = e[l + 1], d[2] = e[l + 2], s = d.join(","), m[s] = s in m ? m[s] + 1 : 1, -1 === c.indexOf(a(s))) {
-						var g = m[s];
-						g > f.dominant.count ? (f.dominant.name = s, f.dominant.count = g) : f.palette.some(function (n) {
-							return g > n.count ? (n.name = s, n.count = g, !0) : void 0
-						})
-					}
+						if (d[0] = e[l], d[1] = e[l + 1], d[2] = e[l + 2], s = d.join(","), m[s] = s in m ? m[s] + 1 : 1, -1 === c.indexOf(a(s))) {
+							var g = m[s];
+							g > f.dominant.count ? (f.dominant.name = s, f.dominant.count = g) : f.palette.some(function (n) {
+								return g > n.count ? (n.name = s, n.count = g, !0) : void 0
+							})
+						}
+						//}
 					l += 4 * r
 				}
 				if (t.success) {
 					var p = o(f.palette);
-					//console.log(a(f.dominant.name) + ' - ' + p);
-					if (p[1] == 'rgb(0,0,0)') {p[0] = a(f.dominant.name);}
-					if (p[0] == 'rgb(255,255,255)') {p[0] = p[1]}
-					var aa = rgbToHsl(p[0]);
-					var bb = rgbToHsl(p[1]);
-					var cc = rgbToHsl(a(f.dominant.name));
-					//console.log(aa[2]);
-					//console.log(bb[2]);
-					//console.log(cc[2]);
-					var a1 = 0;
-					var a2 = 0;
-					if (aa[2] > bb[2]) {a1 = 0; a2 = 1;}
-					else {a1 = 1; a2 = 0;}
-					if ((cc[2] + .20) > aa[2] && (cc[2] < '.98')) {p[0] = a(f.dominant.name);a1=0;a2=1;}
-					if (a(f.dominant.name) == 'rgb(255,255,255)' && (p[1] == 'rgb(0,0,0)')) {p[0] = a(f.dominant.name);a1=0;a2=1;}
-					//console.log(a1, a2, p[a1] + ', ' + p[a2]);
-					if (cc[2] > .98) {a1=0;a2=1;}
-					//console.log(a(f.dominant.name) + p);
 					t.success({
-						dominant: p[a1],
-						secondary: p[a2],
+						dominant: p[0],
+						secondary: p[1],
 						palette: p
 					})
 				}
@@ -133,13 +111,6 @@
 
 	(window);
 
-	function shadeRGBColor(color, percent) {
-		var f=color.split(","),t=percent<0?0:255,p=percent<0?percent*-1:percent,R=parseInt(f[0].slice(4)),G=parseInt(f[1]),B=parseInt(f[2]);return "rgb("+(Math.round((t-R)*p)+R)+","+(Math.round((t-G)*p)+G)+","+(Math.round((t-B)*p)+B)+")";
-	}
-
-	function blendRGBColors(c0, c1, p) {
-		var f=c0.split(","),t=c1.split(","),R=parseInt(f[0].slice(4)),G=parseInt(f[1]),B=parseInt(f[2]);return "rgb("+(Math.round((parseInt(t[0].slice(4))-R)*p)+R)+","+(Math.round((parseInt(t[1])-G)*p)+G)+","+(Math.round((parseInt(t[2])-B)*p)+B)+")";
-	}
 	/* jshint ignore:end */
 
 	/*
@@ -148,38 +119,21 @@
 	$.adaptiveBackground = {
 		run: function (options) {
 			var opts = $.extend({}, DEFAULTS, options);
-			abfound = 'false';
 
-			/* Loop over each element, waiting for it to load
-			then finding its color, and triggering the
-			color found event when color has been found.
-			*/
-			$(opts.selector).each(function (index, el) {
-				var $this = $(this);
+			//$(opts.selector).each(function (index, el) {
+				var $this = $('img.coverart');
+
 				/*  Small helper functions which applies
 				    colors, attrs, triggers events, etc.
 				*/
 				var handleColors = function () {
-					if ($this[0].tagName == 'PICTURE') {
-						var images = $this[0].children;
-						for (var image in images) {
-							if (images[image].tagName == 'IMG') {
-								var img = images[image];
-								break;
-							}
-						};
-						if (img.currentSrc) {
-							img = img.currentSrc;
-						};
-					} else {
-						var img = useCSSBackground() ? getCSSBackground() : $this[0];
-					}
+					var img = $this[0];
 
 					RGBaster.colors(img, {
 						paletteSize: 20,
 						exclude: opts.exclude,
 						success: function (colors) {
-							$this.attr(DATA_COLOR, colors.dominant);
+							//$this.attr(DATA_COLOR, colors.dominant);
 							$this.trigger(EVENT_CF, {
 								color: colors.dominant,
 								palette: colors.palette
@@ -194,94 +148,14 @@
 					return parseInt(((rgb[0] * 299) + (rgb[1] * 587) + (rgb[2] * 114)) / 1000);
 				};
 
-				var useCSSBackground = function () {
-					var attr = $this.attr(DATA_CSS_BG);
-					return (typeof attr !== typeof undefined && attr !== false);
-				};
-
-				var getCSSBackground = function () {
-					var str = $this.css('background-image');
-					var regex = /\(([^)]+)\)/;
-					var match = regex.exec(str)[1].replace(/"/g, '')
-					return match;
-				};
-
-				var getShadeAdjustment = function (color) {
-					//console.log('datacolor' + color);
-					if (color == 'rgb()' || color == 'rgb(,,)'){color = 'rgb(0,0,0)';}
-					if (opts.shadeVariation == true) {
-						return getYIQ(color) <= 128 ? shadeRGBColor(color, opts.shadePercentage) : shadeRGBColor(color, -(opts.shadePercentage), opts.shadePercentage);
-					} else if (opts.shadeVariation == BLEND) {
-						return getYIQ(color) >= 128 ? blendRGBColors(color, opts.shadeColors.dark, opts.shadePercentage) : blendRGBColors(color, opts.shadeColors.light, opts.shadePercentage);
-					}
-				};
-
 				/* Subscribe to our color-found event. */
 				$this.on(EVENT_CF, function (ev, data) {
-					// Try to find the parent.
-					var $parent;
-					if (opts.parent && $this.parents(opts.parent).length) {
-						$parent = $this.parents(opts.parent);
-					} else if ($this.attr(DATA_PARENT) && $this.parents($this.attr(DATA_PARENT)).length) {
-						$parent = $this.parents($this.attr(DATA_PARENT));
-					} else if (useCSSBackground()) {
-						$parent = $this;
-					} else if (opts.parent) {
-						$parent = $this.parents(opts.parent);
-					} else {
-						$parent = $this.parent();
-					}
-
-					if (!!opts.shadeVariation)
-						data.color = getShadeAdjustment(data.color);
-
-					if ($.isNumeric(opts.transparent) && opts.transparent != null && opts.transparent >= 0.01 && opts.transparent <= 0.99) {
-						var dominantColor = data.color;
-						var rgbToRgba = dominantColor.replace("rgb", "rgba");
-						var transparentColor = rgbToRgba.replace(")", ", " + opts.transparent + ")");
-						$parent.css({
-							backgroundColor: transparentColor
-						});
-					} //else {
-						//$parent.css({
-							//backgroundColor: data.color
-							//});
-					//}
-
 					// stash adaptive bg color
-					//console.log(data.color);
-					var shade = rgbToHsl(data.color);
-					var shade2 = shade[2];
-					//console.log(shade[2]);
-					var newbg = data.color;
-					if (shade2 < .10) {
-						shade[2] = shade2 + 0.03;
-					} else if (shade2 < .45 && shade2 > .35) {
-						shade[2] = shade2 - .05;
-					}
-					//console.log(shade[2]);
-					var newshade = hslToRgb(shade);
-					var newbg = 'rgba(';
-					var newmb = 'rgba(';
-					abFound = 'true';
-					newbg = newbg.concat(newshade[0],',',newshade[1],',',newshade[2],',' + SESSION.json['alphablend'] +')');
-					newmb = newmb.concat(newshade[0],',',newshade[1],',',newshade[2],',' + themeOp +')');
-				    //$parent.css({backgroundColor: newbg});
-					data.color = newbg;
-					adaptBack = newbg;
-					//console.log(adaptBack);
-					var newshade = hslToRgb(shade);
-					var newcolor = 'rgba(';
-					newcolor = newcolor.concat(newshade[0],',',newshade[1],',',newshade[2],',',themeOp,')');
-					adaptMback = newcolor;
-					adaptMhalf = 'rgba('.concat(newshade[0],',',newshade[1],',',newshade[2],',0.5)');
+					shadeOp(data.color);
 					var getNormalizedTextColor = function (color) {
 						return getYIQ(color) >= 128 ? opts.normalizedTextColors.dark : opts.normalizedTextColors.light;
 					};
 
-					var getLumaClass = function (color) {
-						return getYIQ(color) <= 128 ? opts.lumaClasses.dark : opts.lumaClasses.light;
-					};
 					// Normalize the text color based on luminance.
 					if (opts.normalizeTextColor) {
 						//$parent.css({color: getNormalizedTextColor(data.color)});
@@ -301,7 +175,7 @@
 
 				/* Handle the colors. */
 				handleColors();
-			});
+				//});
 		}
 	};
 })

--- a/www/js/jquery.knob.js
+++ b/www/js/jquery.knob.js
@@ -581,7 +581,7 @@
             return ret;
         };
 
-        this.listen = function () {
+        /*this.listen = function () {
             // bind MouseWheel
             var s = this,
                 mw = function (e) {
@@ -668,7 +668,7 @@
 
             this.$c.bind("mousewheel DOMMouseScroll", mw);
             this.$.bind("mousewheel DOMMouseScroll", mw)
-        };
+        };*/
 
         this.init = function () {
 

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -3476,13 +3476,13 @@ function lazyLode(view) {
 	       	} else {
 				if (UI.libPos[1] >= 0 && currentView == 'album') {
 					setTimeout(function(){
-						$('#albumcovers .lib-entry').eq(UI.libPos[1]).addClass('active');
 						customScroll('albumcovers', UI.libPos[1], 0);
+						$('#albumcovers .lib-entry').eq(UI.libPos[1]).addClass('active');
 					}, 250);
 				}
 				if (UI.libPos[0] >= 0 && currentView == 'tag') {
-					customScroll('albums', UI.libPos[0], 0);
 					setTimeout(function(){
+						customScroll('albums', UI.libPos[0], 0);
 						$('#albumsList .lib-entry').eq(UI.libPos[0]).addClass('active');
 						$('#albumsList .lib-entry').eq(UI.libPos[0]).click();
 					}, 250);

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -81,12 +81,11 @@ function loadLibrary() {
 
 	$.post('command/moode.php?cmd=loadlib', function(data) {
 		clearTimeout(libpop);
-        $('#lib-content').show();
-		renderLibrary(data);
 		if (currentView == 'album' || currentView == 'tag') setLibMenuAndHeader();
+        $('#lib-content').css('display', 'block');
+		renderLibrary(data);
         GLOBAL.libRendered = true;
         GLOBAL.libLoading = false;
-
 	}, 'json');
 }
 
@@ -645,7 +644,7 @@ var renderAlbums = function() {
 	// Headers clicked
 	if (UI.libPos[0] == -2) {
 		// only scroll the visible list
-		if ($('.tag-view-btn').hasClass('active')) {
+		if (currentView == 'tag') {
 			$('#lib-album').scrollTo(0, 200);
 		}
 		else {
@@ -654,12 +653,12 @@ var renderAlbums = function() {
 	}
 
 	// Start lazy load
-	if ($('.album-view-btn').hasClass('active')) {
+	if (currentView == 'album') {
 		$('img.lazy-albumview').lazyload({
 			container: $('#lib-albumcover')
 		});
 	}
-	else if ($('.tag-view-btn').hasClass('active') && SESSION.json['library_tagview_covers'] == 'Yes') {
+	else if (currentView == 'tag' && SESSION.json['library_tagview_covers'] == 'Yes') {
 		$('img.lazy-tagview').lazyload({
 		    container: $('#lib-album')
 		});
@@ -1393,7 +1392,7 @@ $('#context-menu-lib-item a').click(function(e) {
 // Click coverart context menu item
 $('#context-menu-lib-album a').click(function(e) {
 	UI.dbEntry[0] = $.isNumeric(UI.dbEntry[0]) ? UI.dbEntry[0] : 0;
-	if (!$('.album-view-button').hasClass('active')) {
+	if (currentView != 'album') {
 		$('#lib-song-' + (UI.dbEntry[0] + 1).toString()).removeClass('active');
 		$('img.lib-coverart').removeClass('active');
 	}

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -28,9 +28,6 @@ jQuery(document).ready(function($) { 'use strict';
 	}
 
     GLOBAL.scriptSection = 'panels';
-	$('#config-back').hide();
-	$('#config-tabs').css('display', 'none');
-	$('#menu-bottom').css('display', 'flex');
 
     // NOTE: This is a workaround for the time knob progress slider not updating correctly when the window is hidden
     document.addEventListener("visibilitychange", visChange);
@@ -135,7 +132,6 @@ jQuery(document).ready(function($) { 'use strict';
     	if (SESSION.json['adaptive'] == "No") {document.body.style.setProperty('--adaptmbg', themeBack);}
     	blurrr == true ? themeOp = .85 : themeOp = .95;
 
-
         function mutate(mutations) {
             mutations.forEach(function(mutation) {
                 $('#alpha-blend span').text() < 1 ? $('#cover-options').show() : $('#cover-options').css('display', '');
@@ -149,28 +145,16 @@ jQuery(document).ready(function($) { 'use strict';
             observer.observe(target, config);
 		});
 
-
-    	// Only display transparency related theme options if alphablend is < 1
-    	/*$('#alpha-blend').on('DOMSubtreeModified',function(){
-    		if ($('#alpha-blend span').text() < 1) {
-    			$('#cover-options').show();
-    		}
-            else {
-    			$('#cover-options').css('display', '');
-    		}
-    	});*/
-
     	tempcolor = (THEME.json[SESSION.json['themename']]['mbg_color']).split(",")
     	themeMback = 'rgba(' + tempcolor[0] + ',' + tempcolor[1] + ',' + tempcolor[2] + ',' + themeOp + ')';
     	accentColor = themeToColors(SESSION.json['accent_color']);
     	document.body.style.setProperty('--themetext', themeMcolor);
     	adaptColor = themeColor;
     	adaptBack = themeBack;
-    	adaptMhalf = themeMback;
+    	adaptShade = themeMback;
     	adaptMcolor = themeMcolor;
     	adaptMback = themeMback;
     	tempback = themeMback;
-    	abFound = false;
     	showMenuTopW = false
     	showMenuTopR = false
     	setColors();
@@ -191,11 +175,6 @@ jQuery(document).ready(function($) { 'use strict';
 
         // Setup pines notify
         $.pnotify.defaults.history = false;
-
-    	// Show button bars
-    	if (!UI.mobile) {
-    		$('#playbtns, #togglebtns').show();
-    	}
 
     	// Screen saver backdrop style
     	if (SESSION.json['scnsaver_style'] == 'Animated') {
@@ -286,45 +265,32 @@ jQuery(document).ready(function($) { 'use strict';
         // ACTIVE VIEW
         //
 
-        // Reset active state
-        $('#folder-panel, #radio-panel').removeClass('active');
-
         // Playback
     	if (currentView.indexOf('playback') != -1) {
-    		$('#playback-panel').addClass('active');
     		$(window).scrollTop(0); // make sure it's scrolled to top
-    		if (UI.mobile) {
-    			$('#container-playlist').css('visibility','hidden');
-    			$('#playback-controls').show();
-    		}
-            else {
+    		if (!UI.mobile) {
 		        customScroll('playlist', parseInt(MPD.json['song']));
     		}
-    		$('#menu-bottom').hide();
-    	}
-        // Library
-    	else {
-    		$('#menu-bottom, #viewswitch').css('display', 'flex');
-    		$('#playback-switch').hide();
+			$(document.body).addClass('playback');		
     	}
 
         // Radio view
     	if (currentView == 'radio') {
-    		makeActive('.radio-view-btn','#radio-panel', currentView);
+    		makeActive(currentView);
     	}
         // Folder view
     	else if (currentView == 'folder') {
-    		makeActive('.folder-view-btn','#folder-panel', 'folder');
+    		makeActive('folder');
     		mpdDbCmd('lsinfo', '');
     	}
         // Tag view
     	else if (currentView == 'tag'){
-    		makeActive('.tag-view-btn','#library-panel', 'tag');
+    		makeActive('tag');
             SESSION.json['library_show_genres'] == 'Yes' ? $('#top-columns').removeClass('nogenre') : $('#top-columns').addClass('nogenre');
     	}
     	// Album view
     	else if (currentView == 'album'){
-    		makeActive('.album-view-btn','#library-panel', 'album');
+    		makeActive('album');
     	}
     });
 
@@ -334,15 +300,15 @@ jQuery(document).ready(function($) { 'use strict';
 
     // Radio view
 	$('.radio-view-btn').click(function(e){
-        makeActive('.radio-view-btn','#radio-panel','radio');
+        makeActive('radio');
 	});
     // Folder view
 	$('.folder-view-btn').click(function(e){
-		makeActive('.folder-view-btn','#folder-panel','folder');
+		makeActive('folder');
 	});
     // Tag view
 	$('.tag-view-btn').click(function(e){
-		makeActive('.tag-view-btn','#library-panel','tag');
+		makeActive('tag');
         SESSION.json['library_show_genres'] == 'Yes' ? $('#top-columns').removeClass('nogenre') : $('#top-columns').addClass('nogenre');
 	    $('#albumsList .lib-entry').removeClass('active');
 
@@ -365,7 +331,7 @@ jQuery(document).ready(function($) { 'use strict';
 	$('.album-view-btn').click(function(e){
 		$('#library-panel').addClass('covers').removeClass('tag');
 		GLOBAL.lazyCovers = false;
-		makeActive('.album-view-btn','#library-panel','album');
+		makeActive('album');
 
 		if (!GLOBAL.libRendered) {
 			loadLibrary();
@@ -713,7 +679,7 @@ jQuery(document).ready(function($) { 'use strict';
                 currentView = 'playback,radio';
     			$('#playback-switch').click();
 
-                if (!$('.radio-view-btn').hasClass('active')) {
+                if (currentView != 'radio') {
     				$('.radio-view-btn').click();
     			}
 
@@ -1236,20 +1202,17 @@ jQuery(document).ready(function($) { 'use strict';
         $('#cv-playlist').toggle();
 
         if ($('#cv-playlist').css('display') == 'block') {
-            $('#cv-playlist ul').html($('#playlist ul').html());
             if (SESSION.json['playlist_art'] == 'Yes') {
                 lazyLode('cv-playlist');
             }
             customScroll('cv-playlist', parseInt(MPD.json['song']));
 
             GLOBAL.playbarPlaylistTimer = setTimeout(function() {
-                $('#cv-playlist ul').html('');
                 $('#cv-playlist').hide();
             }, 20000);
         }
         else {
             e.preventDefault();
-            $('#cv-playlist ul').html('');
             window.clearTimeout(GLOBAL.playbarPlaylistTimer);
         }
 	});
@@ -1297,24 +1260,27 @@ jQuery(document).ready(function($) { 'use strict';
         }
 
         if (coverView) {
-			$('body').removeClass('cv');
+            $('#cv-playlist ul').html('');
+            $('#cv-playlist').css('display', '');
 			coverView = false;
-            setColors();
+			$('body').removeClass('cv', function(){
+	            setColors();
+				if (!UI.mobile && currentView.indexOf('playback') != -1) {
+		            customScroll('playlist', parseInt(MPD.json['song']));
+				}
+			});
 
             // TEST: Fixes issue where some elements briefly remain on-screen when entering or returning from CoverView
-            $('#cv-playlist ul').html('');
-            $('#cv-playlist').hide();
-            $('#lib-coverart-img').show();
+            //$('#lib-coverart-img').show();
 
             // TEST: Fixes Queue sometimes not being visable after returning from CoverView
-            UI.mobile ? $('#playback-queue').css('width', '99.9%') : $('#playback-queue').css('width', '38.1%');
+            /*UI.mobile ? $('#playback-queue').css('width', '99.9%') : $('#playback-queue').css('width', '38.1%');
             setTimeout(function() {
                 $('#playback-queue').css('width', ''); // TEST: Restore correct width to force Queue visable
-            }, DEFAULT_TIMEOUT);
-            if (SESSION.json['playlist_art'] == 'Yes') {
+            }, DEFAULT_TIMEOUT);*/
+            /*if (SESSION.json['playlist_art'] == 'Yes') {
                 lazyLode('playlist');
-            }
-            customScroll('playlist', parseInt(MPD.json['song']));
+            }*/
         }
         // Reset screen saver timeout global
         else if (SESSION.json['scnsaver_timeout'] != 'Never') {

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -40,7 +40,7 @@
 	</div>
 
 	<!-- PLAYBACK WITH INTEGRATED QUEUE -->
-	<div id="playback-panel" class="tab-pane">
+	<div id="playback-panel">
 		<div class="btnlist btnlist-top btnlist-top-pl">
 			<form id="pl-search" method="post" onSubmit="return false;">
 				<div class="input-append">
@@ -116,15 +116,15 @@
 						<div id="playback-firstuse-help"><div></div></div>
 						<div aria-label="Cover Art" id="coverart-url"></div>
 						<div id="timeline">
-							<div class="timeline-bg"></div>
-							<div class="timeline-progress"></div>
-							<div class="timeline-thm">
-								<input aria-label="Time" id="timetrack" type="range" min="0" max="1000" value="0" step="1">
+							<div aria-label="Countdown" id="m-countdown"></div>
+							<div id="progress">
+								<div class="timeline-bg"></div>
+								<div class="timeline-progress"></div>
+								<div class="timeline-thm">
+									<input aria-label="Time" id="timetrack" type="range" min="0" max="1000" value="0" step="1">
+								</div>
 							</div>
-							<div id="mobile-time">
-								<div aria-label="Countdown" id="m-countdown"></div>
-								<div aria-label="Total" id="m-total"></div>
-							</div>
+							<div aria-label="Total" id="m-total"></div>
 						</div>
 
 						<div id="songsand">
@@ -169,7 +169,7 @@
 	</div>
 
 	<!-- LIBRARY VIEWS -->
-	<div id="library-panel" class="tab-pane">
+	<div id="library-panel">
 		<div class="container-library">
 			<div id="lib-content">
 				<div id="content-position">
@@ -240,7 +240,7 @@
 	</div>
 
 	<!-- FOLDER VIEW -->
-	<div id="folder-panel" class="tab-pane">
+	<div id="folder-panel">
 		<div id="container-browse">
 			<div aria-label="Back" class="btnlist btnlist-top btnlist-top-db">
 				<button id="db-back" class="btn"><i class="far fa-arrow-left"></i></button>
@@ -264,7 +264,7 @@
 	</div>
 
 	<!-- RADIO VIEW -->
-	<div id="radio-panel" class="tab-pane">
+	<div id="radio-panel">
 		<div id="container-radio">
 			<div class="btnlist btnlist-top btnlist-top-ra">
 				<button aria-label="Radio Manager" id="radio-manager-btn" class="btn"><i class="fas fa-cog"></i></button>


### PR DESCRIPTION
This patch changes from using view-panel.active type determination of the active view to one that adds a view class to the body, this lets us further get rid of css manipulating javascript. This was originally going to switch over to use visibility instead of mostly display, but that led to increased processor use due to the use of overflow:hidden overhead and was additionally slower, either due to increased memory use or the increased processor use. This also removes all of the forced reflow, etc. calls when switching between views except in the case that lazyload runs and we still have some on page load in part or whole because of lazyload but idc.

This is a pretty big change so there may be breakage but so maybe hold off on merge for a day or so.

This entailed:

moode.css

1) changing some % values to a fixed width (using vw wrt the playback sections)

2) removed/changed some display: rules as we're using a targeted approach now.

3) Changed the mobile cover art h/w to be a fixed value to reduce reflows.

4) added targeted (e.g. body.view) rules that replicated some of the removed javascript.

5) added a new scrolling class for mobile portrait that replaces the javascript in the window scroll handler, this also lets us only show the now playing animation when it's visible as it's a cpu hog.

6) revert playbar prev hiding

7) revert playbar font size

8) add media queries for tablet cv use

panels.css

1) added new adaptShade css var (replaces adaptMhalf, used in setting a gradient for the playback view)

2) changed from view-panel.active to body.view layout, this adds a lot of targeted (e.g. body.playback) rules that are applied automatically when we switch views.

3) further consolidated css for radio and database as they're basically the same layout.

4) changed to use targeted css for ellipsis limited text so it's applied only on elements of the active view in case someday we revisit the visibility thing.

5) changed to targeted display of the now playing icon because we really don't want multiple copies of this running.

6) change the display values of various elements (e.g. button bars for radio and folder views) by default so we toggle them on when the view is active, this looks better than disabling them when they're not active

7) changed viewswitch to use body.view instead of an active class added to a viewswitch button

8) modified cv playlist to go to the top of the screen.

9) adjusted quick jump index css to better fit their space(s)

10) change cv to work with the new body.view style by overriding the visibility of the current view

11) redid timelines to use l/r justified times

jquery-knobs

1) commented out the mousewheel listener section from jquery-knobs because it was always active, was mostly just annoying, and chrome said it made our scrolling slower.

jquery-adaptive-backgrounds

1) repurposed to do only what we use it for which led to a lot of code removal.

scripts-library

1) switched a few conditionals that checked for a tag view button having an active class to use currentView.

scripts-panels

1) removed some unneeded javascript css to do with the config screens

2) remove old domsubtree code

3) remove old abFound global

4) switch active view to the much more concise new body.view layout

5) change cv to only copy the playlist on enter/exit rather than each time it's displayed

6) change cv to work with the new body.view layout

playerlib

1) rename adaptMhalf to adaptShade

2) remove abFound global

3) have cv copy the playlist on enter, commented out some 'fixes issue where' code

4) run adaptive function even if default image

5) only paint mobile progress / desktop knob if on playback screen

6) make rgbToHsl work with rgba colors (but ignores the alpha)

7) add rgbaOp function to change the alpha of an rgba color

8) add arrOp function to do what rgbaOp does but with a color that's been split into an array already (used by rgbaOp)

9) add shadeOp function to compute adaptBack, adaptMback and adaptShade colors (used by adaptive-background function and after a theme change in prefs)

10) simplified btnbarfix function a bit

11) add support for adaptShade to setColors.

12) change window scroll handler for mobile portrait (for play queue / playbar display) to add/remove a class to do the css manipulations instead of javascript, this also lets us not run the animation when the play queue isn't visible

13) modify playbar-switch click handler to use the new body.view layout (removed a bunch of js)

14) simplify makeactive as a result of body.view layout

15) simplify lazylode as we didn't use force or skip anymore, add a block of code to scroll the library list when lazyload isn't called