### PR TITLE
FIX: Crossfeed has no effect on Spotify renderer

### DIFF
--- a/www/command/worker.php
+++ b/www/command/worker.php
@@ -1470,8 +1470,15 @@ function runQueuedJob() {
 			}
 			else {
 				sysCmd('sed -i "/controls/c\ \t\t\tcontrols [ ' . $_SESSION['w_queueargs'] . ' ]" ' . ALSA_PLUGIN_PATH . '/crossfeed.conf');
+				sysCmd('alsactl restore');
 				sysCmd('mpc enable only 2');
 			}
+
+			if ($_SESSION['spotifysvc'] == 1) {
+				sysCmd('killall librespot');
+				startSpotify();
+			}
+
 			setMpdHttpd();
 			break;
 		case 'mpd_httpd':

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -2557,6 +2557,9 @@ function startSpotify() {
 	elseif ($_SESSION['alsaequal'] != 'Off') {
 		$device = 'alsaequal';
 	}
+	elseif ($_SESSION['crossfeed'] != 'Off') {
+		$device = 'crossfeed';
+	}
 	elseif ($_SESSION['eqfa12p'] != 'Off') {
 		$device = 'eqfa12p';
 	}

--- a/www/relnotes.txt
+++ b/www/relnotes.txt
@@ -39,6 +39,7 @@ Bug fixes
 - FIX: Squeezelite binary crashes on ARM6
 - FIX: Librespot volume curve option
 - FIX: Order of excution for starting watchdog
+- FIX: Crossfeed has no effect on Spotify renderer
 
 ########################################################
 //


### PR DESCRIPTION
When a crossfeed is configured, MPD is set up to use it. This had no effect on the Spotify render as librespot sinks directly to ALSA. This commit fixes that.

Technically there's no reason to restart librespot when crossfeed is left enabled and only the crossfeed level is changed. `alsactl restore` should suffice to load the new configuration. Only when switching from crossfeed on or off does librespot need to be restarted to source to `crossfeed` or another device. However I don't think there's plumbing to detect such state changes, so I just restart Spotify either way.

The `alsactl reload` might also squashes a bug as I'm not sure if another `mpc enable only 2` reloads the configuration if output 2 was already the only enabled output (i.e. when we're only changing crossfeed levels).