### PR TITLE
[camilladsp] Add possibility to add extensions to the camilladsp config page

### DIFF
--- a/www/cdsp-config.php
+++ b/www/cdsp-config.php
@@ -314,6 +314,36 @@ $_select['camillaguiexpert0'] .= "<input type=\"radio\" name=\"camillaguiexperts
 $_open_camillagui_disabled = $camillaGuiStatus == CGUI_CHECK_ACTIVE ? '': 'disabled';
 $_camillagui_notfound_show = $camillaGuiStatus == CGUI_CHECK_NOTFOUND ? '': 'hide';
 $_camillagui_status_problems = $camillaGuiStatus == CGUI_CHECK_ACTIVE || $camillaGuiStatus == CGUI_CHECK_INACTIVE || $camillaGuiStatus == CGUI_CHECK_NOTFOUND? 'hide': '';
+
+// The extension mechanism is intended for dynamic adding function plugins for generating CamillaDSP configurations
+$extensions_config = '/var/local/www/cdsp_extensions.json';
+$extensions_html = '';
+if(file_exists($extensions_config)) {
+	$_cdsp_extensions_show = '';
+	$extensions = json_decode(file_get_contents($extensions_config), true);
+
+	$extension_template ='
+	<label class="control-label">%s</label>
+	<div class="controls">
+		<a href="%s"><button class="btn btn-primary btn-medium" style="margin-top:0px;">Open</button></a>
+		<div style="display: inline-block; vertical-align: top; margin-top: 2px;">
+			<a aria-label="Help" class="info-toggle" data-cmd="info-%s" href="#notarget"><i class="fas fa-info-circle"></i></a>
+		</div>
+		<span id="info-%s" class="help-block-configs help-block-margin legend-info-help hide">
+			%s<br>
+		</span>
+	</div>
+	<br/>';
+
+	foreach ($extensions as $extension) {
+		$extensions_html .= sprintf($extension_template ,  $extension['title'], $extension['url'], $extension['label'], $extension['label'],  'help help'); // $extension['help']);
+		$extensions_html .= "\n";
+	}
+
+}else {
+	$_cdsp_extensions_show = 'hide';
+}
+
 session_write_close();
 
 waitWorker(1, 'cdsp-config');

--- a/www/templates/cdsp-config.html
+++ b/www/templates/cdsp-config.html
@@ -323,6 +323,16 @@
 		</fieldset>
 	</form>
 
+	<form class="form-horizontal $_cdsp_extensions_show" action="#extensions" method="post" >
+		<a id="extensions"></a>
+		<fieldset>
+			<legend>Extensions</legend>
+				<div class="control-group">
+					$extensions_html
+				</div>
+		</fieldset>
+	</form>
+
 </div>
 </div>
 


### PR DESCRIPTION
This PR is adds a hidden feature for adding extensions from a config file to the camilladsp configuration page.

The config (absent for now) should be placed in `/var/local/www/cdsp_extensions.json` and has the following format:
```json
[{
  "label": "autoeq",
  "title" : "AutoEq",
  "url": "http://host:8091",
  "help": "foobar"
},
{
    "label": "ashirdataset",
    "title" : "ASH IR Dataset",
    "url": "http://host:8092",
    "help": "barfoo"
}]
```
The config above would result in:

![image](https://user-images.githubusercontent.com/1525169/115124918-53e7b580-9fc5-11eb-8694-7f721db98267.png)

Currently it has no effect and the extension header is hidden. But I'm working on config generators for CamillaDSP. Because those require big external datasets, it will not be handy to add those default to moOde. Also it will make it easier to test and replace in this way.
