### PR TITLE
Features/add autocfg settings - batch 1

### DIFF
--- a/www/command/worker.php
+++ b/www/command/worker.php
@@ -458,6 +458,7 @@ workerLog('worker: ' . $result[6]); // MPD httpd
 workerLog('worker: ' . $result[7]); // CamillaDSP
 // MPD crossfade
 workerLog('worker: MPD crossfade (' . ($_SESSION['mpdcrossfade'] == '0' ? 'off' : $_SESSION['mpdcrossfade'] . ' secs')  . ')');
+sendMpdCmd($sock, 'crossfade ' . $_SESSION['mpdcrossfade']);
 
 //
 workerLog('worker: -- Feature availability');

--- a/www/command/worker.php
+++ b/www/command/worker.php
@@ -24,6 +24,7 @@
 
 require_once dirname(__FILE__) . '/../inc/playerlib.php';
 require_once dirname(__FILE__) . '/../inc/eqp.php';
+require_once dirname(__FILE__) . '/../inc/cdsp.php';
 
 //
 // STARTUP SEQUENCE
@@ -420,6 +421,14 @@ if ($_SESSION['i2sdevice'] == 'Allo Piano 2.1 Hi-Fi DAC') {
 workerLog('worker: Reset renderer active flags');
 $result = sdbquery("UPDATE cfg_system SET value='0' WHERE param='btactive' OR param='airplayactv' OR param='spotactive' OR param='slactive' OR param='inpactive'", $dbh);
 
+// CamillaDSP
+$cdsp = new CamillaDsp($_SESSION['camilladsp'], $_SESSION['cardnum'], $_SESSION['camilladsp_quickconv']);
+$cdsp->selectConfig($_SESSION['camilladsp']);
+if ($_SESSION['cdsp_fix_playback'] == 'Yes' ) {
+	$cdsp->setPlaybackDevice($_SESSION['cardnum']);
+}
+workerLog('worker: CamillaDSP ('.$_SESSION['camilladsp'].')');
+
 //
 workerLog('worker: -- MPD');
 //
@@ -446,6 +455,7 @@ workerLog('worker: ' . $result[3]); // ALSA graphic eq
 workerLog('worker: ' . $result[4]); // ALSA polarity inversion
 workerLog('worker: ' . $result[5]); // ALSA bluetooth
 workerLog('worker: ' . $result[6]); // MPD httpd
+workerLog('worker: ' . $result[7]); // CamillaDSP
 // MPD crossfade
 workerLog('worker: MPD crossfade (' . ($_SESSION['mpdcrossfade'] == '0' ? 'off' : $_SESSION['mpdcrossfade'] . ' secs')  . ')');
 
@@ -1476,7 +1486,13 @@ function runQueuedJob() {
 			sysCmd('systemctl restart mpd');
 			break;
         case 'camilladsp':
-            sysCmd('mpc stop');
+			sysCmd('mpc stop');
+			$cdsp = new CamillaDsp($_SESSION['camilladsp'], $_SESSION['cardnum'], $_SESSION['camilladsp_quickconv']);
+			$cdsp->selectConfig($_SESSION['camilladsp']);
+			if ($_SESSION['cdsp_fix_playback'] == 'Yes' ) {
+				$cdsp->setPlaybackDevice($_SESSION['cardnum']);
+			}
+
             if ($_SESSION['w_queueargs'] == 'off') {
                 sysCmd('mpc enable only 1');
             }

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -2956,6 +2956,10 @@ function autoConfigSettings() {
 				$cdsp->setPlaybackDevice($_SESSION['cardnum']);
 			}
 		}],
+		['requires' => ['volume_step_limit'] , 'handler' => setPlayerSession],
+		['requires' => ['volume_mpd_max'] , 'handler' => setPlayerSession],
+		['requires' => ['volume_db_display'] , 'handler' => setPlayerSession],
+
 
 		'MPD',
 		['requires' => ['mixer_type'] , 'handler' => setCfgMpd, 'custom_write' => getCfgMpd],

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -2960,6 +2960,9 @@ function autoConfigSettings() {
 		['requires' => ['volume_mpd_max'] , 'handler' => setPlayerSession],
 		['requires' => ['volume_db_display'] , 'handler' => setPlayerSession],
 
+		['requires' => ['ashufflesvc'] , 'handler' => setPlayerSession],
+		['requires' => ['ashuffle_mode'] , 'handler' => setPlayerSession],
+		['requires' => ['ashuffle_filter'] , 'handler' => setPlayerSession],
 
 		'MPD',
 		['requires' => ['mixer_type'] , 'handler' => setCfgMpd, 'custom_write' => getCfgMpd],

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -3109,6 +3109,7 @@ function autoConfigSettings() {
 		}],
 
 		'Sources',
+		['requires' => ['usb_auto_updatedb'] , 'handler' => setPlayerSession],
 		// Sources are using the array construction of the ini reader
 		// source_name[0] = ...
 		['requires' => ['source_name',

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -2943,6 +2943,17 @@ function autoConfigSettings() {
 		['requires' => ['invert_polarity'] , 'handler' => setPlayerSession],
 		['requires' => ['alsaequal'] , 'handler' => setPlayerSession],
 		['requires' => ['eqfa12p'] , 'handler' => setPlayerSession],
+		['requires' => ['camilladsp_quickconv'] , 'handler' => setPlayerSession],
+		['requires' => ['cdsp_fix_playback'] , 'handler' => setPlayerSession],
+		['requires' => ['camilladsp'], 'handler' => function($values) {
+			playerSession('write', 'camilladsp', $values['camilladsp']);
+
+			$cdsp = new CamillaDsp($_SESSION['camilladsp'], $_SESSION['cardnum'], $_SESSION['camilladsp_quickconv']);
+			$cdsp->selectConfig($_SESSION['camilladsp']);
+			if ($_SESSION['cdsp_fix_playback'] == 'Yes' ) {
+				$cdsp->setPlaybackDevice($_SESSION['cardnum']);
+			}
+		}],
 
 		'MPD',
 		['requires' => ['mixer_type'] , 'handler' => setCfgMpd, 'custom_write' => getCfgMpd],

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -2939,6 +2939,7 @@ function autoConfigSettings() {
 		}],
 
 		'Sound',
+		['requires' => ['autoplay'] , 'handler' => setPlayerSession],
 		['requires' => ['mpdcrossfade'] , 'handler' => setPlayerSession],
 		['requires' => ['crossfeed'] , 'handler' => setPlayerSession],
 		['requires' => ['invert_polarity'] , 'handler' => setPlayerSession],

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -2939,6 +2939,7 @@ function autoConfigSettings() {
 		}],
 
 		'Sound',
+		['requires' => ['mpdcrossfade'] , 'handler' => setPlayerSession],
 		['requires' => ['crossfeed'] , 'handler' => setPlayerSession],
 		['requires' => ['invert_polarity'] , 'handler' => setPlayerSession],
 		['requires' => ['alsaequal'] , 'handler' => setPlayerSession],


### PR DESCRIPTION
Implemented the following autocfg settings from the list at #301 :
* ashufflesvc
* ashuffle_mode
* ashuffle_filter
* autoplay
* camilladsp
* camilladsp_quickconv
* cdsp_fix_playback
* mpdcrossfade
* usb_auto_updatedb
* volume_db_display
* volume_mpd_max
* volume_step_limit