### PR TITLE
Fixes/upnp artwork

### DIFF
--- a/www/command/upnp_albumart.py
+++ b/www/command/upnp_albumart.py
@@ -11,6 +11,7 @@
 import sys
 import os
 import upnpp
+import urllib.parse
 
 def debug(x):
     print("%s" % x, file = sys.stderr)
@@ -27,7 +28,9 @@ def artFromMeta(metadata):
     if dirc.m_items.size():
         dirobj = dirc.m_items[0]
         if "upnp:albumArtURI" in dirobj.m_props:
-            print("%s" % dirobj.m_props["upnp:albumArtURI"])
+            o = urllib.parse.urlsplit(dirobj.m_props["upnp:albumArtURI"])
+            url_escaped = urllib.parse.ParseResult(o.scheme, o.netloc, urllib.parse.quote(o.path), "", "", "").geturl()
+            print("%s" % url_escaped)
             sys.exit(0)
 
 
@@ -63,3 +66,4 @@ if service:
     artFromAVTransport(service)
 
 sys.exit(0)
+

--- a/www/command/upnp_albumart.py
+++ b/www/command/upnp_albumart.py
@@ -6,7 +6,9 @@
 #
 # 2021-01-16 Tim Curtis:
 # - Change 0S._exit() to sys.exit()
-#
+# 2021-04-11 Marcel van de Weert
+# - Escape album art url path
+# - To speedup lookup provide type of system with mode(auto|upnpav|openhome) cmd arg
 
 import sys
 import os
@@ -18,7 +20,7 @@ def debug(x):
 
 def usage():
     prog = os.path.basename(__file__)
-    debug("Usage: %s devname" % prog)
+    debug("Usage: %s devname [mode]" % prog)
     sys.exit(1)
 
 
@@ -51,19 +53,24 @@ def artFromAVTransport(service):
         artFromMeta(retdata["TrackMetaData"])
 
 
-if len(sys.argv) != 2:
+if len(sys.argv) != 2 and len(sys.argv) != 3:
     usage()
 devname = sys.argv[1]
+mode = 'auto'
+if len(sys.argv) == 3:
+    mode = sys.argv[2]
 
 log = upnpp.Logger_getTheLog("stderr")
 log.setLogLevel(0)
 
-service = upnpp.findTypedService(devname, "Info", True)
-if service:
-    artFromOHInfo(service)
-service = upnpp.findTypedService(devname, "AVTransport", True)
-if service:
-    artFromAVTransport(service)
+if mode == "auto" or mode == 'openhome':
+    service = upnpp.findTypedService(devname, "Info", True)
+    if service:
+        artFromOHInfo(service)
+if mode == "auto" or mode == 'upnpav':
+    service = upnpp.findTypedService(devname, "AVTransport", True)
+    if service:
+        artFromAVTransport(service)
 
 sys.exit(0)
 

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -2723,7 +2723,8 @@ function startUPnP() {
 }
 // Get UPnP coverart url
 function getUpnpCoverUrl() {
-	$result = sysCmd('/var/www/command/upnp_albumart.py "' . $_SESSION['upnpname'] . $_SESSION['upnp_svctype'] . '"');
+	$mode = sdbquery("SELECT value FROM cfg_upnp WHERE param='upnpav'", cfgdb_connect())[0]['value'] == 1 ? 'upnpav' : 'openhome';
+	$result = sysCmd('/var/www/command/upnp_albumart.py "' . $_SESSION['upnpname'] . $_SESSION['upnp_svctype'] . '" '. $mode);
 	// If multiple url's are returned, use the first
 	return explode(',', $result[0])[0];
 }


### PR DESCRIPTION
- Protect upnp_albumart.py url against funky chars.
- Speed up upnp_albumart.py by providing used method 
- Let getUpnpCoverUrl provide mode to upnp_albumart.py

See the three commits notes for more info.