### PR TITLE
[CamillaDSP] Add split option for stereo convolution files

### DIFF
--- a/www/cdsp-config.php
+++ b/www/cdsp-config.php
@@ -153,6 +153,16 @@ else if ($selected_coeff && isset($_POST['info']) && $_POST['info'] == '1') {
 // no implementation required, just a placeholder
 
 }
+else if ($selected_coeff && isset($_POST['split']) && $_POST['split'] == '1') {
+ 	$result = $cdsp->splitWaveFile($selected_coeff);
+	 if($result == NULL) {
+		$_SESSION['notify']['title'] =   htmlentities('Split wave file \"' . $selected_coeff . '\" is succesfull.');
+	}else {
+		$_SESSION['notify']['title'] = htmlentities('Split wave file \"' . $selected_coeff . '\" has failed');
+		$_SESSION['notify']['msg'] = htmlentities(implode('<br>', $result));
+	}
+}
+
 // camillagui status toggle
 else if (isset($_POST['camillaguistatus']) && isset($_POST['updatecamillagui']) && $_POST['updatecamillagui'] == '1') {
  	$cdsp->changeCamillaStatus($_POST['camillaguistatus']);
@@ -195,6 +205,7 @@ foreach ($configs as $config_file=>$config_name) {
 	}
 }
 
+$btn_conv_style = 'style="display: none;"';
 if( $_selected_coeff ) {
 	$coeffInfo = $cdsp->coeffInfo($_selected_coeff);
 	$coeffInfoHtml = 'Info:<br/>';
@@ -202,7 +213,7 @@ if( $_selected_coeff ) {
 
 		if($param == 'channels' && $value != 1) {
 			$coeffInfoHtml .= "<span style='color: red'>&#10007;</span> " . $param . ' = ' . $value ." (WARNING: CamillaDSP can only handle files with 1 channel)<br/>";
-
+			$btn_conv_style = ""; //unhide
 		} else {
 			$coeffInfoHtml .= ''. $param . ' = ' . $value . '<br/>';
 		}

--- a/www/templates/cdsp-config.html
+++ b/www/templates/cdsp-config.html
@@ -238,6 +238,7 @@
 						<button id="btn-import-coeff" class="btn btn-medium btn-primary btn-submit" type="submit" name="import" value="1"  style="display:none"/>
 					</div>&nbsp;&nbsp;
 					<button id="btn-check-coeff" class="btn btn-medium btn-primary btn-submit" type="submit" name="info" value="1" style="display:none" >Info</button>
+					<button class="btn btn-medium btn-primary btn-submit" type="submit" name="split" value="1" $btn_conv_style >Split</button>
 					<a aria-label="Help" class="info-toggle" data-cmd="info-convolution-actions" href="#notarget"><i class="fas fa-info-circle"></i></a>
 					<div id="info-convolution-actions" class="help-block-configs help-block-margin legend-info-help hide">
 							<b>Delete:&nbsp;</b>Delete the selected convolution file.<br/>


### PR DESCRIPTION
Provide a button to split a stereao wav file in to mono files:
The button is only available on stereo wave files.

![image](https://user-images.githubusercontent.com/1525169/108726649-f2a4e800-7527-11eb-8154-a08394076bb2.png)

For example `yourwavefile.wav` will be splitted into:
- `yourwavefile_L.wav`
- `yourwavefile_R.wav`
- after the split `yourwavefile.wav` is removed

It will not patch you camilladsp config files for you!

To prevent installing another dep `ffmpeg` is used to split the wave files.
