### PR TITLE
Features/improve cdsp cfg patching

### DIFF
--- a/www/cdsp-config.php
+++ b/www/cdsp-config.php
@@ -44,27 +44,25 @@ if (isset($_POST['save']) && $_POST['save'] == '1') {
 		playerSession('write', 'camilladsp_quickconv', $cfg);
 	}
 
+	if (isset($_POST['cdsp_playbackdevice'])) {
+		$patchPlaybackDevice = $_POST['cdsp_playbackdevice'];
+		playerSession('write', 'cdsp_fix_playback', $patchPlaybackDevice == "1" ? "Yes" : "No");
+	}
+
 	if (isset($_POST['cdsp-mode'])) {
 		$currentMode = $_SESSION['camilladsp'];
 		playerSession('write', 'camilladsp', $_POST['cdsp-mode']);
 		$cdsp->selectConfig($_POST['cdsp-mode']);
-		if ($_SESSION['cdsp_fix_playback'] == 'Yes' ) {
-			$cdsp->setPlaybackDevice($_SESSION['cardnum']);
-		}
-
-		if ( $_SESSION['camilladsp'] != $currentMode && ( $_SESSION['camilladsp'] == 'off' || $currentMode == 'off')) {
-			submitJob('camilladsp', $_POST['cdsp-mode'], 'CamillaDSP ' . $cdsp->getConfigLabel($_POST['cdsp-mode']), '');
-		} else {
-			$cdsp->reloadConfig();
-		}
 	}
 
-	if (isset($_POST['cdsp_playbackdevice'])) {
-		$patchPlaybackDevice = $_POST['cdsp_playbackdevice'];
-		playerSession('write', 'cdsp_fix_playback', $patchPlaybackDevice == "1" ? "Yes" : "No");
-		if ($_SESSION['cdsp_fix_playback'] == 'Yes' ) {
-		   $cdsp->setPlaybackDevice($_SESSION['cardnum']);
-		}
+	if ($_SESSION['cdsp_fix_playback'] == 'Yes' ) {
+		$cdsp->setPlaybackDevice($_SESSION['cardnum']);
+	}
+
+	if ( $_SESSION['camilladsp'] != $currentMode && ( $_SESSION['camilladsp'] == 'off' || $currentMode == 'off')) {
+		submitJob('camilladsp', $_POST['cdsp-mode'], 'CamillaDSP ' . $cdsp->getConfigLabel($_POST['cdsp-mode']), '');
+	} else {
+		$cdsp->reloadConfig();
 	}
 }
 


### PR DESCRIPTION
Made the patching of the cdsp config less error phrone  by not only replacing the device and format, but the entire capture and playback nodes. 

This prevents errors due:

- Selecting the wrong capture or playback device
- Importing external cdsp configs in to moOde

PHP default lacks a yml parser, requires new dep:
```
sudo apt-get install -y php-yaml
```