### PR TITLE
[CamillaDSP] Fix input-xxlarge selectors

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -592,3 +592,13 @@ ol.playhistory {margin-left:55px;}
 	   scrollbar-color: auto;
    }
 }
+
+/* Existing input width selectors doesn't work, because override by bootstrap-select. Add !important to prevent that*/
+@media (min-width:650px) {
+	.input-xlarge{width:270px !important;}
+}
+.input-xxlarge {
+	width:90% !important;
+	max-width: 750px !important;
+}
+

--- a/www/templates/cdsp-config.html
+++ b/www/templates/cdsp-config.html
@@ -44,7 +44,7 @@
 			<div class="control-group">
 				<label class="control-label" for="cdsp-setting-mode">Configuration</label>
 				<div class="controls">
-					<select id="cdsp-setting-mode" class="input-large" name="cdsp-mode" >
+					<select id="cdsp-setting-mode" class="input-xxlarge" name="cdsp-mode" >
 						$_select[cdsp_mode]
 					</select>
 					<a aria-label="Help" class="info-toggle" data-cmd="info-cdspmode" href="#notarget"><i class="fas fa-info-circle"></i></a>
@@ -93,7 +93,7 @@
 
 				<label class="control-label" for="cdsp-basiccon-left">IR Left</label>
 				<div class="controls controls-select">
-				    <select id="cdsp-basiccon-left" class="input-large" name="cdsp_basicconv_left" >
+				    <select id="cdsp-basiccon-left" class="input-xxlarge" name="cdsp_basicconv_left" >
 						$_select[cdsp_quickconv_irl]
 					</select>
 					<div style="display: inline-block; vertical-align: top; margin-top: 2px;">
@@ -107,7 +107,7 @@
 
 				<label class="control-label" for="cdsp-basiccon-right">IR Right</label>
 				<div class="controls controls-select">
-				    <select id="cdsp-basiccon-right" class="input-large" name="cdsp_basicconv_right" >
+				    <select id="cdsp-basiccon-right" class="input-xxlarge" name="cdsp_basicconv_right" >
 						$_select[cdsp_quickconv_irr]
 					</select>
 					<div style="display: inline-block; vertical-align: top; margin-top: 2px;">
@@ -145,7 +145,7 @@
 			<div class="control-group">
 				<label class="control-label" for="cdsp-configs">Pipeline</label>
 				<div class="controls">
-				    <select id="cdsp-configs" class="input-large" name="cdsp-config" onchange="$('#btn-automatic-check').click();">
+				    <select id="cdsp-configs" class="input-xxlarge" name="cdsp-config" onchange="$('#btn-automatic-check').click();">
 						$_select[cdsp_configs]
 					</select>
 					<button id="btn-automatic-check" class="btn btn-medium btn-primary btn-submit" type="submit" name="checkauto" value="1"  style="display:none" ></button>


### PR DESCRIPTION
Some input fields with possible long names, could use longer fields when the space is available.

Only the are bootstrap selectors available for larger input selectors like `.input-xlarge` and `.input-xxlarge` dont' work  because the style  bootstrap-select will override those.

This PR fixes this for xlarge and xxlarge selectors.