### PR TITLE
[CamillaDSP] Add functionality to convert wave files to raw files

### DIFF
--- a/www/cdsp-config.php
+++ b/www/cdsp-config.php
@@ -161,14 +161,14 @@ else if ($selected_coeff && isset($_POST['info']) && $_POST['info'] == '1') {
 // no implementation required, just a placeholder
 
 }
-else if ($selected_coeff && isset($_POST['split']) && $_POST['split'] == '1') {
- 	$result = $cdsp->splitWaveFile($selected_coeff);
-	 if($result == NULL) {
-		$_SESSION['notify']['title'] =   htmlentities('Split wave file \"' . $selected_coeff . '\" is succesfull.');
-	}else {
-		$_SESSION['notify']['title'] = htmlentities('Split wave file \"' . $selected_coeff . '\" has failed');
-		$_SESSION['notify']['msg'] = htmlentities(implode('<br>', $result));
-	}
+else if ($selected_coeff && isset($_POST['convertcoeff']) && $_POST['convertcoeff'] == '1') {
+	$result = $cdsp->convertWaveFile($selected_coeff);
+	if($result == NULL) {
+	   $_SESSION['notify']['title'] =   htmlentities('Split wave file \"' . $selected_coeff . '\" is succesfull.');
+   }else {
+	   $_SESSION['notify']['title'] = htmlentities('Split wave file \"' . $selected_coeff . '\" has failed');
+	   $_SESSION['notify']['msg'] = htmlentities(implode('<br>', $result));
+   }
 }
 
 // camillagui status toggle
@@ -222,7 +222,10 @@ if( $_selected_coeff ) {
 		if($param == 'channels' && $value != 1) {
 			$coeffInfoHtml .= "<span style='color: red'>&#10007;</span> " . $param . ' = ' . $value ." (WARNING: CamillaDSP can only handle files with 1 channel)<br/>";
 			$btn_conv_style = ""; //unhide
-		} else {
+		} elseif ($param == 'extension' && $value == 'wav') {
+			$coeffInfoHtml .= "<span style='color: red'>&#10007;</span> " . $param . ' = ' . $value ." (WARNING: CamillaDSP doesn't support WAV files, convert to raw or skip header bytes in config)<br/>";
+			$btn_conv_style = ""; //unhide
+		}else {
 			$coeffInfoHtml .= ''. $param . ' = ' . $value . '<br/>';
 		}
 	}

--- a/www/templates/cdsp-config.html
+++ b/www/templates/cdsp-config.html
@@ -241,12 +241,14 @@
 						<button id="btn-import-coeff" class="btn btn-medium btn-primary btn-submit" type="submit" name="import" value="1"  style="display:none"/>
 					</div>&nbsp;&nbsp;
 					<button id="btn-check-coeff" class="btn btn-medium btn-primary btn-submit" type="submit" name="info" value="1" style="display:none" >Info</button>
-					<button class="btn btn-medium btn-primary btn-submit" type="submit" name="split" value="1" $btn_conv_style >Split</button>
+					<a data-toggle="modal" href="#convert_coeff" $btn_conv_style><button class="btn btn-medium btn-primary"   >Convert</button></a>&nbsp;&nbsp;
+
 					<a aria-label="Help" class="info-toggle" data-cmd="info-convolution-actions" href="#notarget"><i class="fas fa-info-circle"></i></a>
 					<div id="info-convolution-actions" class="help-block-configs help-block-margin legend-info-help hide">
 							<b>Delete:&nbsp;</b>Delete the selected convolution file.<br/>
 							<b>Download:&nbsp;</b>Download the selected convolution file.<br/>
 							<b>Upload:&nbsp;</b>Upload a convolution file, existing ones are overwritten.<br/>
+							<b>Convert:&nbsp;</b>Split stereo files and convert to RAW. Press convert for more information.<br/>
 	 			    </div>
 				</div>
 			</div>
@@ -409,6 +411,50 @@
 		<div class="modal-footer">
 			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="newpipeline" value="1">Ok</button>
+		</div>
+	</div>
+</form>
+
+<form class="form-horizontal" action="#conv_file" method="post">
+	<div id="convert_coeff" class="modal modal-sm hide" tabindex="-1" role="dialog" aria-labelledby="convert_coeff-label" aria-hidden="true">
+		<input id="convert_coeff_id" type="hidden" name="cdsp-coeffs" value="$_selected_coeff"/>
+		<div class="modal-header">
+			<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+			<h3>Convert convolution WAVE file</h3>
+			<h3>$_selected_coeff</h3>
+		</div>
+
+		<div class="modal-body">
+			<div class="control-group">
+				<label class="control-label" >What does convert</label>
+				<div class="controls">
+					<span id="info-convertwav" class="help-block-configs help-block-margin legend-info-help">
+						CamillaDSP does not support using WAVE files directly. You can use the mono WAVE as RAW file by skipping the WAVE header, or convert it to RAW format.<br/>
+						Stereo WAVE files needs to be split first into two mono files.<br/>
+						<br/>
+						Both the stereo file splitting(if required) and converting to RAW files are done by this WAVE file converter.<br/>
+						After a succesfull convertion the original WAVE file is deleted.<br/>
+						<br/>
+						The convert function will:<br/>
+						- If wave is a stereo file, split it in two mono files<br/>
+						- Convert the mono file(s) to raw format.<br/>
+						- Delete the original wav file afterwards.<br/>
+						<br/>
+						Output file names:<br/>
+						The samplerate and bitrat are added to the filename:<br/>
+						foobar.wav becomes foobar_44100Hz_16b.raw.<br/>
+						If the source was a stereo file the output becomes:
+						<br/>foobar_L_44100Hz_16b.raw and  foobar_R_44100Hz_16b.raw<br/>
+						<br/>
+						Note: due a problem with 24bit conv files with csdp, for the moment all wave ir files are converted to 32bit.<br/>
+					</span>
+				</div>
+			</div>
+		</div>
+
+		<div class="modal-footer">
+			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn btn-primary btn-submit" type="submit" name="convertcoeff" value="1">Convert</button>
 		</div>
 	</div>
 </form>


### PR DESCRIPTION
Use sox for convertion and force 32bit format as output, due an issue with 24bits.

If adds an convert button:
![image](https://user-images.githubusercontent.com/1525169/109564155-f49b1800-7ae0-11eb-8d38-1384213bc721.png)

- on press an dialog follows to confirm to process or cancel (maybe the texts can be improved)
![image](https://user-images.githubusercontent.com/1525169/109564101-e51bcf00-7ae0-11eb-83dd-d1a366edaf58.png)
- the wav is convert to 24b raw file.
- if wav is a stereo file it is converted in to mono files.
- - if the conversion is succesfull the orginal wav is deleted.

Also the coeff file info give now a warning if it is wav:
![image](https://user-images.githubusercontent.com/1525169/109564049-d8977680-7ae0-11eb-99c5-82099cf1cf03.png)



See https://github.com/HEnquist/camilladsp/issues/97 about the 24bits issue.