### PR TITLE
[autocfg] support calling an user script on installation.

### DIFF
--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -3457,6 +3457,22 @@ function autoConfig($cfgfile) {
 			}
 		}
 
+		$script_key = 'script';
+		if(  array_key_exists($script_key, $autocfg) ) {
+			autoCfgLog('autocfg: '. $script_key.':'. $script);
+			$script = $autocfg[$script_key];
+
+			if (file_exists($script)) {
+				$output = sysCmd($script);
+				foreach ($output  as $line) {
+					autoCfgLog($line);
+				}
+			}else {
+				autoCfgLog('autocfg: Error script not found!');
+			}
+			unset($autocfg[$script_key]);
+		}
+
 		// Check for unused but supplied autocfg settings
 		if( empty($available_configs) ) {
 			foreach ($available_configs as $config_name) {


### PR DESCRIPTION
This option allows setting an user script that is executed at the end of the autocfg import. The script setting isn't exported and should be added to the end of the moodecfg.ini file.

Configuration:
```
[User]
script=/path/to/script
```

Example:
```
[User]
script=/boot/script
```