### PR TITLE
Fixes/autocfg names

### DIFF
--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -3062,21 +3062,22 @@ function autoConfigSettings() {
 	$configurationHandlers = [
 		'Names',
 		['requires' => ['browsertitle'] , 'handler' => setPlayerSession],
-		['requires' => ['hostname'] , 'handler' => setPlayerSessionAndSysCmd, 'cmd' => 'chg-name host "moode" "%s"'],
-		['requires' => ['btname'] , 'handler' => setPlayerSessionAndSysCmd, 'cmd' => 'chg-name bluetooth "Moode Bluetooth" "%s"'],
+		['requires' => ['hostname'] , 'handler' => setPlayerSessionAndSysCmd, 'cmd' => 'chg-name host "' . $_SESSION['hostname'] . '" "%s"'],
+		['requires' => ['btname'] , 'handler' => setPlayerSessionAndSysCmd, 'cmd' => 'chg-name bluetooth "' . $_SESSION['btname'] . '" "%s"'],
 		['requires' => ['airplayname'] , 'handler' => setPlayerSession],
 		['requires' => ['spotifyname'] , 'handler' => setPlayerSession],
 		['requires' => ['squeezelitename'] , 'handler' => function($values) {
 				$dbh = cfgdb_connect();
+				$currentName= sdbquery("select value from cfg_sl where param='PLAYERNAME'", $dbh)[0]['value'];
 				$result = sdbquery('update cfg_sl set value=' . "'" . $values['squeezelitename'] . "'" . ' where param=' . "'PLAYERNAME'", $dbh);
-				sysCmd('/var/www/command/util.sh chg-name squeezelite "Moode" ' . '"' . $values['squeezelitename'] . '"');
+				sysCmd('/var/www/command/util.sh chg-name squeezelite "' . $currentName . '" ' . '"' . $values['squeezelitename'] . '"');
 			}, 'custom_write' => function($values) {
 				$dbh = cfgdb_connect();
 				$result = sdbquery("select value from cfg_sl where param='PLAYERNAME'", $dbh)[0]['value'];
 				return "squeezelitename = \"".$result."\"\n";
 			}],
-		['requires' => ['upnpname'] , 'handler' => setPlayerSessionAndSysCmd, 'cmd' => 'chg-name upnp "Moode UPNP" "%s"'],
-		['requires' => ['dlnaname'] , 'handler' => setPlayerSessionAndSysCmd, 'cmd' => 'chg-name dlna "Moode DLNA" "%s"'],
+		['requires' => ['upnpname'] , 'handler' => setPlayerSessionAndSysCmd, 'cmd' => 'chg-name upnp "' . $_SESSION['upnpname'] . '" "%s"'],
+		['requires' => ['dlnaname'] , 'handler' => setPlayerSessionAndSysCmd, 'cmd' => 'chg-name dlna "' . $_SESSION['dlnaname'] . '" "%s"'],
 
 		'System',
 		['requires' => ['timezone'] , 'handler' => setPlayerSessionAndSysCmd, 'cmd' => 'set-timezone %s'],


### PR DESCRIPTION
Most of the autocfg names section could only be import and applied when the current system had the defaults names (= fresh install).

This PR makes sures it also works with non default current names (= non fresh install).