### PR TITLE
Default hide some camilladsp settings.

### DIFF
--- a/other/camilladsp/gui/_install.sh
+++ b/other/camilladsp/gui/_install.sh
@@ -19,6 +19,7 @@ sudo mkdir -p /opt
 sudo unzip -o camillagui-v$CAMILLAGUI_VER.zip -d /opt/camillagui
 
 sudo cp camillagui.yml /opt/camillagui/config
+sudo cp gui-config.yml /opt/camillagui/config
 sudo cp camillagui.service /etc/systemd/system
 
 # Don't start it, start it when needed from the moode config pages

--- a/other/camilladsp/gui/camillagui.yml
+++ b/other/camilladsp/gui/camillagui.yml
@@ -6,3 +6,5 @@ config_dir: "/usr/share/camilladsp/configs"
 coeff_dir: "/usr/share/camilladsp/coeffs"
 working_config: "/usr/share/camilladsp/working_config.yml"
 save_working_config: true
+backup_camilla_path: ""
+backup_camilla_port: 1235

--- a/other/camilladsp/gui/gui-config.yml
+++ b/other/camilladsp/gui/gui-config.yml
@@ -1,0 +1,4 @@
+hide_capture_samplerate: true
+hide_silence: true
+hide_capture_device: true
+hide_playback_device: true

