### PR TITLE
Fix Bluetooth agent for devices requiring PIN

### DIFF
--- a/www/command/bt-agent.py
+++ b/www/command/bt-agent.py
@@ -78,11 +78,11 @@ class Agent(dbus.service.Object):
 
     @dbus.service.method(AGENT_INTERFACE, in_signature="o", out_signature="s")
     def RequestPinCode(self, device):
-        raise Cancelled("Pin code not supported")
+        return "0000"
 
     @dbus.service.method(AGENT_INTERFACE, in_signature="o", out_signature="u")
     def RequestPasskey(self, device):
-        raise Cancelled("Passkey code not supported")
+        return 0000
 
     @dbus.service.method(AGENT_INTERFACE, in_signature="ouq", out_signature="")
     def DisplayPasskey(self, device, passkey, entered):
@@ -94,7 +94,7 @@ class Agent(dbus.service.Object):
 
     @dbus.service.method(AGENT_INTERFACE, in_signature="ou", out_signature="")
     def RequestConfirmation(self, device, passkey):
-        raise Cancelled("Confirmation not supported")
+        return
 
     @dbus.service.method(AGENT_INTERFACE, in_signature="o", out_signature="")
     def RequestAuthorization(self, device):


### PR DESCRIPTION
This hardcoding of the pin to the 0000 screen solves pairing issues for some Xiaomi devices that require a PIN code to associate