### PR TITLE
[CamillaDSP] configuration option to toggle verbose logging of CamillaDSP

### DIFF
--- a/www/cdsp-config.php
+++ b/www/cdsp-config.php
@@ -62,6 +62,10 @@ if (isset($_POST['save']) && $_POST['save'] == '1') {
 	} else {
 		$cdsp->reloadConfig();
 	}
+
+	if( $_POST['log_level'] != $cdsp->getLogLevel() ) {
+		$cdsp->setLogLevel($_POST['log_level']);
+	}
 }
 
 // Check
@@ -343,6 +347,11 @@ if(file_exists($extensions_config)) {
 }else {
 	$_cdsp_extensions_show = 'hide';
 }
+
+$cdsp_log_level = $cdsp->getLogLevel();
+$_cdsp_log_level .= "<option value=\"default\" " . (($cdsp_log_level == 'default') ? "selected" : "") . " >Default</option>\n";
+$_cdsp_log_level .= "<option value=\"verbose\" " . (($cdsp_log_level == 'verbose') ? "selected" : "") . " >Verbose</option>\n";
+
 
 session_write_close();
 

--- a/www/inc/cdsp.php
+++ b/www/inc/cdsp.php
@@ -499,6 +499,21 @@ class CamillaDsp {
         return $exitcode;
     }
 
+    function getLogLevel() {
+        $res=sysCmd("cat " . $this->ALSA_CDSP_CONFIG . "| grep -e '#[ ]*-v'");
+        $level =  (count($res)==0 ) ? 'verbose' : 'default';
+        return $level;
+    }
+
+    function setLogLevel($level) {
+        if( $level == 'verbose') {
+            sysCmd('sed -i "s/#[ ]*-v/         -v/g" ' . $this->ALSA_CDSP_CONFIG);
+        }
+        else {
+            sysCmd('sed -i "s/^[ ]*-v/#        -v/g" ' . $this->ALSA_CDSP_CONFIG);
+        }
+    }
+
     // placeholders for autoconfig support, empty for now
     function backup() {
     }
@@ -586,6 +601,12 @@ function test_cdsp() {
 // }
 
 // yaml_emit_file($fileOut, $yml_cfg);
+    print($cdsp->getLogLevel() );
+    // $cdsp->setLogLevel('verbose');
+    $cdsp->setLogLevel('default');
+
+    print($cdsp->getLogLevel() );
+
 }
 
 

--- a/www/templates/cdsp-config.html
+++ b/www/templates/cdsp-config.html
@@ -75,6 +75,16 @@
 						<b>No:&nbsp;</b>Use an audio device thats different from the moOde defined device for example if you want to create a multi-channel crossover.
 					</span>
 				</div>
+                <label class="control-label" for="log_level">Log level</label>
+                <div class="controls">
+					<select id="log_level" name="log_level" class="input-large">
+						$_cdsp_log_level
+					</select>
+					<a aria-label="Help" class="info-toggle" data-cmd="info-log_level" href="#notarget"><i class="fas fa-info-circle"></i></a>
+					<span id="info-log_level" class="help-block-configs help-block-margin hide">
+						Control the amount of detail of CamillaDSP in the MPD log (/var/log/mpd/log).
+                   </span>
+                </div>
 			</div>
 		</fieldset>
 


### PR DESCRIPTION
To improve support and problem solving make it possible to enable verbose logging of camilladsp into the mpd log.


Example output (watch the DEBG and INFO log entries):
```
May 07 15:12 : alsa_output: opened _audioout type=COPY
May 07 15:12 : alsa_output: buffer: size=3840..16384 time=87074..371520
May 07 15:12 : alsa_output: period: size=1920..2048 time=43537..46440
May 07 15:12 : alsa_output: default period_time = buffer_time/4 = 371519/4 = 92879
May 07 15:12 : alsa_output: format=S24_LE (Signed 24 bit Little Endian)
May 07 15:12 : alsa_output: buffer_size=16384 period_size=2048
May 07 15:12 : output: opened "ALSA Default" (alsa) audio_format=44100:24:2
May 07 15:12 : client: [4] command returned 0
May 07 15:12 : client: [4] process command list
May 07 15:12 : client: process command "status"
May 07 15:12 : client: command returned 0
May 07 15:12 : client: process command "currentsong"
May 07 15:12 : client: command returned 0
May 07 15:12 : client: [4] process command list returned 0
May 07 15:12 : client: [1] process command "status"
May 07 15:12 : client: [1] command returned 0
May 07 15:12 : client: [3] process command "status"
May 07 15:12 : client: [3] command returned 0
May 07 15:12 : client: [4] closed
May 07 15:12 : client: [1] process command "currentsong"
May 07 15:12 : client: [1] command returned 0
May 07 15:12 : client: [3] process command "currentsong"
May 07 15:12 : client: [3] command returned 0
May 07 15:12:18.150 DEBG Read config file Some("/usr/share/camilladsp/working_config.yml"), module: camilladsp
May 07 15:12:18.152 DEBG Apply override for samplerate: 44100, module: camillalib::config
May 07 15:12:18.152 DEBG Samplerate changed, adjusting chunksize: 1024 -> 1024, module: camillalib::config
May 07 15:12:18.153 DEBG Scale extra samples: 0 -> 0, module: camillalib::config
May 07 15:12:18.153 DEBG Apply override for capture channels: 2, module: camillalib::config
May 07 15:12:18.153 DEBG Apply override for capture sample format: S24LE, module: camillalib::config
May 07 15:12:18.154 DEBG Config is valid, module: camilladsp
May 07 15:12:18.154 DEBG Start websocket server on 0.0.0.0:1234, module: camillalib::socketserver
May 07 15:12:18.154 DEBG Wait for config, module: camilladsp
May 07 15:12:18.155 DEBG Config ready, module: camilladsp
May 07 15:12:18.155 DEBG Using channels [true, true], module: camilladsp
May 07 15:12:18.155 DEBG Capture thread ready to start, module: camilladsp
May 07 15:12:18.156 DEBG Build new pipeline, module: camillalib::filters
May 07 15:12:18.156 DEBG build filters, waiting to start processing loop, module: camillalib::processing
May 07 15:12:18.169 DEBG Opening audio device "hw:1,0" with parameters: HwParams { channels: Ok(2), rate: "Ok(44100) Hz", format: Ok(S16LE), access: Ok(RWInterleaved), period_size: "Ok(444) frames", buffer_size: "Ok(2048) frames" }, SwParams(avail_min: Ok(444) frames, start_threshold: Ok(580) frames, stop_threshold: Ok(2048) frames), module: camillalib::alsadevice
May 07 15:12:18.170 DEBG Audio device "hw:1,0" successfully opened, module: camillalib::alsadevice
May 07 15:12:18.170 DEBG Playback thread ready to start, module: camilladsp
May 07 15:12:18.171 DEBG Both capture and playback ready, release barrier, module: camilladsp
May 07 15:12:18.171 DEBG Starting playback loop, module: camillalib::alsadevice
May 07 15:12:18.174 DEBG starting captureloop, module: camillalib::filedevice
May 07 15:12:18.174 DEBG starting captureloop, module: camillalib::filedevice
May 07 15:12:18.175 INFO Starting playback from Prepared state, module: camillalib::alsadevice

```