--- a/www/cdsp-config.php
+++ b/www/cdsp-config.php
@@ -151,6 +151,9 @@ else if (isset($_POST['cdsp-coeffs']) && isset($_POST['info']) && $_POST['info']
 else if (isset($_POST['camillaguistatus']) && isset($_POST['updatecamillagui']) && $_POST['updatecamillagui'] == '1') {
  	$cdsp->changeCamillaStatus($_POST['camillaguistatus']);
 }
+else if (isset($_POST['camillaguiexpertstatus']) && isset($_POST['updatecamillaguiexpert']) && $_POST['updatecamillaguiexpert'] == '1') {
+	$cdsp->setGuiExpertMode($_POST['camillaguiexpertstatus'] == '1');
+}
 else if (isset($_GET['plotpipeline']) ) {
 	$cmd = dirname($_SERVER["SCRIPT_FILENAME"]) . '/command/camillaplotpipeline.py ' . $cdsp->getConfigsLocationsFileName() . '/' . $_GET['plotpipeline'];
 	$output = sysCmd($cmd);
@@ -158,7 +161,10 @@ else if (isset($_GET['plotpipeline']) ) {
 	header("Content-Type: image/svg+xml");
 	echo implode($output);
 	exit(0);
+
 }
+
+
 
 /**
  * Generate data for html templating
@@ -268,8 +274,13 @@ if ( $cdsp->isQuickConvolutionActive() ) {
 
 $camillaGuiStatus = $cdsp->getCamillaGuiStatus();
 $camillaGuiClickHandler = " onchange=\"$('#btn-updat-camilla-gui').click();\"";
+$camillaGuiExpertClickHandler = " onchange=\"$('#btn-updat-camilla-gui-expert').click();\"";
 $_select['camillagui1'] .= "<input type=\"radio\" name=\"camillaguistatus\" id=\"toggle-camillagui1\" value=\"1\" " . (($camillaGuiStatus == CGUI_CHECK_ACTIVE) ? "checked=\"checked\"" : $camillaGuiClickHandler) . " >\n";
 $_select['camillagui0'] .= "<input type=\"radio\" name=\"camillaguistatus\" id=\"toggle-camillagui2\" value=\"0\" " . (($camillaGuiStatus != CGUI_CHECK_ACTIVE) ? "checked=\"checked\"" : $camillaGuiClickHandler) . " >\n";
+$_select['camillaguiexpert1'] .= "<input type=\"radio\" name=\"camillaguiexpertstatus\" id=\"toggle-camillaguiexpert1\" value=\"1\" " . (($cdsp->getGuiExpertMode() == true) ? "checked=\"checked\"" : $camillaGuiExpertClickHandler) . " >\n";
+$_select['camillaguiexpert0'] .= "<input type=\"radio\" name=\"camillaguiexpertstatus\" id=\"toggle-camillaguiexpert2\" value=\"0\" " . (($cdsp->getGuiExpertMode() != true) ? "checked=\"checked\"" : $camillaGuiExpertClickHandler) . " >\n";
+
+
 $_open_camillagui_disabled = $camillaGuiStatus == CGUI_CHECK_ACTIVE ? '': 'disabled';
 $_camillagui_notfound_show = $camillaGuiStatus == CGUI_CHECK_NOTFOUND ? '': 'hide';
 $_camillagui_status_problems = $camillaGuiStatus == CGUI_CHECK_ACTIVE || $camillaGuiStatus == CGUI_CHECK_INACTIVE || $camillaGuiStatus == CGUI_CHECK_NOTFOUND? 'hide': '';

--- a/www/inc/cdsp.php
+++ b/www/inc/cdsp.php
@@ -346,6 +346,23 @@ class CamillaDsp {
         }
     }
 
+    function getGuiExpertMode() {
+        return file_exists('/opt/camillagui/config/gui-config.yml') == false;
+    }
+
+    function setGuiExpertMode($mode) {
+        if( $mode == true
+           && file_exists('/opt/camillagui/config/gui-config.yml')
+           && file_exists('/opt/camillagui/config/gui-config.yml.disabled') == false ) {
+            syscmd("sudo mv /opt/camillagui/config/gui-config.yml /opt/camillagui/config/gui-config.yml.disabled");
+        }
+        else if( $mode == false
+                 && file_exists('/opt/camillagui/config/gui-config.yml.disabled')
+                 && file_exists('/opt/camillagui/config/gui-config.yml') == false ) {
+            syscmd("sudo mv /opt/camillagui/config/gui-config.yml.disabled /opt/camillagui/config/gui-config.yml");
+        }
+    }
+
     // placeholders for autoconfig support, empty for now
     function backup() {
     }
@@ -406,6 +423,9 @@ function test_cdsp() {
         print("\n");
 
     //$cdsp->copyConfig('config_hp.yml', 'fliepflap.yml');
+
+    //$cdsp->setGuiExpertMode(true);
+    //$cdsp->setGuiExpertMode(false);
 }
 
 if (basename(__FILE__) == basename($_SERVER["SCRIPT_FILENAME"])) {

--- a/www/templates/cdsp-config.html
+++ b/www/templates/cdsp-config.html
@@ -277,6 +277,26 @@
 					<button id="btn-updat-camilla-gui" class="btn btn-medium btn-primary btn-submit" type="submit" name="updatecamillagui" value="1" style="display:none"/>
 				</div>
 
+				<label class="control-label" >Expert mode</label>
+				<div class="controls">
+					<div class="toggle">
+						<label class="toggle-radio" for="toggle-camillaguiexpert2">ON</label>
+						$_select[camillaguiexpert1]
+						<label class="toggle-radio" for="toggle-camillaguiexpert1">OFF</label>
+						$_select[camillaguiexpert0]
+					</div>
+
+					<div style="display: inline-block; vertical-align: top; margin-top: 2px;">
+					  <a aria-label="Help" class="info-toggle" data-cmd="info-camillaguiexpert" href="#notarget"><i class="fas fa-info-circle"></i></a>
+				    </div>
+					<span id="info-camillaguiexpert" class="help-block-configs help-block-margin legend-info-help hide">
+						Show settings like playback and capture device settings.<br>
+						Only required for custom setups.
+					</span>
+
+					<button id="btn-updat-camilla-gui-expert" class="btn btn-medium btn-primary btn-submit" type="submit" name="updatecamillaguiexpert" value="1" style="display:none"/>
+				</div>
+
 				<div class="controls">
 					<div style="margin-top:.5em">
 						<a href="cdsp-configeditor.php" target="camillagui"><button class="btn btn-medium btn-primary" $_open_camillagui_disabled>Open</button></a>&nbsp;Pipeline editor<br>


### PR DESCRIPTION
Default the settings are hiden, but can be enabled again by toggling the expert mode to on:
![image](https://user-images.githubusercontent.com/1525169/105903593-5bc83700-6020-11eb-803b-c2a4014f303a.png)

Without hide of the settings:
![image](https://user-images.githubusercontent.com/1525169/105899957-ae532480-601b-11eb-814e-6ecc5b0057ca.png)

With hide of the settings:
![image](https://user-images.githubusercontent.com/1525169/105899863-895eb180-601b-11eb-948d-9d1f6f220860.png)


Requires new camillagui & camillagui-backend to make the it work, but will not break the current camillagui & camillagui-backend.