### PR TITLE
Open the camillagui from within moOde

### DIFF
--- a/www/cdsp-config.php
+++ b/www/cdsp-config.php
@@ -132,6 +132,11 @@ else if (isset($_POST['cdsp-coeffs']) && isset($_POST['info']) && $_POST['info']
 		$coeffInfoHtml .= ''. $param . ' = ' . $value. '<br/>';
 	}
 }
+// camillagui status toggle
+else if (isset($_POST['camillaguistatus']) && isset($_POST['updatecamillagui']) && $_POST['updatecamillagui'] == '1') {
+ 	$cdsp->changeCamillaStatus($_POST['camillaguistatus']);
+}
+
 /**
  * Generate data for html templating
  */
@@ -203,6 +208,13 @@ if( $selectedConfig) {
 	}
 }
 
+$camillaGuiStatus = $cdsp->getCamillaGuiStatus();
+$camillaGuiClickHandler = " onchange=\"$('#btn-updat-camilla-gui').click();\"";
+$_select['camillagui1'] .= "<input type=\"radio\" name=\"camillaguistatus\" id=\"toggle-camillagui1\" value=\"1\" " . (($camillaGuiStatus == CGUI_CHECK_ACTIVE) ? "checked=\"checked\"" : $camillaGuiClickHandler) . " >\n";
+$_select['camillagui0'] .= "<input type=\"radio\" name=\"camillaguistatus\" id=\"toggle-camillagui2\" value=\"0\" " . (($camillaGuiStatus != CGUI_CHECK_ACTIVE) ? "checked=\"checked\"" : $camillaGuiClickHandler) . " >\n";
+$_open_camillagui_disabled = $camillaGuiStatus == CGUI_CHECK_ACTIVE ? '': 'disabled';
+$_camillagui_notfound_show = $camillaGuiStatus == CGUI_CHECK_NOTFOUND ? '': 'hide';
+$_camillagui_status_problems = $camillaGuiStatus == CGUI_CHECK_ACTIVE || $camillaGuiStatus == CGUI_CHECK_INACTIVE || $camillaGuiStatus == CGUI_CHECK_NOTFOUND? 'hide': '';
 session_write_close();
 
 waitWorker(1, 'cdsp-config');

--- a/www/cdsp-configeditor.php
+++ b/www/cdsp-configeditor.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * moOde audio player (C) 2014 Tim Curtis
+ * http://moodeaudio.org
+ *
+ * This Program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This Program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * 2021-MM-DD TC moOde 7.x.x
+ *
+ */
+
+require_once dirname(__FILE__) . '/inc/playerlib.php';
+require_once dirname(__FILE__) . '/inc/cdsp.php';
+
+playerSession('open', '' ,'');
+
+$_camillagui_url = 'http://'. $_SERVER['HTTP_HOST'] . ':5000';
+session_write_close();
+
+waitWorker(1, 'cdsp-configeditor');
+
+$tpl = "cdsp-configeditor.html";
+$section = basename(__FILE__, '.php');
+storeBackLink($section, $tpl);
+
+include('header.php');
+eval("echoTemplate(\"" . getTemplate("templates/$tpl") . "\");");
+include('footer.php');

--- a/www/footer.php
+++ b/www/footer.php
@@ -70,6 +70,7 @@
 				<li><a href="mpd-config.php" class="btn btn-small row2-btns">MPD settings</a></li>
 				<li><a href="eqp-config.php" class="btn btn-small row2-btns">Parametric EQ</a></li>
 				<li><a href="eqg-config.php" class="btn btn-small row2-btns">Graphic EQ</a></li>
