### PR TITLE
Use Spotify default normalization pregain of +3 dB

### DIFF
--- a/var/local/www/db/moode-sqlite3.db.sql
+++ b/var/local/www/db/moode-sqlite3.db.sql
@@ -449,7 +449,7 @@ INSERT INTO cfg_spotify (id, param, value) VALUES (1, 'bitrate', '160');
 INSERT INTO cfg_spotify (id, param, value) VALUES (2, 'initial_volume', '0');
 INSERT INTO cfg_spotify (id, param, value) VALUES (3, 'volume_curve', 'log');
 INSERT INTO cfg_spotify (id, param, value) VALUES (4, 'volume_normalization', 'No');
-INSERT INTO cfg_spotify (id, param, value) VALUES (5, 'normalization_pregain', '0');
+INSERT INTO cfg_spotify (id, param, value) VALUES (5, 'normalization_pregain', '3');
 INSERT INTO cfg_spotify (id, param, value) VALUES (6, 'autoplay', 'No');
 
 -- Table: cfg_network

--- a/www/spo-config.php
+++ b/www/spo-config.php
@@ -58,7 +58,7 @@ $_select['volume_curve'] .= "<option value=\"fixed\" " . (($cfg_spotify['volume_
 // volume normalization
 $_select['volume_normalization'] .= "<option value=\"Yes\" " . (($cfg_spotify['volume_normalization'] == 'Yes') ? "selected" : "") . ">Yes</option>\n";
 $_select['volume_normalization'] .= "<option value=\"No\" " . (($cfg_spotify['volume_normalization'] == 'No') ? "selected" : "") . ">No</option>\n";
-// ormalization pregain
+// normalization pregain
 $_select['normalization_pregain'] = $cfg_spotify['normalization_pregain'];
 // Autoplay
 $_select['autoplay'] .= "<option value=\"Yes\" " . (($cfg_spotify['autoplay'] == 'Yes') ? "selected" : "") . ">Yes</option>\n";


### PR DESCRIPTION
Official Spotify players use a default pregain of +3 dB, see https://artists.spotify.com/faq/mastering-and-loudness#can-users-adjust-the-levels-of-my-music.

While at it, you could consider defaulting "volume_normalization" to "Yes". It's enabled by default on official Spotify players, too. ~~It's not compression; there is no loss of quality unless the tracks have a peak-to-average in excess of 18 dB (and in which case the user is suggested to use a -5 dB pregain).~~ _Edit: Belay that as librespot currently only outputs in 16 bit, thus throwing away bits and reducing dynamic range when doing volume control._