### PR TITLE
Allow negative pregain for Spotify renderer

### DIFF
--- a/www/relnotes.txt
+++ b/www/relnotes.txt
@@ -51,6 +51,7 @@ Updates
 - UPD: Show msg in MPD Config if USB device off or disconnected
 - UPD: Library Config option to ignore CUE files
 - UPD: Decode Pi revision from bitmask instead of from table
+- UPD: Allow negative pregain for Spotify renderer
 
 Bug fixes
 

--- a/www/templates/spo-config.html
+++ b/www/templates/spo-config.html
@@ -88,10 +88,10 @@
 			<div class="control-group">
 				<label class="control-label" for="normalization_pregain">Normalization pre-gain</label>
 				<div class="controls">
-					<input class="input-large" type="number" min="0" max="10" id="normalization_pregain" name="config[normalization_pregain]" value="$_select[normalization_pregain]"> (dB)
+					<input class="input-large" type="number" min="-10" max="10" id="normalization_pregain" name="config[normalization_pregain]" value="$_select[normalization_pregain]"> (dB)
 					<a aria-label="Help" class="info-toggle" data-cmd="info_normalization_pregain" href="#notarget"><i class="fas fa-info-circle"></i></a>
 					<span id="info_normalization_pregain" class="help-block-configs help-block-margin hide">
-						Volume boost in dB [0-10].<br>
+						Volume boost in dB [-10-10].<br>
                     </span>
 				</div>
 			</div>


### PR DESCRIPTION
See https://artists.spotify.com/faq/mastering-and-loudness#can-users-adjust-the-levels-of-my-music:

>Premium users can choose between the following volume normalization levels in their app settings:
>
>**Loud** - equalling ca -11 dB LUFS (+6 dB gain multiplied to ReplayGain)
>**Normal** (default) - equalling ca -14 dB LUFS (+3 dB gain multiplied to ReplayGain)
>**Quiet** - equalling ca - 23 dB LUFS (-5 dB gain multiplied to ReplayGain)
>
>This is to compensate for where playback isn’t loud enough (e.g. in a noisy environment) or dynamic enough (e.g. in a quiet environment).