### PR TITLE
Features/camilladsp enhancements

### DIFF
--- a/other/camilladsp/gui/camillagui.yml
+++ b/other/camilladsp/gui/camillagui.yml
@@ -4,3 +4,5 @@ camilla_port: 1234
 port: 15000
 config_dir: "/usr/share/camilladsp/configs"
 coeff_dir: "/usr/share/camilladsp/coeffs"
+working_config: "/usr/share/camilladsp/working_config.yml"
+save_working_config: true

--- a/www/cdsp-config.php
+++ b/www/cdsp-config.php
@@ -111,6 +111,11 @@ else if ($selectedConfig && isset($_POST['remove']) && $_POST['remove'] == '1') 
 		$_SESSION['notify']['title'] = htmlentities('Cannot remove active configuration \"' . $selectedConfig . '\"');
 	}
 }
+// Copy pipeline
+else if ($selectedConfig && isset($_POST['copypipeline']) && $_POST['copypipeline'] == '1') {
+	$cdsp->copyConfig($selectedConfig, $_POST['new-pipelinename'] . '.yml');
+	$selectedConfig = $_POST['new-pipelinename'] . '.yml';
+}
 // Import (Upload)
 else if (isset($_FILES['coeffsfile']) && isset($_POST['import']) && $_POST['import'] == '1') {
 	$configFileName = $cdsp->getCoeffsLocation() . $_FILES["coeffsfile"]["name"];

--- a/www/command/worker.php
+++ b/www/command/worker.php
@@ -1497,7 +1497,7 @@ function runQueuedJob() {
             if ($_SESSION['w_queueargs'] == 'off') {
                 sysCmd('mpc enable only 1');
             }
-			else if ($_SESSION['w_queueargs'] == 'on') {
+			else {
                 sysCmd('mpc enable only 8');
 			}
 			sysCmd('systemctl restart mpd');

--- a/www/command/worker.php
+++ b/www/command/worker.php
@@ -1486,7 +1486,8 @@ function runQueuedJob() {
 			updMpdConf($_SESSION['i2sdevice']);
 			sysCmd('systemctl restart mpd');
 			break;
-        case 'camilladsp':
+		case 'camilladsp':
+			$playing = sysCmd('mpc status | grep "\[playing\]"');
 			sysCmd('mpc stop');
 			$cdsp = new CamillaDsp($_SESSION['camilladsp'], $_SESSION['cardnum'], $_SESSION['camilladsp_quickconv']);
 			$cdsp->selectConfig($_SESSION['camilladsp']);
@@ -1498,13 +1499,18 @@ function runQueuedJob() {
                 sysCmd('mpc enable only 1');
             }
 			else {
-                sysCmd('mpc enable only 8');
+				sysCmd('mpc enable only 8');
+
+				sysCmd('systemctl restart mpd');
+				// Wait for mpd to start accepting connections
+				$sock = openMpdSock('localhost', 6600);
+				closeMpdSock($sock);
+				setMpdHttpd();
 			}
-			sysCmd('systemctl restart mpd');
-			// Wait for mpd to start accepting connections
-			$sock = openMpdSock('localhost', 6600);
-			closeMpdSock($sock);
-            setMpdHttpd();
+
+			if (!empty($playing)) {
+				sysCmd('mpc play');
+			}
             break;
 		case 'eqfa12p':
 		case 'alsaequal':

--- a/www/inc/cdsp.php
+++ b/www/inc/cdsp.php
@@ -37,6 +37,7 @@ class CamillaDsp {
     private $ALSA_CDSP_CONFIG = '/etc/alsa/conf.d/camilladsp.conf';
     private $CAMILLA_CONFIG_DIR = '/usr/share/camilladsp';
     private $CAMILLA_EXE = '/usr/local/bin/camilladsp';
+    private $CAMILLAGUI_WORKING_CONGIG = '/usr/share/camilladsp/working_config.yml';
     private $device = NULL;
     private $configfile = NULL;
     private $quickConvolutionConfig = ";;;";
@@ -92,6 +93,7 @@ class CamillaDsp {
             $configfilename = $this->CAMILLA_CONFIG_DIR . '/configs/' . str_replace ('/', '\/', $configname);
             $configfilename = str_replace ('/', '\/', $configfilename);
             syscmd("sudo sed -i -s '/[ ]config_out/s/\\\".*\\\"/\\\"" . $configfilename . "\\\"/g' " . $this->ALSA_CDSP_CONFIG );
+            syscmd("sudo ln -s -f " . $configfilename . " " . $this->CAMILLAGUI_WORKING_CONGIG);
         }
         if( $configname == '__quick_convolution__.yml' ) {
             $this->writeQuickConvolutionConfig();

--- a/www/inc/cdsp.php
+++ b/www/inc/cdsp.php
@@ -155,6 +155,10 @@ class CamillaDsp {
         file_put_contents ( $configFile, $newLines) ;
     }
 
+    function copyConfig($source, $destination) {
+        copy($this->CAMILLA_CONFIG_DIR . '/configs/' . $source , $this->CAMILLA_CONFIG_DIR . '/configs/' . $destination);
+    }
+
     function detectSupportedSoundFormats() {
         $available_alsa_sample_formats_from_sound_card_as_string = sysCmd('moodeutl -f')[0]; //Sound card sample formats from ALSA
         $available_alsa_sample_formats_from_sound_card = explode (', ', $available_alsa_sample_formats_from_sound_card_as_string);
@@ -401,6 +405,7 @@ function test_cdsp() {
         print_r( $cdsp->getCamillaGuiStatus() );
         print("\n");
 
+    //$cdsp->copyConfig('config_hp.yml', 'fliepflap.yml');
 }
 
 if (basename(__FILE__) == basename($_SERVER["SCRIPT_FILENAME"])) {

--- a/www/templates/cdsp-config.html
+++ b/www/templates/cdsp-config.html
@@ -155,17 +155,19 @@
 			<div class="control-group">
 				<div class="controls">
 					<a data-toggle="modal" href="#remove-pipeline"><button class="btn btn-medium btn-primary">Delete</button></a>
+					<a data-toggle="modal" href="#copy-pipeline"><button class="btn btn-medium btn-primary">Copy</button></a>&nbsp;&nbsp;
 					<button class="btn btn-medium btn-primary btn-submit" type="submit" name="export" value="1">Download</button>
 					<div class="modal-button-style">
 						<label for="pipelineconfig" id="choose-pipeline-cfg" class="btn btn-primary btn-medium">Upload</label>
 						<input type="file" id="pipelineconfig" accept=".yml" name="pipelineconfig" style="display:none" onchange="$('#btn-import-pipeline').click();" >
 						<button id="btn-import-pipeline" class="btn btn-medium btn-primary btn-submit" type="submit" name="import" value="1"  style="display:none"/>
-					</div>
+					</div>&nbsp;&nbsp;
 					<button class="btn btn-medium btn-primary btn-submit" type="submit" name="check" value="1">Check</button>
 					<a data-toggle="modal" href="#show-pipeline"><button class="btn btn-medium btn-primary">Show</button></a>
 					<a aria-label="Help" class="info-toggle" data-cmd="info-configuration-actions" href="#notarget"><i class="fas fa-info-circle"></i></a>
 					<div id="info-configuration-actions" class="help-block-configs help-block-margin hide">
 						<b>Delete:&nbsp;</b>Delete the selected configuation file.<br/>
+						<b>Copy:&nbsp;</b>Provide new name and copy the selected configuation file.<br/>
 						<b>Download:&nbsp;</b>Download the selected configuation file.<br/>
 						<b>Upload:&nbsp;</b>Upload a new configuration file. If file already exists it will be overwritten.<br/>
 						<b>Check:&nbsp;</b>Check if the selected configuration is a valid CamillaDSP configuration.<br/><br/>
@@ -223,13 +225,13 @@
 			<!-- ids and names aren't correct: (copy of above now)-->
 			<div class="control-group">
 				<div class="controls">
-					<a data-toggle="modal" href="#remove-coeff"><button class="btn btn-medium btn-primary">Delete</button></a>
+					<a data-toggle="modal" href="#remove-coeff"><button class="btn btn-medium btn-primary">Delete</button></a>&nbsp;&nbsp;
 					<button class="btn btn-medium btn-primary btn-submit" type="submit" name="export" value="1">Download</button>
 					<div class="modal-button-style">
 						<label for="coeffsfile" id="choose-coeff-cfg" class="btn btn-primary btn-medium">Upload new</label>
 						<input type="file" id="coeffsfile" accept=".wav,.txt,.csv" name="coeffsfile" style="display:none" onchange="$('#btn-import-coeff').click();" >
 						<button id="btn-import-coeff" class="btn btn-medium btn-primary btn-submit" type="submit" name="import" value="1"  style="display:none"/>
-					</div>
+					</div>&nbsp;&nbsp;
 					<button class="btn btn-medium btn-primary btn-submit" type="submit" name="info" value="1">Info</button>
 					<a aria-label="Help" class="info-toggle" data-cmd="info-convolution-actions" href="#notarget"><i class="fas fa-info-circle"></i></a>
 					<div id="info-convolution-actions" class="help-block-configs help-block-margin legend-info-help hide">
@@ -350,6 +352,30 @@
 
 		<div class="modal-footer">
 			<button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
+		</div>
+	</div>
+</form>
+
+<form class="form-horizontal" method="post">
+	<div id="copy-pipeline" class="modal modal-sm hide" tabindex="-1" role="dialog" aria-labelledby="copy-pipeline-label" aria-hidden="true">
+		<input id="config_copy_id" type="hidden" name="cdsp-config" value="$selectedConfig"/>
+		<div class="modal-header">
+			<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+			<h3>Copy pipeline to</h3>
+		</div>
+
+		<div class="modal-body">
+			<div class="control-group">
+				<label class="control-label" for="new-pipelinename">Pipeline name</label>
+				<div class="controls">
+					<input class="input-large" type="text" pattern="[A-Za-z0-9 .\-]*" id="new-pipelineinput" name="new-pipelinename" value="" autofocus>
+				</div>
+			</div>
+		</div>
+
+		<div class="modal-footer">
+			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn btn-primary btn-submit" type="submit" name="copypipeline" value="1">Ok</button>
 		</div>
 	</div>
 </form>


### PR DESCRIPTION

fixes:
- set the correct mmpd output

enhancements:
- New button for copyin pipelines
- If due a activating a new camilladsp mpd is restart and the status was playing, continue playing after restart
- Added already (non breaking) support for a new feature (created by @JWahle) camillagui+camillabackend, where the current working config can be saved from the camillagui on apply. Waiting for a new (beta) release, currently it is only available on the head of both projects.