### PR TITLE
[CamillaDSP] Select other config without audio stop

### DIFF
--- a/www/cdsp-config.php
+++ b/www/cdsp-config.php
@@ -45,12 +45,18 @@ if (isset($_POST['save']) && $_POST['save'] == '1') {
 	}
 
 	if (isset($_POST['cdsp-mode'])) {
+		$currentMode = $_SESSION['camilladsp'];
 		playerSession('write', 'camilladsp', $_POST['cdsp-mode']);
 		$cdsp->selectConfig($_POST['cdsp-mode']);
 		if ($_SESSION['cdsp_fix_playback'] == 'Yes' ) {
 			$cdsp->setPlaybackDevice($_SESSION['cardnum']);
 		}
-		submitJob('camilladsp', $_POST['cdsp-mode'], 'CamillaDSP ' . $cdsp->getConfigLabel($_POST['cdsp-mode']), '');
+
+		if ( $_SESSION['camilladsp'] != $currentMode && ( $_SESSION['camilladsp'] == 'off' || $currentMode == 'off')) {
+			submitJob('camilladsp', $_POST['cdsp-mode'], 'CamillaDSP ' . $cdsp->getConfigLabel($_POST['cdsp-mode']), '');
+		} else {
+			$cdsp->reloadConfig();
+		}
 	}
 
 	if (isset($_POST['cdsp_playbackdevice'])) {

--- a/www/cdsp-config.php
+++ b/www/cdsp-config.php
@@ -89,6 +89,7 @@ else if (isset($_FILES['pipelineconfig']) && isset($_POST['import']) && $_POST['
 		if ($_SESSION['cdsp_fix_playback'] == 'Yes' ) {
 			$cdsp->setPlaybackDevice($_SESSION['cardnum']);
 		}
+		$cdsp->reloadConfig();
 	}
 	$selectedConfig = $configFileBaseName;
 	$_SESSION['notify']['title'] =  htmlentities('Import \"' . $configFileBaseName . '\" completed');

--- a/www/snd-config.php
+++ b/www/snd-config.php
@@ -230,13 +230,18 @@ if (isset($_POST['alsaequal']) && $_POST['alsaequal'] != $_SESSION['alsaequal'])
 
 // CamillaDSP
 if (isset($_POST['camilladsp']) && $_POST['camilladsp'] != $_SESSION['camilladsp']) {
+	$currentMode = $_SESSION['camilladsp'];
 	playerSession('write', 'camilladsp', $_POST['camilladsp']);
 	$cdsp->selectConfig($_POST['camilladsp']);
 	if ($_SESSION['cdsp_fix_playback'] == 'Yes' ) {
 		$cdsp->setPlaybackDevice($_SESSION['cardnum']);
 	}
-	//TODO: deal with Quick Convolution
-    submitJob('camilladsp', $_POST['camilladsp'], 'CamillaDSP ' . $cdsp->getConfigLabel($_POST['cdsp-mode']), '');
+
+    if ( $_SESSION['camilladsp'] != $currentMode && ( $_SESSION['camilladsp'] == 'off' || $currentMode == 'off')) {
+		submitJob('camilladsp', $_POST['cdsp-mode'], 'CamillaDSP ' . $cdsp->getConfigLabel($_POST['cdsp-mode']), '');
+	} else {
+		$cdsp->reloadConfig();
+	}
 }
 
 // AUDIO RENDERERS


### PR DESCRIPTION
It makes two changes to the way how is dealt with camilladsp configs:

- Uses a link to the configuration (same link as already used with camillagui).
- Send a SIGHUP signal to camilladsp, when the configuration is changes or update (lit quick conv changes).

The results is instant change when listing music, which make it easier to compare different configs.