### PR TITLE
Update watchdog.sh

### DIFF
--- a/www/command/watchdog.sh
+++ b/www/command/watchdog.sh
@@ -34,6 +34,11 @@ MPD_ACTIVE=$(pgrep -c -x mpd)
 HW_PARAMS_LAST=""
 SQL_DB=/var/local/www/db/moode-sqlite3.db
 SESSION_DIR=/var/local/php
+
+while [ ! $(sqlite3 $SQL_DB "SELECT value FROM cfg_system WHERE param='sessionid'") ]; do
+        sleep 1
+done
+
 SESSION_FILE=$SESSION_DIR/sess_$(sqlite3 $SQL_DB "SELECT value FROM cfg_system WHERE param='sessionid'")
 
 while true; do


### PR DESCRIPTION
This is to fix the false error appearing in moode.log:

`watchdog: Error: PHP session permissions
`

Basically, we should wait until 'sessionid' is returned from DB to avoid malformed SESSION_FILE variable.