### PR TITLE
Fix moodutil import error with camilladsp

### DIFF
--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -3068,15 +3068,7 @@ function autoConfigSettings() {
 		['requires' => ['eqfa12p'] , 'handler' => setPlayerSession],
 		['requires' => ['camilladsp_quickconv'] , 'handler' => setPlayerSession],
 		['requires' => ['cdsp_fix_playback'] , 'handler' => setPlayerSession],
-		['requires' => ['camilladsp'], 'handler' => function($values) {
-			playerSession('write', 'camilladsp', $values['camilladsp']);
-
-			$cdsp = new CamillaDsp($_SESSION['camilladsp'], $_SESSION['cardnum'], $_SESSION['camilladsp_quickconv']);
-			$cdsp->selectConfig($_SESSION['camilladsp']);
-			if ($_SESSION['cdsp_fix_playback'] == 'Yes' ) {
-				$cdsp->setPlaybackDevice($_SESSION['cardnum']);
-			}
-		}],
+		['requires' => ['camilladsp'], 'handler' => setPlayerSession],
 		['requires' => ['volume_step_limit'] , 'handler' => setPlayerSession],
 		['requires' => ['volume_mpd_max'] , 'handler' => setPlayerSession],
 		['requires' => ['volume_db_display'] , 'handler' => setPlayerSession],


### PR DESCRIPTION
Error occures when manual import is done with 'moodeutl -i' (as opposed of letting the worker.php handle it on the next reboot).