### PR TITLE
Library option to ignore cue files

### DIFF
--- a/var/local/www/db/moode-sqlite3.db.sql
+++ b/var/local/www/db/moode-sqlite3.db.sql
@@ -423,6 +423,7 @@ INSERT INTO cfg_system (id, param, value) VALUES (149, 'recorder_status', 'Not i
 INSERT INTO cfg_system (id, param, value) VALUES (150, 'recorder_storage', '/mnt/SDCARD');
 INSERT INTO cfg_system (id, param, value) VALUES (151, 'volume_db_display', '0');
 INSERT INTO cfg_system (id, param, value) VALUES (152, 'search_site', 'Google');
+INSERT INTO cfg_system (id, param, value) VALUES (153, 'cuefiles_ignore', '1');
 
 -- Table: cfg_theme
 CREATE TABLE cfg_theme (id INTEGER PRIMARY KEY, theme_name CHAR (32), tx_color CHAR (32), bg_color CHAR (32), mbg_color CHAR (32));

--- a/www/command/worker.php
+++ b/www/command/worker.php
@@ -647,6 +647,8 @@ workerLog('worker: NAS and UPnP sources (' . $result . ')');
 //
 workerLog('worker: -- Miscellaneous');
 //
+setCuefilesIgnore($_SESSION['cuefiles_ignore']);
+workerLog('worker: MPD ignore cuefiles (' . $_SESSION['cuefiles_ignore'] . ')');
 
 // Start rotary encoder
 if (isset($_SESSION['rotaryenc']) && $_SESSION['rotaryenc'] == 1) {

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -3232,6 +3232,8 @@ function autoConfigSettings() {
 
 		'Sources',
 		['requires' => ['usb_auto_updatedb'] , 'handler' => setPlayerSession],
+		['requires' => ['cuefiles_ignore'] , 'handler' => setPlayerSession],
+
 		// Sources are using the array construction of the ini reader
 		// source_name[0] = ...
 		['requires' => ['source_name',
@@ -4050,5 +4052,26 @@ function loadRadio() {
 	foreach ($result as $row) {
 		$_SESSION[$row['station']] = array('name' => $row['name'], 'type' => $row['type'], 'logo' => $row['logo'],
 			'bitrate' => $row['bitrate'], 'format' => $row['format'], 'home_page' => $row['home_page']);
+	}
+}
+
+function setCuefilesIgnore($ignore) {
+//TODO: implemented if and call from startup
+	$file = MPD_MUSICROOT . '.mpdignore';
+	if(is_file($file) == false  ) {
+		if( $ignore == 1) {
+			sysCmd('touch "' . $file . '"');
+			sysCmd('chmod 777 "' . $file . '"');
+			sysCmd('chown root:root "' . $file . '"');
+			sysCmd('echo "**/*.cue" >> ' . $file);
+		}
+	}else {
+		if( sysCmd('cat ' . $file . ' | grep cue') ) {
+			if($ignore == 0) {
+				sysCmd("sed -i '/^\*\*\/\*\.cue/d' " . $file );
+			}
+		}else if($ignore == "1") {
+			sysCmd('echo "**/*.cue" >> ' . $file);
+		}
 	}
 }

--- a/www/lib-config.php
+++ b/www/lib-config.php
@@ -52,6 +52,15 @@ if (isset($_POST['update_usb_auto_updatedb'])) {
 		playerSession('write', 'usb_auto_updatedb', $_POST['usb_auto_updatedb']);
 	}
 }
+// ignore cuefiles on library scan
+if (isset($_POST['update_cuefiles_ignore'])) {
+	if (isset($_POST['cuefiles_ignore']) && $_POST['cuefiles_ignore'] != $_SESSION['cuefiles_ignore']) {
+		$_SESSION['notify']['title'] = $_POST['cuefiles_ignore'] == '1' ? 'MPD ignore CUE files' : 'MPD ignore CUE files';
+		$_SESSION['notify']['duration'] = 3;
+		playerSession('write', 'cuefiles_ignore', $_POST['cuefiles_ignore']);
+		setCuefilesIgnore($_SESSION['cuefiles_ignore']);
+	}
+}
 // re-mount nas sources
 if (isset($_POST['remount_sources'])) {
 	$result = cfgdb_read('cfg_source', $dbh);
@@ -274,6 +283,10 @@ if (!isset($_GET['cmd'])) {
 	// auto-updatedb on usb insert/remove
 	$_select['usb_auto_updatedb1'] = "<input type=\"radio\" name=\"usb_auto_updatedb\" id=\"toggle_usb_auto_updatedb0\" value=\"1\" " . (($_SESSION['usb_auto_updatedb'] == '1') ? "checked=\"checked\"" : "") . ">\n";
 	$_select['usb_auto_updatedb0'] = "<input type=\"radio\" name=\"usb_auto_updatedb\" id=\"toggle_usb_auto_updatedb1\" value=\"0\" " . (($_SESSION['usb_auto_updatedb'] == '0') ? "checked=\"checked\"" : "") . ">\n";
+
+	// ignore cuefiles on lbirary scan
+	$_select['cuefiles_ignore1'] = "<input type=\"radio\" name=\"cuefiles_ignore\" id=\"toggle_cuefiles_ignore0\" value=\"1\" " . (($_SESSION['cuefiles_ignore'] == '1') ? "checked=\"checked\"" : "") . ">\n";
+	$_select['cuefiles_ignore0'] = "<input type=\"radio\" name=\"cuefiles_ignore\" id=\"toggle_cuefiles_ignore1\" value=\"0\" " . (($_SESSION['cuefiles_ignore'] == '0') ? "checked=\"checked\"" : "") . ">\n";
 
 	// thumbcache status
 	$_thmcache_status = $_SESSION['thmcache_status'];

--- a/www/templates/lib-config.html
+++ b/www/templates/lib-config.html
@@ -73,6 +73,20 @@
 			<span id="info-usbautoupdate" class="help-block-configs" style="margin-top:-.35em;">
 				Automatically update the MPD database on USB insert or remove.
             </span>
+			<p/>
+
+			<div class="toggle">
+				<label class="toggle-radio" for="toggle_cuefiles_ignore1">YES</label>
+				$_select[cuefiles_ignore1]
+				<label class="toggle-radio" for="toggle_cuefiles_ignore0">NO</label>
+				$_select[cuefiles_ignore0]
+			</div>
+			<div style="display: inline-block; vertical-align: top; margin-top: 5px;">
+				<button class="btn btn-primary btn-small btn-submit" type="submit" name="update_cuefiles_ignore" value="novalue">Set</button>
+			</div>
+			<span id="info-cuefiles-ignore" class="help-block-configs" style="margin-top:-.35em;">
+				Ignore CUE files. Prevent duplicate tracks entries. Requires update of the library.
+            </span>
 
 			<p></p>
 			<legend>Thumbnail Generator</legend>


### PR DESCRIPTION
This is item that is coming back in the support forums, espcially because the behaviour of MPD change somewhere arround 0.21.25/26.  By making ignoring cuefiles default you have the old behaviour back, with the flexibilty to still include the cuefiles if you want.

![image](https://user-images.githubusercontent.com/1525169/107561453-d5deeb00-6bde-11eb-9382-b429e2aeb298.png)
