### PR TITLE
UPD: Improve crossfeed settings and a Linkwitz setting

### DIFF
--- a/www/relnotes.txt
+++ b/www/relnotes.txt
@@ -31,6 +31,7 @@ Updates
 - UPD: Set correct 0dB level for HDMI
 - UPD: Open station home page for "Streaming source"
 - UPD: Automatically detect SMB protocol version
+- UPD: Improve crossfeed settings and a Linkwitz setting
 
 Bug fixes
 

--- a/www/snd-config.php
+++ b/www/snd-config.php
@@ -528,9 +528,10 @@ $_select['invert_polarity0'] .= "<input type=\"radio\" name=\"invert_polarity\" 
 // Crossfeed
 $_select['crossfeed'] .= "<option value=\"Off\" " . (($_SESSION['crossfeed'] == 'Off' OR $_SESSION['crossfeed'] == '') ? "selected" : "") . ">Off</option>\n";
 if ($_crossfeed_set_disabled == '') {
+	$_select['crossfeed'] .= "<option value=\"700 3.0\" " . (($_SESSION['crossfeed'] == '700 3.0') ? "selected" : "") . ">700 Hz 3.0 dB</option>\n";
 	$_select['crossfeed'] .= "<option value=\"700 4.5\" " . (($_SESSION['crossfeed'] == '700 4.5') ? "selected" : "") . ">700 Hz 4.5 dB</option>\n";
-	$_select['crossfeed'] .= "<option value=\"700 6.0\" " . (($_SESSION['crossfeed'] == '700 6.0') ? "selected" : "") . ">700 Hz 6.0 dB</option>\n";
-	$_select['crossfeed'] .= "<option value=\"650 9.5\" " . (($_SESSION['crossfeed'] == '650 9.5') ? "selected" : "") . ">650 Hz 9.5 dB</option>\n";
+	$_select['crossfeed'] .= "<option value=\"800 6.0\" " . (($_SESSION['crossfeed'] == '800 6.0') ? "selected" : "") . ">800 Hz 6.0 dB</option>\n";
+	$_select['crossfeed'] .= "<option value=\"650 10.0\" " . (($_SESSION['crossfeed'] == '650 10.0') ? "selected" : "") . ">650 Hz 10.0 dB</option>\n";
 }
 // HTTP streaming server
 $_select['mpd_httpd1'] .= "<input type=\"radio\" name=\"mpd_httpd\" id=\"toggle-mpd-httpd1\" value=\"1\" " . (($_SESSION['mpd_httpd'] == 1) ? "checked=\"checked\"" : "") . ">\n";

--- a/www/templates/snd-config.html
+++ b/www/templates/snd-config.html
@@ -285,12 +285,14 @@
 					<button class="btn btn-primary btn-small set-button btn-submit" type="submit" name="update_crossfeed" value="novalue" $_crossfeed_set_disabled>Set</button>
 					<a aria-label="Help" class="info-toggle" data-cmd="info-crossfeed" href="#notarget"><i class="fas fa-info-circle"></i></a>
 					<span id="info-crossfeed" class="help-block-configs help-block-margin hide">
-						- 700 Hz, 4.5 dB - Default<br>
-						This setting is closest to the virtual speaker placement with azimuth 30 degrees and the removal of about 3 meters, while listening by headphones.<br>
-						- 700 Hz, 6.0 dB - Chu Moy (most popular)<br>
-						This setting is close to the parameters of a Chu Moy crossfeeder.<br>
+						- 700 Hz, 3.0 dB - Linkwitz<br>
+						Approximates an original Linkwitz crossfeeder with azimuth 40 degrees. Highest crossfeed level, lowest separation.<br>
+						- 700 Hz, 4.5 dB - Bauer<br>
+						Approximates a virtual speaker placement with azimuth 30 degrees at about 3 meters distance.<br>
+						- 800 Hz, 6.0 dB - Chu Moy<br>
+						Approximates a Chu Moy modified Linkwitz crossfeeder.<br>
 						- 650 Hz, 9.5 dB - Jan Meier<br>
-						This setting is close to the parameters of a crossfeeder implemented in Jan Meier's CORDA amplifiers, making the smallest change to the signal for relaxed listening with headphones.<br>
+						Approximates a Jan Meier natural crossfeeder. Lowest crossfeed level, highest separation.<br>
                     </span>
 				</div>
 			</div>


### PR DESCRIPTION
Although I know the crossfeed levels were taken from the upstream bs2b project, they are neither accurate nor complete. This commit does the following:

- Clarify that the bs2b default setting of 700 Hz / 4.5 dB approximates a Beier crossfeed.
- Fix the Chu Moy center frequency to be 800 Hz. See: https://headwizememorial.wordpress.com/2018/03/09/an-acoustic-simulator-for-headphone-amplifiers/
- Fix the Jan Meier level to be 10 dB and *not* the bass-enhanced version, but the Meier natural one. The bs2b plugin does no further EQ'ing. See: https://headwizememorial.wordpress.com/2018/03/09/a-diy-headphone-amplifier-with-natural-crossfeed/
- Add a fourth setting for the original Linkwitz crossfeed of 700 Hz / 3.0 dB. See: https://www.linkwitzlab.com/headphone-xfeed.htm
- Improve info text and clarify what's the most crossfeed, and what's the least.

It would be nice to also (or only?) have two input fields for a custom configuration, but that's for another day.