+				<li><a href="cdsp-config.php" class="btn btn-small row2-btns">CamillaDSP</a></li>
 				<li class="context-menu"><a href="#notarget" class="btn btn-small row2-btns" data-cmd="setforclockradio-m">Clock radio</a></li>
 				<?php if ($_SESSION['feat_bitmask'] & $FEAT_INPSOURCE) { ?>
 					<li><a href="inp-config.php" class="btn btn-small row2-btns">Input source</a></li>

--- a/www/inc/cdsp.php
+++ b/www/inc/cdsp.php
@@ -29,6 +29,11 @@ require_once dirname(__FILE__) . '/playerlib.php';
 const CDSP_CHECK_VALID = 1;
 const CDSP_CHECK_INVALID = 0;
 const CDSP_CHECK_NOTFOUND = -1;
+
+const CGUI_CHECK_ACTIVE = 0;
+const CGUI_CHECK_INACTIVE = 3;
+const CGUI_CHECK_ERROR = -2;
+const CGUI_CHECK_NOTFOUND = -1;
 class CamillaDsp {
 
     private $ALSA_CDSP_CONFIG = '/etc/alsa/conf.d/camilladsp.conf';
@@ -217,6 +222,25 @@ class CamillaDsp {
             'S16_LE' => 'S16LE');
     }
 
+    function getCamillaGuiStatus() {
+        $output = array();
+        $exitcode = CGUI_CHECK_NOTFOUND;
+        if( file_exists('/etc/systemd/system/camillagui.service')) {
+            $cmd = 'systemctl status camillagui';
+            exec($cmd, $output, $exitcode);
+        }
+
+        return $exitcode;
+    }
+
+    function changeCamillaStatus($enable) {
+        if($enable) {
+            syscmd("sudo systemctl start camillagui");
+        }else {
+            syscmd("sudo systemctl stop camillagui");
+        }
+    }
+
     // placeholders for autoconfig support, empty for now
     function backup() {
     }
@@ -266,6 +290,12 @@ function test_cdsp() {
 
     $res = $cdsp->coeffInfo('test1.txt');
     print_r($res);
+        $cdsp->changeCamillaStatus(0);
+        print_r( $cdsp->getCamillaGuiStatus() );
+        print("\n");
+        $cdsp->changeCamillaStatus(1);
+        print_r( $cdsp->getCamillaGuiStatus() );
+        print("\n");
 
 }
 

--- a/www/templates/cdsp-config.html
+++ b/www/templates/cdsp-config.html
@@ -182,23 +182,49 @@ devices:
 		</fieldset>
 
 	</form>
-	<!-- disabled while the camilla webgui isn't include in moode -->
-	<!--
+
 	<form class="form-horizontal" action="" method="post" >
 		<fieldset>
-			<legend>Pipeline Editor</legend>
+			<legend>Camilla GUI - Pipeline Editor</legend>
+			<span id="info-camillagui-notfound" class="help-block-configs help-block-margin legend-info-help">
+				<i>The use of the CamillaGUI is high experimental in moOde. The CamillaGUI runs standalone from moOde.</i><br/>
+			</span>
 			<div class="control-group">
+				<span id="info-camillagui-notfound" class="help-block-configs help-block-margin legend-info-help $_camillagui_notfound_show" >
+					<span style='color: red'>&#10007;</span> Service not found. Maybe Camillagui isn't installed.
+				</span>
+				<span id="info-camillagui-problems" class="help-block-configs help-block-margin legend-info-help $_camillagui_status_problems">
+					<span style='color: red'>&#10007;</span> Unknown problem with camillagui.
+				</span>
+
+				<label class="control-label" >Status</label>
+				<div class="controls">
+					<div class="toggle">
+						<label class="toggle-radio" for="toggle-camillagui2">ON</label>
+						$_select[camillagui1]
+						<label class="toggle-radio" for="toggle-camillagui1">OFF</label>
+						$_select[camillagui0]
+					</div>
+
+					<a aria-label="Help" class="info-toggle" data-cmd="info-camillagui" href="#notarget"><i class="fas fa-info-circle"></i></a>
+					<span id="info-camillagui" class="help-block-configs help-block-margin legend-info-help hide">
+						Show the current status of the camillagui. On press the status will be toggled.
+						To save resources after a reboot the camillagui is disabled again.
+					</span>
+
+					<button id="btn-updat-camilla-gui" class="btn btn-medium btn-primary btn-submit" type="submit" name="updatecamillagui" value="1" style="display:none"/>
+				</div>
+
 				<div style="margin-top:.5em">
-					<a href="cdsp-configeditor.php"><button class="btn btn-medium btn-primary">Open</button></a>&nbsp;Camilla DSP Pipeline Editor<br>
+					<a href="cdsp-configeditor.php" target="camillagui"><button class="btn btn-medium btn-primary" $_open_camillagui_disabled >Open</button></a>&nbsp;Camilla DSP Pipeline Editor<br>
 				</div>
 			</div>
 		</fieldset>
 	</form>
-	-->
+
 </div>
 </div>
 
-<!-- TODO: set selected from javascript -->
 <form class="form-horizontal" method="post">
 	<div id="remove-pipeline" class="modal modal-sm2 hide" tabindex="-1" role="dialog" aria-labelledby="remove-pipeline-label" aria-hidden="true">
 		<input id="config_remove_id" type="hidden" name="cdsp-config" value="$selectedConfig"/>
@@ -223,7 +249,6 @@ devices:
 
 <form class="form-horizontal" method="post">
 	<div id="remove-coeff" class="modal modal-sm2 hide" tabindex="-1" role="dialog" aria-labelledby="remove-coeff-label" aria-hidden="true">
-		<!-- TODO:set correct selected-->
 		<input id="coeff_remove_id" type="hidden" name="cdsp-coeffs" value="$_selected_coeff"/>
 		<div class="modal-header">
 			<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>

--- a/www/templates/cdsp-configeditor.html
+++ b/www/templates/cdsp-configeditor.html
@@ -1,0 +1,30 @@
+<!--
+/**
+ * moOde audio player (C) 2014 Tim Curtis
+ * http://moodeaudio.org
+ *
+ * (C) 2020 @bitlab (@bitkeeper Git)
+ *
+ * This Program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This Program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * 2020-MM-DD TC moOde 7.x.x
+ *
+ */
+-->
+<div class="container">
+	<div class="container2">
+		<h1 class="cdsp-config">Camillgui</h1>
+		<iframe src="$_camillagui_url" style="width:100%;height:1000px;"/>
+	</div>
+</div>


### PR DESCRIPTION
The PR adds to the bottom of camilladsp config page the functionality to open the camillagui.
With the toggle buttonthe camillagui can be enabled or disabled. After a boot it is always disabled.

![image](https://user-images.githubusercontent.com/1525169/103574986-350b5a80-4ed1-11eb-8d90-a1a02f89fc9f.png)

The camillagui wrapped in moOde with a iframe:

![image](https://user-images.githubusercontent.com/1525169/103575264-be229180-4ed1-11eb-8d9f-c772bfe4e9c9.png)

Not further integration then:
- starting/stopping the gui service
- providing a configuration file with the path to the configs
- opening the editor
- if problems with starting the service a message is shown

Use is experimental.