### PR TITLE
Added option to set max ALSA volume in dB

### DIFF
--- a/var/local/www/commandw/slpower.sh
+++ b/var/local/www/commandw/slpower.sh
@@ -21,15 +21,13 @@
 
 SQLDB=/var/local/www/db/moode-sqlite3.db
 
-RESULT=$(sqlite3 $SQLDB "select value from cfg_system where param='alsavolume_max' or param='alsavolume' or param='amixname' or param='rsmaftersl' or param='wrkready' or param='inpactive'")
+RESULT=$(sqlite3 $SQLDB "select value from cfg_system where param in ('alsavolume', 'rsmaftersl', 'wrkready', 'inpactive')")
 # friendly names
 readarray -t arr <<<"$RESULT"
-ALSAVOLUME_MAX=${arr[0]}
-ALSAVOLUME=${arr[1]}
-AMIXNAME=${arr[2]}
-RSMAFTERSL=${arr[3]}
-WRKREADY=${arr[4]}
-INPACTIVE=${arr[5]}
+ALSAVOLUME=${arr[0]}
+RSMAFTERSL=${arr[1]}
+WRKREADY=${arr[2]}
+INPACTIVE=${arr[3]}
 
 if [[ $INPACTIVE == '1' ]]; then
 	exit 1
@@ -59,7 +57,7 @@ if [[ $WRKREADY == "1" ]]; then
 		sleep 1
 		$(sqlite3 $SQLDB "update cfg_system set value='1' where param='slactive'")
 		if [[ $ALSAVOLUME != "none" && $VOPT == "" ]]; then
-			/var/www/command/util.sh set-alsavol "$AMIXNAME" $ALSAVOLUME_MAX
+			/var/www/command/util.sh set-alsavol-to-max
 		fi
 	else
 		# Value 2 is returned

--- a/var/local/www/commandw/spotevent.sh
+++ b/var/local/www/commandw/spotevent.sh
@@ -21,14 +21,12 @@
 
 SQLDB=/var/local/www/db/moode-sqlite3.db
 
-RESULT=$(sqlite3 $SQLDB "select value from cfg_system where param='alsavolume_max' or param='alsavolume' or param='amixname' or param='mpdmixer' or param='rsmafterspot' or param='inpactive'")
+RESULT=$(sqlite3 $SQLDB "select value from cfg_system where param in ('alsavolume', 'mpdmixer', 'rsmafterspot', 'inpactive')")
 readarray -t arr <<<"$RESULT"
-ALSAVOLUME_MAX=${arr[0]}
-ALSAVOLUME=${arr[1]}
-AMIXNAME=${arr[2]}
-MPDMIXER=${arr[3]}
-RSMAFTERSPOT=${arr[4]}
-INPACTIVE=${arr[5]}
+ALSAVOLUME=${arr[0]}
+MPDMIXER=${arr[1]}
+RSMAFTERSPOT=${arr[2]}
+INPACTIVE=${arr[3]}
 
 if [[ $INPACTIVE == '1' ]]; then
 	exit 1
@@ -43,7 +41,7 @@ if [[ $PLAYER_EVENT == "start" ]]; then
 	$(sqlite3 $SQLDB "update cfg_system set value='1' where param='spotactive'")
 
 	if [[ $ALSAVOLUME != "none" ]]; then
-		/var/www/command/util.sh set-alsavol "$AMIXNAME" $ALSAVOLUME_MAX
+		/var/www/command/util.sh set-alsavol-to-max
 	fi
 fi
 
@@ -53,7 +51,7 @@ if [[ $PLAYER_EVENT == "stop" ]]; then
 	# Restore 0dB hardware volume when mpd configured as below
 	if [[ $MPDMIXER == "software" || $MPDMIXER == "disabled" ]]; then
 		if [[ $ALSAVOLUME != "none" ]]; then
-			/var/www/command/util.sh set-alsavol "$AMIXNAME" $ALSAVOLUME_MAX
+			/var/www/command/util.sh set-alsavol-to-max
 		fi
 	fi
 

--- a/var/local/www/commandw/spspost.sh
+++ b/var/local/www/commandw/spspost.sh
@@ -23,14 +23,12 @@ SQLDB=/var/local/www/db/moode-sqlite3.db
 
 $(sqlite3 $SQLDB "update cfg_system set value='0' where param='airplayactv'")
 
