### PR TITLE
[CamillaDSP] Fix SIGHUP kills CDSP with -w flag

### DIFF
--- a/www/inc/cdsp.php
+++ b/www/inc/cdsp.php
@@ -112,7 +112,14 @@ class CamillaDsp {
     function reloadConfig() {
         if( $this->configfile != 'off') {
             $this->patchRelConvPath($this->getConfig());
-            syscmd('sudo killall -s SIGHUP camilladsp');
+
+            // Due a issue with cdsp, don't send SIGHUP if cdsp is started with the -w flag.
+            // (see https://github.com/HEnquist/camilladsp/issues/96)
+            $cmd = 'sudo ps -elf |grep camilladsp| grep "\-w"';
+            exec($cmd, $output, $exitcode);
+            if( $exitcode != 0 ) {
+                syscmd('sudo killall -s SIGHUP camilladsp');
+            }
         }
     }
 


### PR DESCRIPTION
Due a issue with cdsp, don't send SIGHUP if cdsp is started with the -w flag. It will kills the CDSP process. See https://github.com/HEnquist/camilladsp/issues/96.

This commit is a workarround by preventing sending a SIGHUP if cdsp is running with -w flag.
When cdsp solved this commit can be reverted.