### PR TITLE
Features/camilladsp improvements

### DIFF
--- a/www/cdsp-config.php
+++ b/www/cdsp-config.php
@@ -75,6 +75,12 @@ else if (isset($_POST['cdsp-config']) && isset($_POST['check']) && $_POST['check
 else if (isset($_FILES['pipelineconfig']) && isset($_POST['import']) && $_POST['import'] == '1') {
 	$configFileName = $cdsp->getConfigsLocationsFileName() . $_FILES["pipelineconfig"]["name"];
 	move_uploaded_file($_FILES["pipelineconfig"]["tmp_name"], $configFileName);
+
+	if( $_SESSION['camilladsp'] == $_FILES["pipelineconfig"]["name"] ) { // if upload active config, fix it
+		if ($_SESSION['cdsp_fix_playback'] == 'Yes' ) {
+			$cdsp->setPlaybackDevice($_SESSION['cardnum']);
+		}
+	}
 	$_SESSION['notify']['title'] =  htmlentities('Import \"' . $_FILES["pipelineconfig"]["name"] . '\" completed');
 }
 // Export (Download)

--- a/www/cdsp-config.php
+++ b/www/cdsp-config.php
@@ -90,9 +90,16 @@ else if (isset($_POST['cdsp-config']) && isset($_POST['export']) && $_POST['expo
 }
 // Remove
 else if (isset($_POST['cdsp-config']) && isset($_POST['remove']) && $_POST['remove'] == '1') {
-	$configFileName = $cdsp->getConfigsLocationsFileName() . $_POST['cdsp-config'];
-	unlink($configFileName);
-	$_SESSION['notify']['title'] = htmlentities('Remove configuration \"' . $_POST['cdsp-config'] . '\" completed');
+
+	if( $_SESSION['camilladsp'] != $_POST['cdsp-config'] ) { // can't remove active config
+		$configFileName = $cdsp->getConfigsLocationsFileName() . $_POST['cdsp-config'];
+		unlink($configFileName);
+		$_SESSION['notify']['title'] = htmlentities('Remove configuration \"' . $_POST['cdsp-config'] . '\" completed');
+	}
+	else {
+		$_SESSION['notify']['title'] = htmlentities('Cannot remove active configuration \"' . $_POST['cdsp-config'] . '\"');
+	}
+
 }
 // Import (Upload)
 else if (isset($_FILES['coeffsfile']) && isset($_POST['import']) && $_POST['import'] == '1') {

--- a/www/cdsp-config.php
+++ b/www/cdsp-config.php
@@ -124,7 +124,14 @@ else if (isset($_POST['cdsp-coeffs']) && isset($_POST['remove']) && $_POST['remo
 	unlink($configFileName);
 	$_SESSION['notify']['title'] = htmlentities('Remove configuration \"' . $_POST['cdsp-coeffs'] . '\" completed');
 }
+else if (isset($_POST['cdsp-coeffs']) && isset($_POST['info']) && $_POST['info'] == '1') {
+	$coeffInfo = $cdsp->coeffInfo($_POST['cdsp-coeffs']);
 
+	$coeffInfoHtml ='Mediainfo:<br/>';
+	foreach ($coeffInfo as  $param=>$value) {
+		$coeffInfoHtml .= ''. $param . ' = ' . $value. '<br/>';
+	}
+}
 /**
  * Generate data for html templating
  */
@@ -150,7 +157,7 @@ $configs = $cdsp->getAvailableCoeffs();
 $_selected_coeff = NULL;
 foreach ($configs as $config_file=>$config_name) {
 	$selected = ($_POST['cdsp-coeffs'] == $config_file || (isset($_POST['cdsp-coeffs']) == false && $_selected_coeff == NULL) ) ? 'selected' : '';
-	$_select['cdsp_coeffs'] .= sprintf("<option value='%s' %s>%s</option>\n", $config_file, $selected, $config_name);
+	$_select['cdsp_coeffs'] .= sprintf("<option value='%s' %s>%s</option>\n", $config_file, $selected, $config_file);
 	if ($selected == 'selected') {
 		$_selected_coeff = $config_file;
 	}

--- a/www/inc/cdsp.php
+++ b/www/inc/cdsp.php
@@ -158,6 +158,38 @@ class CamillaDsp {
     }
 
     /**
+     * Provide coeff info
+     */
+    function coeffInfo($coefffile) {
+        $fileName = $this->CAMILLA_CONFIG_DIR . '/coeffs/'. $coefffile;
+        $jsonString = syscmd("mediainfo --Output=JSON " . $fileName);
+        $mediaDataObj = json_decode(implode($jsonString));
+
+        $ext = $mediaDataObj->{'media'}->{'track'}[0]->{'FileExtension'};
+        $siz = $mediaDataObj->{'media'}->{'track'}[0]->{'FileSize'};
+        $rate =$mediaDataObj->{'media'}->{'track'}[1]->{'SamplingRate'};
+        $bits =$mediaDataObj->{'media'}->{'track'}[1]->{'BitDepth'};
+        $ch = $mediaDataObj->{'media'}->{'track'}[1]->{'Channels'};
+        $format =$mediaDataObj->{'media'}->{'track'}[1]->{'Format'};
+
+        $mediaInfo = Array();
+        if($ext)
+            $mediaInfo['extension'] = $ext;
+        if($format)
+            $mediaInfo['format'] = $format;
+        if($rate)
+            $mediaInfo['samplerate'] = $rate/1000.0 . ' kHz';
+        if($bits)
+            $mediaInfo['bitdepth'] = $bits . ' bits';
+        if($ch)
+            $mediaInfo['channels'] = $ch;
+        if($siz != NULL)
+            $mediaInfo['size'] = sprintf('%.1f kB', $siz/1024.0) ;
+
+        return $mediaInfo;
+    }
+
+    /**
      * Returns the version of the used CamillaDSP
      */
     function version() {
@@ -223,7 +255,18 @@ function test_cdsp() {
     print_r($cdsp->detectSupportedSoundFormats());
 
 
-    $cdsp->setPlaybackDevice(7);
+    // $cdsp->setPlaybackDevice(7);
+
+    // print_r($cdsp->coeffinfo('Sennheiser_HD800S.wav'));
+    $res = $cdsp->coeffInfo('Sennheiser_HD800S.wav');
+    print_r($res);
+//    print_r($res->{'media'}->{'track'}[0]->{'Format'});
+
+    // print($res['media']['track'][1]['BitDepth']);
+
+    $res = $cdsp->coeffInfo('test1.txt');
+    print_r($res);
+
 }
 
 if (basename(__FILE__) == basename($_SERVER["SCRIPT_FILENAME"])) {

--- a/www/templates/cdsp-config.html
+++ b/www/templates/cdsp-config.html
@@ -131,9 +131,10 @@
 			<div class="control-group">
 				<label class="control-label" for="cdsp-configs">Pipeline</label>
 				<div class="controls">
-					<select id="cdsp-configs" class="input-large" name="cdsp-config" onchange="$('#config_remove_id').val($('#cdsp-configs :selected').val() ); $('#cdsp_check_msg').html('');">
+				    <select id="cdsp-configs" class="input-large" name="cdsp-config" onchange="$('#btn-automatic-check').click();">
 						$_select[cdsp_configs]
 					</select>
+					<button id="btn-automatic-check" class="btn btn-medium btn-primary btn-submit" type="submit" name="checkauto" value="1"  style="display:none" ></button>
 					<br/>
 					<div id="cdsp_check_msg">
 					$checkMsg
@@ -194,7 +195,7 @@
 <!-- TODO: set selected from javascript -->
 <form class="form-horizontal" method="post">
 	<div id="remove-pipeline" class="modal modal-sm2 hide" tabindex="-1" role="dialog" aria-labelledby="remove-pipeline-label" aria-hidden="true">
-		<input id="config_remove_id" type="hidden" name="cdsp-config" value="$_selected_configuration"/>
+		<input id="config_remove_id" type="hidden" name="cdsp-config" value="$selectedConfig"/>
 		<div class="modal-header">
 			<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
 			<h3>Remove Pipeline</h3>
@@ -217,7 +218,7 @@
 <form class="form-horizontal" method="post">
 	<div id="remove-coeff" class="modal modal-sm2 hide" tabindex="-1" role="dialog" aria-labelledby="remove-coeff-label" aria-hidden="true">
 		<!-- TODO:set correct selected-->
-		<input id="coeff_remove_id" type="hidden" name="cdsp-coeffs" value="$_selected_configuration"/>
+		<input id="coeff_remove_id" type="hidden" name="cdsp-coeffs" value="$_selected_coeff"/>
 		<div class="modal-header">
 			<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
 			<h3>Remove Coeff</h3>

--- a/www/templates/cdsp-config.html
+++ b/www/templates/cdsp-config.html
@@ -156,23 +156,29 @@
 					<input type="file" id="coeffsfile" accept=".wav,.txt,.csv" name="coeffsfile" style="display:none" onchange="$('#btn-import-coeff').click();" >
 					<button id="btn-import-coeff" class="btn btn-medium btn-primary btn-submit" type="submit" name="import" value="1"  style="display:none"/>
 				</div>
+				<button class="btn btn-medium btn-primary btn-submit" type="submit" name="info" value="1">Info</button>
 				<a aria-label="Help" class="info-toggle" data-cmd="info-convolution-actions" href="#notarget"><i class="fas fa-info-circle"></i></a>
 				<div id="info-convolution-actions" class="help-block-configs help-block-margin legend-info-help hide">
 						Remove: delete the selected convolution file.<br/>
 						Download: download the selected convolution file.<br/>
 						Upload new: upload a convolution file, existing ones are overwritten.<br/>
+						Info: provide mediainfo about the convolution file.<br/>
  			    </div>
 			</div>
 
 			<legend>Convolution Files</legend>
 			<div class="control-group">
 				<label class="control-label" for="cdsp-coeffs">Coeffs</label>
-				<div class="controls">
-					<select id="cdsp-coeffs" class="input-large" name="cdsp-coeffs" onchange="$('#coeff_remove_id').val($('#cdsp-coeffs :selected').val() );">
+				<div class="controls" >
+					<select id="cdsp-coeffs" class="input-xxlarge" name="cdsp-coeffs" onchange="$('#coeff_remove_id').val($('#cdsp-coeffs :selected').val() );$('#coeff-info').html('');">
 						$_select[cdsp_coeffs]
 					</select>
+					<div id="coeff-info" >
+						$coeffInfoHtml
+					</div>
 				</div>
 			</div>
+
 		</fieldset>
 
 	</form>


### PR DESCRIPTION
Added to the CamillaDSP settings page:

- Protect remove of active configuration
- When active configuration is upload reapply patch device and format
- When other configuration is selected at the pipeline configuration check the config always (still manual check is also available(
- Added Info button to convolution file list; provide mediainfo about the convolution file (if it is a soundfile).