### PR TITLE
add in restart.sh a call to custom reboot & poweroff scripts

### DIFF
--- a/var/local/www/commandw/restart.sh
+++ b/var/local/www/commandw/restart.sh
@@ -19,6 +19,9 @@
 # 2019-04-12 TC moOde 5.0
 #
 
+# scripts directory
+sdir="$(dirname $0)"
+
 if [[ -z $1 ]]; then
 	echo "args are reboot, poweroff"
 	exit 0
@@ -27,13 +30,21 @@ fi
 if [[ $1 = "reboot" ]]; then
 	mpc stop
 	systemctl stop nginx
-	reboot
+	if [[ -x "${sdir}/custom_reboot.sh" ]]; then
+		"${sdir}/custom_reboot.sh"
+	else
+		reboot
+	fi
 fi
 
 if [[ $1 = "poweroff" ]]; then
 	mpc stop
 	systemctl stop nginx
-	poweroff
+	if [[ -x "${sdir}/custom_poweroff.sh" ]]; then
+		"${sdir}/custom_poweroff.sh"
+	else
+		poweroff
+	fi
 fi
 
 echo "args are reboot, poweroff"


### PR DESCRIPTION
Hello Tim,
I use the "[AUDIOPHONICS PI-SPC II](https://www.audiophonics.fr/fr/accessoires-pour-raspberry-pi-et-autres-sbc/audiophonics-pi-spc-ii-module-de-controle-alimentation-lineaire-pour-raspberry-pi-p-11504.html)" power button with Moode and I have just migrated from version 6.7.1 to version 7.0.1. What's annoying is that at each major version update (new iso image) I have to edit and modify the `restart.sh` script from directory `commandw `to add the [AUDIOPHONICS scripts](https://github.com/audiophonics/Raspberry-pwr-management) call.
Would it be possible that you could add in the `restart.sh` script a call to custom scripts (eg. `custom_reboot` and `custom_poweroff`, as proposed in this PR) ?
Like that it would not be necessary to modify your script anymore, we just have to copy the custom scripts into `commandw` directory.
This could be useful for other users who would like to do some processing before a reboot or a poweroff (for example to also display an information message on an lcd or on the PI 7" screen, poweroff an audio amplifier,etc...).
Regards