### PR TITLE
Features/gulp patch for min usages

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -402,6 +402,25 @@ gulp.task('patchfooter', function (done) {
         .on('end', done);
 });
 
+gulp.task('patchindex', function (done) {
+    return gulp.src(pkg.app.src+'/index.php')
+        .pipe($.if(!mode.force(), $.newer( { dest: pkg.app.dist})))
+        .pipe($.replace(/indextpl[.]html/g, "indextpl.min.html"))
+        .pipe($.replace(/footer[.]php/g, "footer.min.php"))
+        .pipe($.size({showFiles: true, total: false}))
+        .pipe(gulp.dest(DEPLOY_LOCATION))
+        .on('end', done);
+});
+
+gulp.task('patchconfigs', function (done) {
+    return gulp.src(pkg.app.src+'/*-config.php')
+        .pipe($.if(!mode.force(), $.newer( { dest: pkg.app.dist})))
+        .pipe($.replace(/footer[.]php/g, "footer.min.php"))
+        .pipe($.size({showFiles: true, total: false}))
+        .pipe(gulp.dest(DEPLOY_LOCATION))
+        .on('end', done);
+});
+
 gulp.task('minifyhtml', function (done) {
     return gulp.src(pkg.app.src+'/templates/indextpl.html')
         .pipe($.if(!mode.force(), $.newer( { dest: pkg.app.dist})))
@@ -451,17 +470,21 @@ gulp.task('deployvarlocalwww', function (done) {
         .on('end', done);
 });
 
-gulp.task('deployback', gulp.series(['patchheader','patchfooter', 'minifyhtml'], function (done) {
+gulp.task('deployback', gulp.series(['patchheader','patchfooter', 'patchindex', 'patchconfigs', 'minifyhtml'], function (done) {
     return gulp.src([  pkg.app.src+'/*.php'
                       ,pkg.app.src+'/command/**/*'
                       ,pkg.app.src+'/inc/**/*'
                       ,pkg.app.src+'/templates/**/*'
                       ,pkg.app.src+'/*'
+                      // exclude generated content:
                       ,'!'+pkg.app.src+'/index.html'
                       ,'!'+pkg.app.src+'/templates/indextpl.min.html'
                       ,'!'+pkg.app.src+'/templates/indextpl.html'
                       ,'!'+pkg.app.src+'/header.php'
+                      ,'!'+pkg.app.src+'/footer.php'
                       ,'!'+pkg.app.src+'/footer.min.php'
+                      ,'!'+pkg.app.src+'/index.php'
+                      ,'!'+pkg.app.src+'/*-config.php'
                       ,pkg.app.src+'/css/shellinabox*.css'
                       ],
                       {base: pkg.app.src})

--- a/www/apl-config.php
+++ b/www/apl-config.php
@@ -82,4 +82,4 @@ storeBackLink($section, $tpl);
 
 include('header.php');
 eval("echoTemplate(\"" . getTemplate("templates/$tpl") . "\");");
-include('footer.min.php');
+include('footer.php');

--- a/www/blu-config.php
+++ b/www/blu-config.php
@@ -195,4 +195,4 @@ storeBackLink($section, $tpl);
 
 include('header.php');
 eval("echoTemplate(\"" . getTemplate("templates/$tpl") . "\");");
-include('footer.min.php');
+include('footer.php');

--- a/www/chp-config.php
+++ b/www/chp-config.php
@@ -300,4 +300,4 @@ storeBackLink($section, $tpl);
 
 include('header.php');
 eval("echoTemplate(\"" . getTemplate("templates/$tpl") . "\");");
-include('footer.min.php');
+include('footer.php');

--- a/www/eqg-config.php
+++ b/www/eqg-config.php
@@ -126,4 +126,4 @@ storeBackLink($section, $tpl);
 
 include('header.php');
 eval("echoTemplate(\"" . getTemplate("templates/$tpl") . "\");");
-include('footer.min.php');
+include('footer.php');

--- a/www/eqp-config.php
+++ b/www/eqp-config.php
@@ -157,4 +157,4 @@ storeBackLink($section, $tpl);
 
 include('header.php');
 eval("echoTemplate(\"" . getTemplate("templates/$tpl") . "\");");
-include('footer.min.php');
+include('footer.php');

--- a/www/gpio-config.php
+++ b/www/gpio-config.php
@@ -98,4 +98,4 @@ storeBackLink($section, $tpl);
 
 include('header.php');
 eval("echoTemplate(\"" . getTemplate("templates/$tpl") . "\");");
-include('footer.min.php');
+include('footer.php');

--- a/www/header.php
+++ b/www/header.php
@@ -42,24 +42,17 @@
     <!-- RESOURCES -->
     <!-- Common CSS -->
 	<!-- build:css css/styles.min.css -->
-    <link href="css/bootstrap.min.css" rel="stylesheet">
-    <link href="css/bootstrap-select.min.css" rel="stylesheet">
-    <link href="css/flat-ui.min.css" rel="stylesheet">
-    <link href="css/jquery.pnotify.default.min.css" rel="stylesheet">
-    <link href="css/fontawesome-moode.min.css" rel="stylesheet">
-    <link href="css/panels.min.css" rel="stylesheet">
-    <link href="css/moode.min.css" rel="stylesheet">
+    <link href="css/bootstrap.css" rel="stylesheet">
+    <link href="css/bootstrap-select.css" rel="stylesheet">
+    <link href="css/flat-ui.css" rel="stylesheet">
+    <link href="css/jquery.pnotify.default.css" rel="stylesheet">
+    <link href="css/fontawesome-moode.css" rel="stylesheet">
+    <link href="css/panels.css" rel="stylesheet">
+    <link href="css/moode.css" rel="stylesheet">
 	<!-- endbuild -->
 
-    <!-- Common JS -->
+	<!-- Common JS -->
 	<!-- build:js js/lib.min.js defer -->
-
-	<!--removeIf(USEBUNDLE)-->
-	<script src="js/jquery-1.8.2.min.js" />
-	<script src="js/jquery-ui-1.10.0.custom.min.js" defer></script>
-	<!--endRemoveIf(USEBUNDLE)-->
-
-	<!-- BUNDLE_TAG
 	<script src="js/jquery-1.8.2.js" />
 	<script src="js/jquery-ui/jquery-ui.js" ></script>
 	<script src="js/jquery-ui/jquery.ui.core.js" defer></script>
@@ -70,14 +63,14 @@
 	<script src="js/jquery-ui/jquery.ui.slider.js" defer></script>
 	<script src="js/jquery-ui/jquery.ui.tooltip.js" defer></script>
 	<script src="js/jquery-ui/jquery.ui.effect.js" defer></script>
-	BUNDLE_TAG -->
-    <script src="js/bootstrap.min.js" defer></script>
-    <script src="js/bootstrap-select.min.js" defer></script>
-    <script src="js/jquery.pnotify.min.js" defer></script>
-    <script src="js/notify.min.js" defer></script>
+
+    <script src="js/bootstrap.js" defer></script>
+    <script src="js/bootstrap-select.js" defer></script>
+    <script src="js/jquery.pnotify.js" defer></script>
+    <script src="js/notify.js" defer></script>
     <script src="js/playerlib-nomin.js" defer></script>
-    <script src="js/playerlib.min.js" defer></script>
-    <script src="js/links.min.js" defer></script>
+    <script src="js/playerlib.js" defer></script>
+    <script src="js/links.js" defer></script>
 	<!-- endbuild -->
 
     <!-- Playback / Library -->
@@ -85,19 +78,19 @@
     <?php if ($section == 'index') { ?>
 	<!--endRemoveIf(GENINDEXDEV)-->
 		<!-- build:css css/main.min.css -->
-        <link href="css/jquery.countdown.min.css" rel="stylesheet">
+        <link href="css/jquery.countdown.css" rel="stylesheet">
 		<!-- endbuild -->
 		<!-- build:js js/main.min.js defer -->
-        <script src="js/jquery.countdown.min.js" defer></script>
-        <script src="js/jquery.scrollTo.min.js" defer></script>
-        <script src="js/jquery.touchSwipe.min.js" defer></script>
-        <script src="js/jquery.lazyload.min.js" defer></script>
-        <script src="js/jquery.md5.min.js" defer></script>
-        <script src="js/jquery.adaptive-backgrounds.min.js" defer></script>
-        <script src="js/jquery.knob.min.js" defer></script>
-        <script src="js/bootstrap-contextmenu.min.js" defer></script>
-        <script src="js/scripts-library.min.js" defer></script>
-        <script src="js/scripts-panels.min.js" defer></script>
+        <script src="js/jquery.countdown.js" defer></script>
+        <script src="js/jquery.scrollTo.js" defer></script>
+        <script src="js/jquery.touchSwipe.js" defer></script>
+        <script src="js/jquery.lazyload.js" defer></script>
+        <script src="js/jquery.md5.js" defer></script>
+        <script src="js/jquery.adaptive-backgrounds.js" defer></script>
+        <script src="js/jquery.knob.js" defer></script>
+        <script src="js/bootstrap-contextmenu.js" defer></script>
+        <script src="js/scripts-library.js" defer></script>
+        <script src="js/scripts-panels.js" defer></script>
 		<!-- endbuild -->
     <!-- Configs -->
 	<!--removeIf(GENINDEXDEV)-->
@@ -106,13 +99,13 @@
 		<!--removeIf(NOCONFIGSECTION)-->
 		<!-- build:js js/config.min.js defer -->
 		<!-- CONFIGBLOCKSECTION_BEGIN -->
-        <script src="js/custom_checkbox_and_radio.min.js" defer></script>
+        <script src="js/custom_checkbox_and_radio.js" defer></script>
         <script src="js/custom_radio.js" defer></script>
-        <script src="js/jquery.tagsinput.min.js" defer></script>
-        <script src="js/jquery.placeholder.min.js" defer></script>
+        <script src="js/jquery.tagsinput.js" defer></script>
+        <script src="js/jquery.placeholder.js" defer></script>
         <script src="js/i18n/_messages.en.js" defer></script>
-        <script src="js/application.min.js" defer></script>
-        <script src="js/scripts-configs.min.js" defer></script>
+        <script src="js/application.js" defer></script>
+        <script src="js/scripts-configs.js" defer></script>
 		<!-- CONFIGBLOCKSECTION_END -->
 		<!-- endbuild -->
 		<!--endRemoveIf(NOCONFIGSECTION)-->

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -250,10 +250,8 @@ function integrityCheck() {
 		// Check file hash
 		if (md5(file_get_contents($row['param'])) !== $row['value']) {
 			if ($row['action'] === 'exit') {
-				// $_SESSION['ic_return_code'] = '3';
-				// return false;
-				workerLog('worker: Integrity check (' . $row['action'] . ': ' . basename($row['param']) . ')');
-				$warning = true;
+				$_SESSION['ic_return_code'] = '3';
+				return false;
 			}
 			elseif ($row['action'] === 'warning') {
 				workerLog('worker: Integrity check (' . $row['action'] . ': ' . basename($row['param']) . ')');

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -250,8 +250,10 @@ function integrityCheck() {
 		// Check file hash
 		if (md5(file_get_contents($row['param'])) !== $row['value']) {
 			if ($row['action'] === 'exit') {
-				$_SESSION['ic_return_code'] = '3';
-				return false;
+				// $_SESSION['ic_return_code'] = '3';
+				// return false;
+				workerLog('worker: Integrity check (' . $row['action'] . ': ' . basename($row['param']) . ')');
+				$warning = true;
 			}
 			elseif ($row['action'] === 'warning') {
 				workerLog('worker: Integrity check (' . $row['action'] . ': ' . basename($row['param']) . ')');

--- a/www/index.php
+++ b/www/index.php
@@ -30,7 +30,7 @@ session_write_close();
 
 $section = basename(__FILE__, '.php');
 
-$tpl = "indextpl.min.html";
+$tpl = "indextpl.html";
 include('header.php');
 eval("echoTemplate(\"".getTemplate("/var/www/templates/$tpl")."\");");
-include('footer.min.php');
+include('footer.php');

--- a/www/inp-config.php
+++ b/www/inp-config.php
@@ -70,4 +70,4 @@ storeBackLink($section, $tpl);
 
 include('header.php');
 eval("echoTemplate(\"" . getTemplate("templates/$tpl") . "\");");
-include('footer.min.php');
+include('footer.php');

--- a/www/lib-config.php
+++ b/www/lib-config.php
@@ -385,4 +385,4 @@ storeBackLink($section, $tpl);
 
 include('header.php');
 eval("echoTemplate(\"".getTemplate("templates/$tpl")."\");");
-include('footer.min.php');
+include('footer.php');

--- a/www/mpd-config.php
+++ b/www/mpd-config.php
@@ -242,4 +242,4 @@ storeBackLink($section, $tpl);
 
 include('header.php');
 eval("echoTemplate(\"" . getTemplate("templates/$tpl") . "\");");
-include('footer.min.php');
+include('footer.php');

--- a/www/net-config.php
+++ b/www/net-config.php
@@ -206,4 +206,4 @@ storeBackLink($section, $tpl);
 
 include('header.php');
 eval("echoTemplate(\"" . getTemplate("templates/$tpl") . "\");");
-include('footer.min.php');
+include('footer.php');

--- a/www/snd-config.php
+++ b/www/snd-config.php
@@ -626,4 +626,4 @@ storeBackLink($section, $tpl);
 
 include('header.php');
 eval("echoTemplate(\"" . getTemplate("templates/$tpl") . "\");");
-include('footer.min.php');
+include('footer.php');

--- a/www/spo-config.php
+++ b/www/spo-config.php
@@ -71,4 +71,4 @@ storeBackLink($section, $tpl);
 
 include('header.php');
 eval("echoTemplate(\"" . getTemplate("templates/$tpl") . "\");");
-include('footer.min.php');
+include('footer.php');

--- a/www/sqe-config.php
+++ b/www/sqe-config.php
@@ -76,4 +76,4 @@ storeBackLink($section, $tpl);
 
 include('header.php');
 eval("echoTemplate(\"" . getTemplate("templates/$tpl") . "\");");
-include('footer.min.php');
+include('footer.php');

--- a/www/sys-config.php
+++ b/www/sys-config.php
@@ -531,4 +531,4 @@ storeBackLink($section, $tpl);
 
 include('header.php');
 eval("echoTemplate(\"" . getTemplate("templates/$tpl") . "\");");
-include('footer.min.php');
+include('footer.php');

--- a/www/upp-config.php
+++ b/www/upp-config.php
@@ -78,4 +78,4 @@ storeBackLink($section, $tpl);
 
 include('header.php');
 eval("echoTemplate(\"" . getTemplate("templates/$tpl") . "\");");
-include('footer.min.php');
+include('footer.php');


### PR DESCRIPTION
This patch makes sure when gulp handles the minifying of the sources and the minified versions of the source are removed, the sources are still usable with the use of gulp.

In that case the sources are copied from ~/moode/www to /var/www and shouldn't use any reference to a (missing) minified source. 
If gulp is used it should patch the source where required to use the min version instead.