### PR TITLE
Fixed SoX resampling quality defaulting to 'high' for all presets.

### DIFF
--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -1922,7 +1922,7 @@ function updMpdConf($i2sdevice) {
 				$data .= $cfg['value'] == 'disabled' ? '' : $cfg['param'] . " \"" . $cfg['value'] . "\"\n";
 				break;
 			case 'sox_quality':
-				$sox_quality = ($cfg['value'] == 'custom' && ($patch_id & PATCH_SOX_CUSTOM_RECIPE)) ? $cfg['value'] : 'high';
+				$sox_quality = $cfg['value'];
 				break;
 			case 'sox_multithreading':
 				$sox_multithreading = $cfg['value'];


### PR DESCRIPTION
SoX resampling quality was defaulting to 'high' if anything but the custom recipe option was selected.