### PR TITLE
Support for remote deploy with gulp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __MACOSX
 /build
 /node_modules
 /www/index.html
+/logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "moOde",
-  "version": "6.6.0d",
+  "version": "7.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -214,6 +214,12 @@
       "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
       "dev": true
     },
+    "ansicolors": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+      "dev": true
+    },
     "anymatch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
@@ -410,6 +416,15 @@
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
       "dev": true
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -601,6 +616,15 @@
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "beeper": {
       "version": "1.1.1",
@@ -3036,6 +3060,56 @@
         "through2": "2.0.5"
       }
     },
+    "gulp-scp3": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/gulp-scp3/-/gulp-scp3-0.0.4.tgz",
+      "integrity": "sha512-kr2v7xR2NDFxVYCxhmcpUy5BxyK0W/HCIXVjJKvIfqLJEXJKH5gaLf/X8QazOqwd9fSBvkKJKP995ynRS1yN0A==",
+      "dev": true,
+      "requires": {
+        "async": "3.1.1",
+        "debug": "4.1.1",
+        "ssh2": "0.8.9",
+        "through2": "3.0.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.1.1.tgz",
+          "integrity": "sha512-X5Dj8hK1pJNC2Wzo2Rcp9FBVdJMGRR/S7V+lH46s8GVFhtbo5O4Le5GECCF/8PISVdkUA6mMPvgz7qTTD1rf1g==",
+          "dev": true
+        },
+        "ssh2": {
+          "version": "0.8.9",
+          "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.9.tgz",
+          "integrity": "sha512-GmoNPxWDMkVpMFa9LVVzQZHF6EW3WKmBwL+4/GeILf2hFmix5Isxm7Amamo8o7bHiU0tC+wXsGcUXOxp8ChPaw==",
+          "dev": true,
+          "requires": {
+            "ssh2-streams": "0.4.10"
+          }
+        },
+        "ssh2-streams": {
+          "version": "0.4.10",
+          "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.10.tgz",
+          "integrity": "sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==",
+          "dev": true,
+          "requires": {
+            "asn1": "0.2.4",
+            "bcrypt-pbkdf": "1.0.2",
+            "streamsearch": "0.1.2"
+          }
+        },
+        "through2": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.4",
+            "readable-stream": "2.3.7"
+          }
+        }
+      }
+    },
     "gulp-size": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/gulp-size/-/gulp-size-3.0.0.tgz",
@@ -3068,6 +3142,34 @@
         "source-map": "0.6.1",
         "strip-bom-string": "1.0.0",
         "through2": "2.0.5"
+      }
+    },
+    "gulp-ssh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/gulp-ssh/-/gulp-ssh-0.7.0.tgz",
+      "integrity": "sha512-RHWlmkznzgFg9YcR8OK5a7CpJHHskGOORhruPLx7UM4CU91AEaKevjHCB/OYRtJSd9Jj5JMeVKs5EcNKC7eE2A==",
+      "dev": true,
+      "requires": {
+        "ansicolors": "0.3.2",
+        "fancy-log": "1.3.3",
+        "plugin-error": "1.0.1",
+        "ssh2": "0.5.5",
+        "through2": "2.0.5",
+        "vinyl": "2.2.0"
+      },
+      "dependencies": {
+        "plugin-error": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+          "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "1.1.0",
+            "arr-diff": "4.0.0",
+            "arr-union": "3.1.0",
+            "extend-shallow": "3.0.2"
+          }
+        }
       }
     },
     "gulp-uglify-es": {
@@ -6658,6 +6760,26 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "ssh2": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.5.5.tgz",
+      "integrity": "sha1-x3gezS7OcwSiU89iD6taXCK7IjU=",
+      "dev": true,
+      "requires": {
+        "ssh2-streams": "0.1.20"
+      }
+    },
+    "ssh2-streams": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.1.20.tgz",
+      "integrity": "sha1-URGNFUVV31Rp7h9n4M8efoosDjo=",
+      "dev": true,
+      "requires": {
+        "asn1": "0.2.4",
+        "semver": "5.7.1",
+        "streamsearch": "0.1.2"
+      }
+    },
     "stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -6734,6 +6856,12 @@
         "commander": "2.20.3",
         "limiter": "1.1.5"
       }
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+      "dev": true
     },
     "string-width": {
       "version": "1.0.2",
@@ -7110,6 +7238,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "dev": true
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moOde",
-  "version": "7.0.0b1",
+  "version": "7.1.0",
   "description": "moOde audio player",
   "author": "Tim Curtis",
   "main": "index.js",
@@ -34,6 +34,11 @@
   "server": {
     "proxy": "http://moode.test"
   },
+  "remote": {
+    "host": "yourmoodedevice",
+    "user": "pi",
+    "password": "moodeaudio"
+  },
   "devDependencies": {
     "autoprefixer": "^9.8.0",
     "browser-sync": "^2.26.7",
@@ -57,8 +62,10 @@
     "gulp-rename": "^2.0.0",
     "gulp-replace": "^1.0.0",
     "gulp-replace-task": "^0.11.0",
+    "gulp-scp3": "0.0.4",
     "gulp-size": "^3.0.0",
     "gulp-sourcemaps": "^2.6.5",
+    "gulp-ssh": "^0.7.0",
     "gulp-uglify-es": "^2.0.0",
     "gulp-useref": "^4.0.1",
     "http-proxy-middleware": "^1.0.4",


### PR DESCRIPTION
Implement #303.

Perform a deploy (~copy) of the var/www dir to a moOde device. After the upload it will restart the services with `moodeutl -r` for you.
This should work from another moOde, Windows, Mac and Linux (but is only tested with moOde and Windows).

Prepare:
Because new npm command are used first perform a `npm ci` to update your module tree.

How to use:
```bash
gulp deploy --remote
```
The remote deploy will perform first a `deploy --test` internally to build a source tree to copy.


In the package.json you can configure the remote device to use:
```json
  "remote": {
    "host": "yourmoodedevice",
    "user": "pi",
    "password": "moodeaudio"
  },
```