### PR TITLE
Fix missing brackets at if condition

### DIFF
--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -991,7 +991,7 @@ function genSearchUrl (artist, title, album) {
 			searchStr = artist;
 			break;
 	}
-    	if SESSION.json['search_site'] != 'Disabled' {
+    	if (SESSION.json['search_site'] != 'Disabled') {
 		var returnStr =  '<a id="coverart-link" href=' + '"' + searchEngine + searchStr + '"' + ' target="_blank">'+ title + '</a>';
 	} else {
 		var returnStr =  title;


### PR DESCRIPTION
While performing a gulp build found missing brackets arround javascript condition.