### PR TITLE
Features/camilladsp check ir file format

### DIFF
--- a/www/cdsp-config.php
+++ b/www/cdsp-config.php
@@ -128,6 +128,8 @@ else if (isset($_FILES['coeffsfile']) && isset($_POST['import']) && $_POST['impo
 	$configFileName = $cdsp->getCoeffsLocation() . $_FILES["coeffsfile"]["name"];
 	move_uploaded_file($_FILES["coeffsfile"]["tmp_name"], $configFileName);
 	$_SESSION['notify']['title'] =  htmlentities('Import \"' . $_FILES["coeffsfile"]["name"] . '\" completed');
+
+	$selected_coeff = $_FILES["coeffsfile"]["name"];
 }
 // Coeffs export (Download)
 else if ($selected_coeff && isset($_POST['export']) && $_POST['export'] == '1') {
@@ -145,14 +147,11 @@ else if ($selected_coeff && isset($_POST['remove']) && $_POST['remove'] == '1') 
 	$configFileName = $cdsp->getCoeffsLocation() . $selected_coeff;
 	unlink($configFileName);
 	$_SESSION['notify']['title'] = htmlentities('Remove configuration \"' . $selected_coeff . '\" completed');
+	$selected_coeff = NULL;
 }
 else if ($selected_coeff && isset($_POST['info']) && $_POST['info'] == '1') {
-	$coeffInfo = $cdsp->coeffInfo($selected_coeff);
+// no implementation required, just a placeholder
 
-	$coeffInfoHtml ='Info:<br/>';
-	foreach ($coeffInfo as  $param=>$value) {
-		$coeffInfoHtml .= ''. $param . ' = ' . $value. '<br/>';
-	}
 }
 // camillagui status toggle
 else if (isset($_POST['camillaguistatus']) && isset($_POST['updatecamillagui']) && $_POST['updatecamillagui'] == '1') {
@@ -193,6 +192,20 @@ foreach ($configs as $config_file=>$config_name) {
 	$_select['cdsp_coeffs'] .= sprintf("<option value='%s' %s>%s</option>\n", $config_file, $selected, $config_file);
 	if ($selected == 'selected') {
 		$_selected_coeff = $config_file;
+	}
+}
+
+if( $_selected_coeff ) {
+	$coeffInfo = $cdsp->coeffInfo($_selected_coeff);
+	$coeffInfoHtml = 'Info:<br/>';
+	foreach ($coeffInfo as  $param=>$value) {
+
+		if($param == 'channels' && $value != 1) {
+			$coeffInfoHtml .= "<span style='color: red'>&#10007;</span> " . $param . ' = ' . $value ." (WARNING: CamillaDSP can only handle files with 1 channel)<br/>";
+
+		} else {
+			$coeffInfoHtml .= ''. $param . ' = ' . $value . '<br/>';
+		}
 	}
 }
 

--- a/www/cdsp-config.php
+++ b/www/cdsp-config.php
@@ -26,7 +26,7 @@ require_once dirname(__FILE__) . '/inc/cdsp.php';
 playerSession('open', '' ,'');
 $cdsp = new CamillaDsp($_SESSION['camilladsp'], $_SESSION['cardnum'], $_SESSION['camilladsp_quickconv']);
 $selectedConfig = isset($_POST['cdsp-config']) ? $_POST['cdsp-config']: NULL;
-
+$selected_coeff = isset($_POST['cdsp-coeffs']) ? $_POST['cdsp-coeffs']: NULL;
 /**
  * Post parameter processing
  */
@@ -130,24 +130,24 @@ else if (isset($_FILES['coeffsfile']) && isset($_POST['import']) && $_POST['impo
 	$_SESSION['notify']['title'] =  htmlentities('Import \"' . $_FILES["coeffsfile"]["name"] . '\" completed');
 }
 // Coeffs export (Download)
-else if (isset($_POST['cdsp-coeffs']) && isset($_POST['export']) && $_POST['export'] == '1') {
-	$configFileName = $cdsp->getCoeffsLocation() . $_POST['cdsp-coeffs'];
+else if ($selected_coeff && isset($_POST['export']) && $_POST['export'] == '1') {
+	$configFileName = $cdsp->getCoeffsLocation() . $selected_coeff;
 
 	header("Content-Description: File Transfer");
 	header("Content-Type: application/binary");
-	header("Content-Disposition: attachment; filename=\"". $_POST['cdsp-coeffs'] ."\"");
+	header("Content-Disposition: attachment; filename=\"". $selected_coeff ."\"");
 
 	readfile ($configFileName);
  	exit();
 }
 // Coeffs remove
-else if (isset($_POST['cdsp-coeffs']) && isset($_POST['remove']) && $_POST['remove'] == '1') {
-	$configFileName = $cdsp->getCoeffsLocation() . $_POST['cdsp-coeffs'];
+else if ($selected_coeff && isset($_POST['remove']) && $_POST['remove'] == '1') {
+	$configFileName = $cdsp->getCoeffsLocation() . $selected_coeff;
 	unlink($configFileName);
-	$_SESSION['notify']['title'] = htmlentities('Remove configuration \"' . $_POST['cdsp-coeffs'] . '\" completed');
+	$_SESSION['notify']['title'] = htmlentities('Remove configuration \"' . $selected_coeff . '\" completed');
 }
-else if (isset($_POST['cdsp-coeffs']) && isset($_POST['info']) && $_POST['info'] == '1') {
-	$coeffInfo = $cdsp->coeffInfo($_POST['cdsp-coeffs']);
+else if ($selected_coeff && isset($_POST['info']) && $_POST['info'] == '1') {
+	$coeffInfo = $cdsp->coeffInfo($selected_coeff);
 
 	$coeffInfoHtml ='Info:<br/>';
 	foreach ($coeffInfo as  $param=>$value) {
@@ -189,7 +189,7 @@ foreach ($configs as $config_file=>$config_name) {
 $configs = $cdsp->getAvailableCoeffs();
 $_selected_coeff = NULL;
 foreach ($configs as $config_file=>$config_name) {
-	$selected = ($_POST['cdsp-coeffs'] == $config_file || (isset($_POST['cdsp-coeffs']) == false && $_selected_coeff == NULL) ) ? 'selected' : '';
+	$selected = ($selected_coeff == $config_file || ($selected_coeff == NULL && $_selected_coeff == NULL) ) ? 'selected' : '';
 	$_select['cdsp_coeffs'] .= sprintf("<option value='%s' %s>%s</option>\n", $config_file, $selected, $config_file);
 	if ($selected == 'selected') {
 		$_selected_coeff = $config_file;

--- a/www/templates/cdsp-config.html
+++ b/www/templates/cdsp-config.html
@@ -217,7 +217,7 @@
 			<div class="control-group">
 				<label class="control-label" for="cdsp-coeffs">Impulse response</label>
 				<div class="controls" >
-					<select id="cdsp-coeffs" class="input-xxlarge" name="cdsp-coeffs" onchange="$('#coeff_remove_id').val($('#cdsp-coeffs :selected').val() );$('#coeff-info').html('');">
+					<select id="cdsp-coeffs" class="input-xxlarge" name="cdsp-coeffs" onchange="$('#coeff_remove_id').val($('#cdsp-coeffs :selected').val() );$('#coeff-info').html('');$('#btn-check-coeff').click();">
 						$_select[cdsp_coeffs]
 					</select>
 					<div id="coeff-info" >
@@ -236,13 +236,12 @@
 						<input type="file" id="coeffsfile" accept=".wav,.txt,.csv" name="coeffsfile" style="display:none" onchange="$('#btn-import-coeff').click();" >
 						<button id="btn-import-coeff" class="btn btn-medium btn-primary btn-submit" type="submit" name="import" value="1"  style="display:none"/>
 					</div>&nbsp;&nbsp;
-					<button class="btn btn-medium btn-primary btn-submit" type="submit" name="info" value="1">Info</button>
+					<button id="btn-check-coeff" class="btn btn-medium btn-primary btn-submit" type="submit" name="info" value="1" style="display:none" >Info</button>
 					<a aria-label="Help" class="info-toggle" data-cmd="info-convolution-actions" href="#notarget"><i class="fas fa-info-circle"></i></a>
 					<div id="info-convolution-actions" class="help-block-configs help-block-margin legend-info-help hide">
 							<b>Delete:&nbsp;</b>Delete the selected convolution file.<br/>
 							<b>Download:&nbsp;</b>Download the selected convolution file.<br/>
 							<b>Upload:&nbsp;</b>Upload a convolution file, existing ones are overwritten.<br/>
-							<b>Info:&nbsp;</b>Show information about the convolution file.
 	 			    </div>
 				</div>
 			</div>

--- a/www/templates/cdsp-config.html
+++ b/www/templates/cdsp-config.html
@@ -211,13 +211,14 @@
 		</fieldset>
 	</form>
 
-	<form class="form-horizontal" action="" method="post" enctype="multipart/form-data">
+	<form class="form-horizontal" action="#conv_file" method="post" enctype="multipart/form-data">
+		<a id="conv_file"></a>
 		<fieldset>
-			<legend>Convolution file</legend>
+			<legend><a href="#conv_file"></a>Convolution file</legend>
 			<div class="control-group">
 				<label class="control-label" for="cdsp-coeffs">Impulse response</label>
 				<div class="controls" >
-					<select id="cdsp-coeffs" class="input-xxlarge" name="cdsp-coeffs" onchange="$('#coeff_remove_id').val($('#cdsp-coeffs :selected').val() );$('#coeff-info').html('');$('#btn-check-coeff').click();">
+					     <select id="cdsp-coeffs" class="input-xxlarge" name="cdsp-coeffs" onchange="$('#coeff_remove_id').val($('#cdsp-coeffs :selected').val() );$('#btn-check-coeff').click();">
 						$_select[cdsp_coeffs]
 					</select>
 					<div id="coeff-info" >
@@ -248,7 +249,8 @@
 		</fieldset>
 	</form>
 
-	<form class="form-horizontal" action="" method="post" >
+	<form class="form-horizontal" action="#pipeline_editor" method="post" >
+		<a id="pipeline_editor"></a>
 		<fieldset>
 			<legend>Pipeline editor</legend>
 			<div class="control-group">


### PR DESCRIPTION
Improvements to moode camilladsp config page:
- After upload convolution file select it in available files.
- After select convolution file or upload always show info about the file.
- Remove Info button, because the info is now always shown.
- Show warning when a stereo wave file is found:
![image](https://user-images.githubusercontent.com/1525169/108716312-3abe0d80-751c-11eb-9759-4f1683f4a588.png)
- Created html anchor so that on form post we keep on the same part of page.
