### PR TITLE
Fixed CamillaDSP sample config

### DIFF
--- a/www/templates/cdsp-config.html
+++ b/www/templates/cdsp-config.html
@@ -104,24 +104,24 @@
 					In case this is due to channel counts or sampling rates which are not supported by your DAC,<br>
 					you can either handle this in CamillaDSP with mixers or resamplers<br>
 					or change the formats which are passed to CamillaDSP in <code>/etc/alsa/conf.d/camilladsp.conf</code><br>
-					If this file is erroneous, <code>/var/log/moode.log</code> and <code>/var/log/syslog</code> may also provide hints.
+					If this file is erroneous, <code>/var/log/moode.log</code> and <code>/var/log/syslog</code> may also provide hints.<br>
 					<br>
 					With the currently selected sound device, this is the minimal config, that you need to get any sound through CamillaDSP:<br>
 <code><span style="white-space: pre;">
-	devices:
-	samplerate: 44100  # irrelevant if resampling is disabled - then it will be overridden with the incoming sample rate
-	chunksize: 1024
-	queuelimit: 2  # increasing this introduces significant latency when stopping playback or changing songs
-				   # e.g.: samplerate=44100, chunksize=1024, queuelimit=44 => latency ~ 1s
-	capture:
-	  type: Stdin
-	  channels: 2  # irrelevant - will always be overridden (currently always 2)
-	  format: S32LE  # irrelevant - will always be overridden with the incoming sample format
-	playback:
-	  type: Alsa
-	  channels: 2
-	  device: "$sound_device_type:$current_sound_device_number"  # by default, this is automatically updated when configuration is choosen. (correct value is only shown, when playback is stopped.)																									  #
-	  format: $sound_device_sample_format  # supported formats are: $sound_device_supported_sample_formats # correct value is only shown, when playback is stopped
+devices:
+  samplerate: 44100  # irrelevant if resampling is disabled - then it will be overridden with the incoming sample rate
+  chunksize: 4096 # increase, if buffer underruns occur when using higher samplerates (e.g. to 8192, 16384, 32768, 65536, ...)
+  queuelimit: 1  # increasing this introduces significant latency when stopping playback or changing songs
+                 # e.g.: samplerate=44100, chunksize=1024, queuelimit=44 => latency ~ 1s
+  capture:
+    type: Stdin
+    channels: 2  # irrelevant - will always be overridden (currently always 2)
+    format: S32LE  # irrelevant - will always be overridden with the incoming sample format
+  playback:
+    type: Alsa
+    channels: 2
+    device: "$sound_device_type:$current_sound_device_number"  # by default, this is automatically updated when configuration is choosen. (correct value is only shown, when playback is stopped.)																									  #
+    format: $sound_device_sample_format  # supported formats are: $sound_device_supported_sample_formats (correct value is only shown, when playback is stopped)
 </span></code><br><br/>
 					Any reference to a convolution file should be relative like <code>../coeffs/yourfile.wav</code>
 				</div>


### PR DESCRIPTION
This just fixes some info text - no actual code changes.
- fixed indentation, since it is significant in YAML format
- added instructions on how to fix buffer underruns on higher sampling rates