### PR TITLE
[camilladsp] Support alsa_output_mode for device type

### DIFF
--- a/www/cdsp-config.php
+++ b/www/cdsp-config.php
@@ -54,7 +54,7 @@ if (isset($_POST['save']) && $_POST['save'] == '1') {
 	}
 
 	if ($_SESSION['cdsp_fix_playback'] == 'Yes' ) {
-		$cdsp->setPlaybackDevice($_SESSION['cardnum']);
+		$cdsp->setPlaybackDevice($_SESSION['cardnum'], $_SESSION['alsa_output_mode']);
 	}
 
 	if ( $_SESSION['camilladsp'] != $currentMode && ( $_SESSION['camilladsp'] == 'off' || $currentMode == 'off')) {
@@ -87,7 +87,7 @@ else if (isset($_FILES['pipelineconfig']) && isset($_POST['import']) && $_POST['
 
 	if( $_SESSION['camilladsp'] == $configFileBaseName ) { // if upload active config, fix it
 		if ($_SESSION['cdsp_fix_playback'] == 'Yes' ) {
-			$cdsp->setPlaybackDevice($_SESSION['cardnum']);
+			$cdsp->setPlaybackDevice($_SESSION['cardnum'], $_SESSION['alsa_output_mode']);
 		}
 		$cdsp->reloadConfig();
 	} else {

--- a/www/command/worker.php
+++ b/www/command/worker.php
@@ -458,7 +458,7 @@ $result = sdbquery("UPDATE cfg_system SET value='0' WHERE param='btactive' OR pa
 $cdsp = new CamillaDsp($_SESSION['camilladsp'], $_SESSION['cardnum'], $_SESSION['camilladsp_quickconv']);
 $cdsp->selectConfig($_SESSION['camilladsp']);
 if ($_SESSION['cdsp_fix_playback'] == 'Yes' ) {
-	$cdsp->setPlaybackDevice($_SESSION['cardnum']);
+	$cdsp->setPlaybackDevice($_SESSION['cardnum'], $_SESSION['alsa_output_mode']);
 }
 unset($cdsp);
 workerLog('worker: CamillaDSP (' . $_SESSION['camilladsp'] . ')');

--- a/www/inc/cdsp.php
+++ b/www/inc/cdsp.php
@@ -40,7 +40,6 @@ class CamillaDsp {
     private $CAMILLA_EXE = '/usr/local/bin/camilladsp';
     private $CAMILLAGUI_WORKING_CONGIG = '/usr/share/camilladsp/working_config.yml';
     private $device = NULL;
-    private $deviceType = 'plughw';
     private $configfile = NULL;
     private $quickConvolutionConfig = ";;;";
 
@@ -59,7 +58,7 @@ class CamillaDsp {
     /**
      * Set in camilladsp config file the playback device to use
      */
-    function setPlaybackDevice($device) {
+    function setPlaybackDevice($device, $deviceType = "plughw") {
         if( $this->configfile != NULL && $this->configfile != 'off' && $this->configfile != 'custom') {
             $this->device = $device;
             $supportedFormats = $this->detectSupportedSoundFormats();
@@ -72,7 +71,7 @@ class CamillaDsp {
                                                     'format' => $useFormat);
             $yml_cfg['devices']['playback'] = Array( 'type' => 'Alsa',
                                                 'channels' => 2,
-                                                'device' => $this->deviceType . ":" . $device . ",0",
+                                                'device' => $deviceType . ":" . $device . ",0",
                                                 'format' => $useFormat);
 
             // patch issue where yaml parser to an empty [], which would break the cdsp config

--- a/www/snd-config.php
+++ b/www/snd-config.php
@@ -269,7 +269,7 @@ if (isset($_POST['update_camilladsp']) && isset($_POST['camilladsp']) && $_POST[
 	playerSession('write', 'camilladsp', $_POST['camilladsp']);
 	$cdsp->selectConfig($_POST['camilladsp']);
 	if ($_SESSION['cdsp_fix_playback'] == 'Yes' ) {
-		$cdsp->setPlaybackDevice($_SESSION['cardnum']);
+		$cdsp->setPlaybackDevice($_SESSION['cardnum'], $_SESSION['alsa_output_mode']);
 	}
 
     if ( $_SESSION['camilladsp'] != $currentMode && ( $_SESSION['camilladsp'] == 'off' || $currentMode == 'off')) {


### PR DESCRIPTION
Prepared camilladsp configuration for the upcoming `alsa_output_mode` setting.

Expect it to be `hw` or `plughw`.