### PR TITLE
Autodetect support smb protocols

### DIFF
--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -2210,7 +2210,14 @@ function sourceMount($action, $id = '') {
 			// cifs and nfs
 			if ($mp[0]['type'] != 'upnp') {
 				if ($mp[0]['type'] == 'cifs') {
-					$mountstr = "mount -t cifs \"//" . $mp[0]['address'] . "/" . $mp[0]['remotedir'] . "\" -o username=\"" . $mp[0]['username'] . "\",password=\"" . $mp[0]['password'] . "\",rsize=" . $mp[0]['rsize'] . ",wsize=" . $mp[0]['wsize'] . ",iocharset=" . $mp[0]['charset'] . "," . $mp[0]['options'] . " \"/mnt/NAS/" . $mp[0]['name'] . "\"";
+					$options = $mp[0]['options'];
+					if(strpos($options, 'vers=') == False) {
+						$version = detectCifsProtocol($mp[0]['address']);
+						if($verssion) {
+							$options = 'vers=' . $version. ','.$options;
+						}
+					}
+					$mountstr = "mount -t cifs \"//" . $mp[0]['address'] . "/" . $mp[0]['remotedir'] . "\" -o username=\"" . $mp[0]['username'] . "\",password=\"" . $mp[0]['password'] . "\",rsize=" . $mp[0]['rsize'] . ",wsize=" . $mp[0]['wsize'] . ",iocharset=" . $mp[0]['charset'] . "," . $options . " \"/mnt/NAS/" . $mp[0]['name'] . "\"";
 				}
 				else {
 					$mountstr = "mount -t nfs -o " . $mp[0]['options'] . " \"" . $mp[0]['address'] . ":/" . $mp[0]['remotedir'] . "\" \"/mnt/NAS/" . $mp[0]['name'] . "\"";
@@ -2294,6 +2301,33 @@ function sourceMount($action, $id = '') {
 
 	// returns true/false for 'mount' or a log message for 'mountall' and 'unmountall'
 	return $return;
+}
+
+/**
+ * Detect highest available suported cifs protocol of source
+ */
+function detectCifsProtocol($host) {
+	$output=sysCmd("nmap " . $host . " -p 139 --script smb-protocols |grep \|");
+	$parts = explode('  ',end($output));
+	$version = NULL;
+	if( count($parts)>=2 )  {
+		$version = trim($parts[2]);
+		$CIFVERSIONLUT = Array( "2.02" => "2.0",
+								"2.10" => "2.1",
+								"3.00" => "3.0",
+								"3.02" => "3.0.2",
+								"3.11" => "3.1.1"
+								);
+		if( strpos( $version, 'SMBv1') ) {
+			$version = '1.0';
+		} else if( array_key_exists( $version, $CIFVERSIONLUT ) ) {
+			$version = $CIFVERSIONLUT[$version];
+		} else {
+			$version = NULL;
+		}
+	}
+
+	return $version;
 }
 
 function ui_notify($notify) {

--- a/www/js/scripts-configs.js
+++ b/www/js/scripts-configs.js
@@ -217,8 +217,8 @@ jQuery(document).ready(function($){ 'use strict';
 		$('#mounttype').val($(this).val()); // hidden input on manual server entry
 		if ($(this).val() == 'cifs') {
 			$('#userid-password').show();
-			$('#options').val('vers=1.0,sec=ntlm,ro,dir_mode=0777,file_mode=0777');
-			$('#info-mount-flags').html('vers=2.0 or 3.0 may be needed and/or sec=ntlm removed depending on what the NAS requires.');
+			$('#options').val('ro,dir_mode=0777,file_mode=0777');
+			$('#info-mount-flags').html('vers=2.0 or 3.0 may be needed and/or sec=ntlm/ntlmssp removed depending on what the NAS requires.');
 			$('#scan-btn').show();
 			$('#edit-server').show();
 			$('#advanced-options').show();

--- a/www/lib-config.php
+++ b/www/lib-config.php
@@ -336,7 +336,7 @@ if (isset($_GET['cmd']) && !empty($_GET['cmd'])) {
 				$_edit_server_hide = '';
 				$_userid_pwd_hide = '';
 				$_advanced_options_hide = '';
-				$_options = 'vers=1.0,ro,dir_mode=0777,file_mode=0777';
+				$_options = 'ro,dir_mode=0777,file_mode=0777';
 			}
 			elseif ($_POST['mounttype'] == 'nfs') {
 				$_protocol = "<option value=\"cifs\">SMB (Samba)</option>\n";
@@ -363,7 +363,7 @@ if (isset($_GET['cmd']) && !empty($_GET['cmd'])) {
 			$_protocol = "<option value=\"cifs\" selected>SMB (Samba)</option>\n";
 			$_protocol .= "<option value=\"nfs\">NFS</option>\n";
 			$_protocol .= "<option value=\"upnp\">UPnP</option>\n";
-			$_options = 'vers=1.0,ro,dir_mode=0777,file_mode=0777';
+			$_options = 'ro,dir_mode=0777,file_mode=0777';
 		}
 
 		$server = isset($_POST['nas_manualserver']) && !empty(trim($_POST['nas_manualserver'])) ? $_POST['nas_manualserver'] : ' '; // space for select

--- a/www/templates/src-config.html
+++ b/www/templates/src-config.html
@@ -151,7 +151,7 @@
 					<div class="controls">
 						<input class="input-large" type="text" id="options" name="mount[options]" value="$_options">
 						<span id="info-mount-flags" class="help-block-configs help-block-margin">
-							vers=2.0, 3.0, 3.1 etc may be needed and/or sec=ntlm depending on what the NAS device requires.
+							vers=1.0, 2.0, 3.0, 3.1 etc may be needed and/or sec=ntlm depending on what the NAS device requires.
 	                    </span>
 					</div>
 				</div>


### PR DESCRIPTION
CIFS v1 isn't used by modern systems anymore, while moOde default use v1.
To improve out of the box behaviour of moOde switch the default from v1 to v2.