### PR TITLE
[moodeutl] Show current audio format while device is busy

### DIFF
--- a/usr/local/bin/moodeutl
+++ b/usr/local/bin/moodeutl
@@ -274,8 +274,18 @@ function audio_formats($option) {
 			echo $result;
 		}
 	}
-	else {
+	else if($option == '-F') {
 		echo "Audio device busy\n" ;
+		echo shell_exec('cat /proc/asound/card' . $cardnum . '/stream0');
+	}
+	else {
+		$audio_format = trim(shell_exec('cat /proc/asound/card' . $cardnum . '/stream0 | grep Format:'));
+		if (!empty($audio_format)) {
+			echo explode(': ', $audio_format)[1] . "\n";
+		}
+		else {
+			echo "Unable to detect formats\n";
+		}
 	}
 }
 


### PR DESCRIPTION

`moodeutl -f` while playing returns that the device is busy.
This PR makes it possible that also when the device is busy the audio format is returned.

In addition `moodeutl -F` will return, while the device is busy, the following:
```
pi@moodedev:/usr/share/camilladsp $ moodeutl -F
Audio device busy
Cambridge Audio Cambridge Audio USB Audio 2.0 at usb-0000:01:00.0-1.4, high spe : USB Audio

Playback:
  Status: Running
    Interface = 1
    Altset = 1
    Packet Size = 72
    Momentary freq = 44105 Hz (0x5.8360)
    Feedback Format = 16.16
  Interface 1
    Altset 1
    Format: S32_LE
    Channels: 2
    Endpoint: 1 OUT (ASYNC)
    Rates: 44100, 48000, 88200, 96000, 192000
    Data packet interval: 125 us
    Bits: 24
```

supporting cases:
* The audioinfo.php didn't show the supported audio format (found by @TheOldPresbyope )
* Camilladsp requires this information to patching configuration files, which failed while the device is playing.