-RESULT=$(sqlite3 $SQLDB "select value from cfg_system where param='alsavolume_max' or param='alsavolume' or param='amixname' or param='mpdmixer' or param='rsmafterapl' or param='inpactive'")
+RESULT=$(sqlite3 $SQLDB "select value from cfg_system where param in ('alsavolume', 'mpdmixer', 'rsmafterapl', 'inpactive')")
 readarray -t arr <<<"$RESULT"
-ALSAVOLUME_MAX=${arr[0]}
-ALSAVOLUME=${arr[1]}
-AMIXNAME=${arr[2]}
-MPDMIXER=${arr[3]}
-RSMAFTERAPL=${arr[4]}
-INPACTIVE=${arr[5]}
+ALSAVOLUME=${arr[0]}
+MPDMIXER=${arr[1]}
+RSMAFTERAPL=${arr[2]}
+INPACTIVE=${arr[3]}
 
 if [[ $INPACTIVE == '1' ]]; then
 	exit 1
@@ -39,7 +37,7 @@ fi
 # Restore 0dB hardware volume when MPD configured as below
 if [[ $MPDMIXER == "software" || $MPDMIXER == "disabled" ]]; then
 	if [[ $ALSAVOLUME != "none" ]]; then
-		/var/www/command/util.sh set-alsavol "$AMIXNAME" $ALSAVOLUME_MAX
+		/var/www/command/util.sh set-alsavol-to-max
 	fi
 fi
 

--- a/var/local/www/commandw/spspre.sh
+++ b/var/local/www/commandw/spspre.sh
@@ -21,12 +21,10 @@
 
 SQLDB=/var/local/www/db/moode-sqlite3.db
 
-RESULT=$(sqlite3 $SQLDB "select value from cfg_system where param='alsavolume_max' or param='alsavolume' or param='amixname' or param='inpactive'")
+RESULT=$(sqlite3 $SQLDB "select value from cfg_system where param in ('alsavolume', 'inpactive')")
 readarray -t arr <<<"$RESULT"
-ALSAVOLUME_MAX=${arr[0]}
-ALSAVOLUME=${arr[1]}
-AMIXNAME=${arr[2]}
-INPACTIVE=${arr[3]}
+ALSAVOLUME=${arr[0]}
+INPACTIVE=${arr[1]}
 
 if [[ $INPACTIVE == '1' ]]; then
 	exit 1
@@ -40,5 +38,5 @@ sleep 1
 $(sqlite3 $SQLDB "update cfg_system set value='1' where param='airplayactv'")
 
 if [[ $ALSAVOLUME != "none" ]]; then
-	/var/www/command/util.sh set-alsavol "$AMIXNAME" $ALSAVOLUME_MAX
+	/var/www/command/util.sh set-alsavol-to-max
 fi

--- a/www/command/worker.php
+++ b/www/command/worker.php
@@ -657,7 +657,7 @@ else {
 // Since we initially set alsa volume to 0 at the beginning of startup it must be reset
 if ($_SESSION['alsavolume'] != 'none') {
 	if ($_SESSION['mpdmixer'] == 'software' || $_SESSION['mpdmixer'] == 'disabled') {
-		$result = sysCmd('/var/www/command/util.sh set-alsavol ' . '"' . $_SESSION['amixname']  . '" ' . $_SESSION['alsavolume_max']);
+		$result = sysCmd('/var/www/command/util.sh set-alsavol-to-max');
 	}
 }
 
@@ -893,7 +893,7 @@ function chkBtActive() {
 			playerSession('write', 'btactive', '1');
 			$GLOBALS['scnsaver_timeout'] = $_SESSION['scnsaver_timeout']; // reset timeout
 			if ($_SESSION['alsavolume'] != 'none') {
-				sysCmd('/var/www/command/util.sh set-alsavol ' . '"' . $_SESSION['amixname']  . '" ' . $_SESSION['alsavolume_max']);
+				sysCmd('/var/www/command/util.sh set-alsavol-to-max');
 			}
 		}
 		sendEngCmd('btactive1'); // Placing here enables each conected device to be printed to the indicator overlay
@@ -1389,7 +1389,7 @@ function runQueuedJob() {
 
 			// Reset hardware volume to 0dB (100) if indicated
 			if (($_SESSION['mpdmixer'] == 'software' || $_SESSION['mpdmixer'] == 'disabled') && $_SESSION['alsavolume'] != 'none') {
-				sysCmd('/var/www/command/util.sh set-alsavol ' . '"' . $_SESSION['amixname']  . '" ' . $_SESSION['alsavolume_max']);
+				sysCmd('/var/www/command/util.sh set-alsavol-to-max');
 			}
 
 			// Restart mpd and pick up conf changes
@@ -1600,7 +1600,7 @@ function runQueuedJob() {
 			if ($_SESSION['slsvc'] == '1') {
 				sysCmd('mpc stop');
 				if ($_SESSION['alsavolume'] != 'none') {
-					sysCmd('/var/www/command/util.sh set-alsavol ' . '"' . $_SESSION['amixname']  . '" ' . $_SESSION['alsavolume_max']);
+					sysCmd('/var/www/command/util.sh set-alsavol-to-max');
 				}
 				cfgSqueezelite();
 				startSqueezeLite();

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -3545,7 +3545,7 @@ function reconfMpdVolume($mixertype) {
 	playerSession('write', 'mpdmixer', $mixertype);
 	// Reset hardware volume to 0dB if indicated
 	if (($mixertype == 'software' || $mixertype == 'disabled') && $_SESSION['alsavolume'] != 'none') {
-		sysCmd('/var/www/command/util.sh set-alsavol ' . '"' . $_SESSION['amixname']  . '" ' . $_SESSION['alsavolume_max']);
+		sysCmd('/var/www/command/util.sh set-alsavol-to-max');
 	}
 	// Update /etc/mpd.conf
 	updMpdConf($_SESSION['i2sdevice']);

--- a/www/snd-config.php
+++ b/www/snd-config.php
@@ -454,8 +454,8 @@ $_chip_link_disable = !empty($result[0]['chipoptions']) ? '' : 'onclick="return 
 if ($_SESSION['alsavolume'] == 'none') {
 	$_alsavolume_max = '';
 	$_alsavolume_max_readonly = 'readonly';
-	$_alsavolume_hide = 'hide'; // Hides the SET button
-	$_alsavolume_msg = "<span class=\"help-block-configs help-block-margin\">Hardware volume controller not detected</span>";
+	$_alsavolume_max_hide = 'hide'; // Hides the SET button
+	$_alsavolume_max_msg = "<span class=\"help-block-configs help-block-margin\">Hardware volume controller not detected</span>";
 }
 else {
 	$_alsavolume_max = $_SESSION['alsavolume_max'];

--- a/www/templates/snd-config.html
+++ b/www/templates/snd-config.html
@@ -72,7 +72,8 @@
 					<button class="btn btn-primary btn-small set-button btn-submit status-msg $_alsavolume_max_hide" type="submit" name="update_alsavolume_max" value="novalue">Set</button>
 					<!--a aria-label="Help" class="info-toggle" data-cmd="info-alsavolume_max" href="#notarget"><i class="fas fa-info-circle"></i></a-->
 					<span id="info-alsavolume_max" class="help-block-configs help-block-margin">
-						This volume level is used to set 0dB when MPD volume control is set to Software or Disabled, or when any of the Audio Renderers are active.
+						This volume level is used to set 0dB (max volume) when MPD volume control is set to Software or Disabled, or when any of the Audio Renderers are active.<br>
+						To prevent clipping, for HDMI and Headphone outputs 100% volume is set to 0dB instead of the +4dB default on these outputs. All other values are passed through untouched.
 					</span>
 					$_alsavolume_max_msg
 				</div>


### PR DESCRIPTION
Fixes #275 

I added a field to set the volume in dB.
If one is set, the other is updated accordingly.
If setting dB fails for some reason, the % value stays and dB value becomes blank.

![set_volume_in_dB](https://user-images.githubusercontent.com/7657699/104079160-e556c700-5221-11eb-9df3-1651b88404dd.png)

I also thought about adding some indicator, which clarifies whether % or dB value is used to set the volume.
Since setting the % usually gives a fractional dB value, it should be obvious, which one is currently in use.
However, if you know a simple, pretty solution to this, I will implement it.
I tried with simple checkboxes, but didn't like the look of it:
![set_volume_in_dB_with_checkbox](https://user-images.githubusercontent.com/7657699/104080253-2ac9c300-5227-11eb-98ad-3ab5fdf809dd.png)

What do you think?