### PR TITLE
Initial implementation of gui for backup restore.

### DIFF
--- a/www/backup.php
+++ b/www/backup.php
@@ -30,25 +30,25 @@ playerSession('open', '' ,'');
 if( isset($_POST['backup_create']) && $_POST['backup_create'] == '1' ) {
 	$backupOptions = '';
 	if( isset($_POST['backup_system']) && $_POST['backup_system'] == '1' ) {
-		$backupOptions .= $backupOptions ? ',config' : 'config';
+		$backupOptions .= $backupOptions ? ' config' : 'config';
 	}
 	if( isset($_POST['backup_camilladsp']) && $_POST['backup_camilladsp'] == '1' ) {
-		$backupOptions .= $backupOptions ? ',cdsp' : 'cdsp';
+		$backupOptions .= $backupOptions ? ' cdsp' : 'cdsp';
 	}
 	if( isset($_POST['backup_radiostations_moode']) && $_POST['backup_radiostations_moode'] == '1' ) {
-		$backupOptions .= $backupOptions ? ',r_sys' : 'r_sys';
+		$backupOptions .= $backupOptions ? ' r_sys' : 'r_sys';
 	}
 	if( isset($_POST['backup_radiostations_other']) && $_POST['backup_radiostations_other'] == '1' ) {
-		$backupOptions .= $backupOptions ? ',r_other' : 'r_other';
+		$backupOptions .= $backupOptions ? ' r_other' : 'r_other';
 	}
 
 	if($backupOptions) {
-		$backupOptions = '--what=' . $backupOptions . ' ';
+		$backupOptions = '--what ' . $backupOptions . ' ';
 	}
 
 	$tempBackupFileName = '/tmp/backup.zip';
-	sysCmd('/var/www/backupmananger.py ' . $backupOptions . '--backup ' . $tempBackupFileName);
-	// print('/var/www/backupmananger.py ' . $backupOptions . '--backup ' . $tempBackupFileName);
+	sysCmd('sudo -u pi /var/www/command/backupmanager.py ' . $backupOptions . '--backup ' . $tempBackupFileName);
+	// print('/var/www/command/backupmanager.py ' . $backupOptions . '--backup ' . $tempBackupFileName);
 
 	// create name for backup file in browser
 	$dt = new DateTime('NOW');

--- a/www/backup.php
+++ b/www/backup.php
@@ -50,6 +50,12 @@ if( isset($_POST['backup_create']) && $_POST['backup_create'] == '1' ) {
 		$backupOptions .= '--wlanpwd ' .$_POST['backup_wlan0pwd'] .' ';
 	}
 
+	if( isset($_FILES['backup_scriptfile']) ) {
+		move_uploaded_file($_FILES["backup_scriptfile"]["tmp_name"], '/tmp/script');
+		//TODO: test if file exists
+		$backupOptions .= '--script /tmp/script ';
+	}
+
 	$tempBackupFileName = '/tmp/backup.zip';
 	sysCmd('sudo -u pi /var/www/command/backupmanager.py ' . $backupOptions . '--backup ' . $tempBackupFileName);
 	// print('/var/www/command/backupmanager.py ' . $backupOptions . '--backup ' . $tempBackupFileName);

--- a/www/backup.php
+++ b/www/backup.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * moOde audio player (C) 2014 Tim Curtis
+ * http://moodeaudio.org
+ *
+ * (C) 2021 @bitlab (@bitkeeper Git)
+ *
+ * This Program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This Program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+require_once dirname(__FILE__) . '/inc/playerlib.php';
+
+playerSession('open', '' ,'');
+
+/**
+ * Post parameter processing
+ */
+if( isset($_POST['backup_create']) && $_POST['backup_create'] == '1' ) {
+	$backupOptions = '';
+	if( isset($_POST['backup_system']) && $_POST['backup_system'] == '1' ) {
+		$backupOptions .= $backupOptions ? ',config' : 'config';
+	}
+	if( isset($_POST['backup_camilladsp']) && $_POST['backup_camilladsp'] == '1' ) {
+		$backupOptions .= $backupOptions ? ',cdsp' : 'cdsp';
+	}
+	if( isset($_POST['backup_radiostations_moode']) && $_POST['backup_radiostations_moode'] == '1' ) {
+		$backupOptions .= $backupOptions ? ',r_sys' : 'r_sys';
+	}
+	if( isset($_POST['backup_radiostations_other']) && $_POST['backup_radiostations_other'] == '1' ) {
+		$backupOptions .= $backupOptions ? ',r_other' : 'r_other';
+	}
+
+	if($backupOptions) {
+		$backupOptions = '--what=' . $backupOptions . ' ';
+	}
+
+	$tempBackupFileName = '/tmp/backup.zip';
+	sysCmd('/var/www/backupmananger.py ' . $backupOptions . '--backup ' . $tempBackupFileName);
+	// print('/var/www/backupmananger.py ' . $backupOptions . '--backup ' . $tempBackupFileName);
+
+	// create name for backup file in browser
+	$dt = new DateTime('NOW');
+	$backupFileName = 'moode_'. $_SESSION['hostname'].'_'. $dt->format('ymd_Hi').'.zip';
+
+	header("Content-Description: File Transfer");
+	header("Content-type: application/octet-stream");
+	header("Content-Transfer-Encoding: binary");
+	header("Content-Disposition: attachment; filename=" . $backupFileName);
+	header("Content-length: " . filesize($tempBackupFileName));
+	header("Pragma: no-cache");
+	header("Expires: 0");
+	readfile ($tempBackupFileName);
+
+	// remove leftovers after backup
+	unlink($tempBackupFileName);
+	exit();
+}
+else if( isset($_POST['restore_start']) && $_POST['restore_start'] == '1' ) {
+	if( isset($_FILES['restore_backupfile']) ) {
+		$restoreOptions = '';
+		if( isset($_POST['restore_system']) && $_POST['restore_system'] == '1' ) {
+			$restoreOptions .= $restoreOptions ? ',config' : 'config';
+		}
+		if( isset($_POST['restore_camilladsp']) && $_POST['restore_camilladsp'] == '1' ) {
+			$restoreOptions .= $restoreOptions ? ',cdsp' : 'cdsp';
+		}
+		if( isset($_POST['restore_radiostations_moode']) && $_POST['restore_radiostations_moode'] == '1' ) {
+			$restoreOptions .= $restoreOptions ? ',r_sys' : 'r_sys';
+		}
+		if( isset($_POST['restore_radiostations_other']) && $_POST['restore_radiostations_other'] == '1' ) {
+			$restoreOptions .= $restoreOptions ? ',r_other' : 'r_other';
+		}
+
+		if($restoreOptions) {
+			$restoreOptions = '--what=' . $restoreOptions . ' ';
+		}
+
+		$tempBackupFileName = '/tmp/restore.zip';
+		$configFileBaseName = $_FILES["restore_backupfile"]["name"];
+
+		// move_uploaded_file($_FILES["restore_backupfile"]["tmp_name"], '/tmp/'.$configFileBaseName);
+		move_uploaded_file($_FILES["restore_backupfile"]["tmp_name"], $tempBackupFileName);
+
+		// print('/var/www/backupmananger.py ' . $restoreOptions . '--restore ' . $tempBackupFileName);
+		sysCmd('/var/www/backupmananger.py ' . $restoreOptions . '--restore ' . $tempBackupFileName);
+
+		//TODO: maybe reset file rights?
+
+		unlink($tempBackupFileName);
+		sysCmd('reboot');
+	}
+	else {
+		print('no file');
+	}
+}
+
+/**
+ * Generate data for html templating
+ */
+
+ // Helper method to generate html code for toggle button
+function genToggleButton($id, $value, $disabled) {
+	$template = '
+	<div class="toggle">
+		<label class="toggle-radio" for="toggle_%id2">YES</label>
+		<input type="radio" name="%id" id="toggle_%id1" value="1" %checked1>
+		<label class="toggle-radio" for="toggle_%id1">NO</label>
+		<input type="radio" name="%id" id="toggle_%id2" value="0" %checked0>
+	</div>
+	<div style="display: inline-block; vertical-align: top; margin-top: 2px;">
+	  <a aria-label="Help" class="info-toggle" data-cmd="info-%id" href="#notarget"><i class="fas fa-info-circle"></i></a>
+	</div>';
+
+	return strtr($template , [
+		'%id' => $id,
+		' %checked1' => ($value == True ? 'checked="checked"': ''),
+		' %checked0' => ($value != True ? 'checked="checked"': '')
+	]);
+}
+
+$_backup_visible = (!(isset($_GET['action']) && $_GET['action'] == 'restore')) ? '': 'hidden';
+$_restore_visible = (isset($_GET['action']) && $_GET['action'] == 'restore') ? '': 'hidden';
+
+
+// toggle buttons for backup
+$_togglebtn_backup_system = genToggleButton('backup_system', True, True);
+$_togglebtn_backup_camilladsp = genToggleButton('backup_camilladsp', True, True);
+$_togglebtn_backup_radiostations_moode = genToggleButton('backup_radiostations_moode', False, True);
+$_togglebtn_backup_radiostations_other = genToggleButton('backup_radiostations_other', True, True);
+
+// toggle buttons for restore
+$_togglebtn_restore_system = genToggleButton('restore_system', True, True);
+$_togglebtn_restore_camilladsp = genToggleButton('restore_camilladsp', True, True);
+$_togglebtn_restore_radiostations_moode = genToggleButton('restore_radiostations_moode', False, True);
+$_togglebtn_restore_radiostations_other = genToggleButton('restore_radiostations_other', True, True);
+
+
+session_write_close();
+
+waitWorker(1, 'backup');
+
+$tpl = "backup.html";
+$section = basename(__FILE__, '.php');
+storeBackLink($section, $tpl);
+
+include('header.php');
+eval("echoTemplate(\"" . getTemplate("templates/$tpl") . "\");");
+include('footer.php');

--- a/www/backup.php
+++ b/www/backup.php
@@ -46,6 +46,10 @@ if( isset($_POST['backup_create']) && $_POST['backup_create'] == '1' ) {
 		$backupOptions = '--what ' . $backupOptions . ' ';
 	}
 
+	if( isset($_POST['backup_wlan0pwd']) && $_POST['backup_wlan0pwd']  ) {
+		$backupOptions .= '--wlanpwd ' .$_POST['backup_wlan0pwd'] .' ';
+	}
+
 	$tempBackupFileName = '/tmp/backup.zip';
 	sysCmd('sudo -u pi /var/www/command/backupmanager.py ' . $backupOptions . '--backup ' . $tempBackupFileName);
 	// print('/var/www/command/backupmanager.py ' . $backupOptions . '--backup ' . $tempBackupFileName);

--- a/www/command/worker.php
+++ b/www/command/worker.php
@@ -854,6 +854,17 @@ session_write_close();
 // Check permissions on the session file
 phpSessionCheck();
 
+
+// Auto restore backup if present
+// Do it just before autocfg so an autocfg always overrules backup settings
+$restoreBackup = false;
+if (file_exists('/boot/moodebackup.zip')) {
+	$restore_log = '/home/pi/backup_restore.log';
+	sysCmd('/var/www/command/backupmanager.py --restore /boot/moodebackup.zip > '.$restore_log);
+	unlink('/boot/moodebackup.zip');
+	sysCmd('sync');
+	$restoreBackup = true; // delay reboot incase autocfg is also present
+}
 // Auto-configure if indicated
 // NOTE: This is done near the end of startup because autoConfig() uses the wpa_passphrase utility which requires
 // sufficient kernel entropy in order to generate the PSK. If there is not enough entropy, wpa_passphrase returns
@@ -865,6 +876,8 @@ if (file_exists('/boot/moodecfg.ini')) {
 
 	sysCmd('sync');
 	autoCfgLog('autocfg: System restarted');
+	sysCmd('reboot');
+} else if($restoreBackup) {
 	sysCmd('reboot');
 }
 

--- a/www/templates/backup.html
+++ b/www/templates/backup.html
@@ -29,7 +29,7 @@
 				<legend>Backup</legend>
 				<div class="control-group">
 
-					<label class="control-label">System Config</label>
+					<!-- <label class="control-label">System Config</label>
 					<div class="controls">
 						$_togglebtn_backup_system
 						<span id="info-backup_system" class="help-block-configs help-block-margin legend-info-help hide">
@@ -90,7 +90,7 @@
 						<div id="info-backup_scriptfile" class="help-block-configs help-block-margin legend-info-help hide">
 								<b>Delete:&nbsp;</b>Delete the selected convolution file.</b><br/>
 						</div>
-					</div>
+					</div> -->
 
 					<br/>
 					<div class="control-group">
@@ -117,11 +117,7 @@
 					<div class="controls">
 						<div class="modal-button-style">
 							<label for="restore_backupfile" id="choose+restore_backupfile" class="btn btn-primary btn-medium">Select</label>
-
 							<input type="file" id="restore_backupfile" accept=".zip" name="restore_backupfile" style="display:none" required>
-
-							<!-- <input type="file" id="restore_backupfile" accept=".zip" name="restore_backupfile" style="display:none" onchange="$('#btn-restore_backupfile').click();" >
-							<button id="btn-restore_backupfile" class="btn btn-medium btn-primary btn-submit" type="submit" name="restore_backup_file" value="1"  style="display:none"/> -->
 						</div>
 						<a aria-label="Help" class="info-toggle" data-cmd="info-restore_backupfile" href="#notarget"><i class="fas fa-info-circle"></i></a>
 						<div id="info-restore_backupfile" class="help-block-configs help-block-margin legend-info-help hide">
@@ -130,7 +126,7 @@
 					</div>
 					<br/>
 
-					<label class="control-label">System Config</label>
+					<!-- <label class="control-label">System Config</label>
 					<div class="controls">
 						$_togglebtn_restore_system
 						<span id="info-restore_system" class="help-block-configs help-block-margin legend-info-help hide">
@@ -168,7 +164,7 @@
 					</div>
 
 					</div>
-					<br/>
+					<br/> -->
 					<div class="control-group">
 						<div class="controls">
 							<!-- <a data-toggle="modal" href="#remove-coeff"><button class="btn btn-medium btn-primary">Delete</button></a>&nbsp;&nbsp; -->

--- a/www/templates/backup.html
+++ b/www/templates/backup.html
@@ -70,7 +70,7 @@
 
 					<label class="control-label" for="wlan0pwd">WLAN pwd</label>
 					<div class="controls">
-						<input class="input-large" type="password" pattern=".{8,64}" id="backup_wlan0pwd" name="backup_wlan0pwd" value="$_wlan0pwd" disabled>
+						<input class="input-large" type="password" pattern=".{8,64}" id="backup_wlan0pwd" name="backup_wlan0pwd" value="$_wlan0pwd" >
 						<a aria-label="Help" class="info-toggle" data-cmd="info-backup_wlan0pwd" href="#notarget"><i class="fas fa-info-circle"></i></a>
 						<a class="show-hide-password" href="#notarget" data-id="backup_wlan0pwd"><i class="fal fa-eye"></i></a>
 						<span id="info-backup_wlan0pwd" class="help-block-configs help-block-margin hide">

--- a/www/templates/backup.html
+++ b/www/templates/backup.html
@@ -1,0 +1,190 @@
+<!--
+/**
+ * moOde audio player (C) 2014 Tim Curtis
+ * http://moodeaudio.org
+ *
+ * (C) 2021 @bitlab (@bitkeeper Git)
+ *
+ * This Program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This Program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+-->
+<div class="container">
+	<div class="container2">
+		<h1 class="cdsp-config">System Backup/Restore</h1>
+		<form class="form-horizontal" action="" method="post" id="backup" $_backup_visible >
+
+			<fieldset>
+				<legend>Backup</legend>
+				<div class="control-group">
+
+					<label class="control-label">System Config</label>
+					<div class="controls">
+						$_togglebtn_backup_system
+						<span id="info-backup_system" class="help-block-configs help-block-margin legend-info-help hide">
+							<b>Backup system config, including backdrop image.</b><br/>
+						</span>
+					</div>
+
+					<label class="control-label">CamillaDsp</label>
+					<div class="controls">
+						$_togglebtn_backup_camilladsp
+						<span id="info-backup_camilladsp" class="help-block-configs help-block-margin legend-info-help hide">
+							<b>Backup camilladsp pipeline configurations and ir files.</b><br/>
+						</span>
+					</div>
+
+					<label class="control-label">Radio Stations:</label>
+					<div class="controls">
+					</div>
+					<br/>
+
+					<label class="control-label">moOde</label>
+					<div class="controls">
+						$_togglebtn_backup_radiostations_moode
+						<span id="info-backup_radiostations_moode" class="help-block-configs help-block-margin legend-info-help hide">
+							<b>Backup moOde standard supplied radio stations.</b><br/>
+						</span>
+					</div>
+
+					<label class="control-label">Other</label>
+					<div class="controls">
+						$_togglebtn_backup_radiostations_other
+						<span id="info-backup_radiostations_other" class="help-block-configs help-block-margin legend-info-help hide">
+							<b>Backup user defined radio stations.</b><br/>
+						</span>
+					</div>
+
+					<br/>
+
+					<label class="control-label" for="wlan0pwd">WLAN pwd</label>
+					<div class="controls">
+						<input class="input-large" type="password" pattern=".{8,64}" id="backup_wlan0pwd" name="backup_wlan0pwd" value="$_wlan0pwd" disabled>
+						<a aria-label="Help" class="info-toggle" data-cmd="info-backup_wlan0pwd" href="#notarget"><i class="fas fa-info-circle"></i></a>
+						<a class="show-hide-password" href="#notarget" data-id="backup_wlan0pwd"><i class="fal fa-eye"></i></a>
+						<span id="info-backup_wlan0pwd" class="help-block-configs help-block-margin hide">
+							Length 8-63 chars. The password will be converted to a pre-shared key (PSK) after saving.
+						</span>
+					</div>
+
+					<br/>
+
+					<label class="control-label">Add Script</label>
+					<div class="controls">
+						<div class="modal-button-style">
+							<label for="backup_scriptfile" id="choose-backup_scriptfile" class="btn btn-primary btn-medium">Select</label>
+							<input type="file" id="backup_scriptfile" accept=".wav,.txt,.raw,.csv" name="backup_scriptfile" style="display:none" onchange="$('#btn-backup_scriptfile').click();" disabled>
+							<button id="btn-backup_scriptfile" class="btn btn-medium btn-primary btn-submit" type="submit" name="backup_scriptfile" value="1"  style="display:none" disabled/>
+						</div>&nbsp;&nbsp;
+						<a aria-label="Help" class="info-toggle" data-cmd="info-backup_scriptfile" href="#notarget"><i class="fas fa-info-circle"></i></a>
+						<div id="info-backup_scriptfile" class="help-block-configs help-block-margin legend-info-help hide">
+								<b>Delete:&nbsp;</b>Delete the selected convolution file.</b><br/>
+						</div>
+					</div>
+
+					<br/>
+					<div class="control-group">
+						<div class="controls">
+							<button class="btn btn-medium btn-primary btn-submit" type="submit" name="backup_create" form="backup" value="1">Create Backup</button>
+
+							<button id="btn-check-coeff" class="btn btn-medium btn-primary btn-submit" type="submit" name="info" value="1" style="display:none" >Info</button>
+
+						</div>
+					</div>
+
+				</div>
+
+			</fieldset>
+		</form>
+
+
+		<form class="form-horizontal" action="" method="post" id="restore"  enctype="multipart/form-data" $_restore_visible>
+			<fieldset>
+				<legend>Restore</legend>
+				<div class="control-group">
+
+					<label class="control-label">Backup file</label>
+					<div class="controls">
+						<div class="modal-button-style">
+							<label for="restore_backupfile" id="choose+restore_backupfile" class="btn btn-primary btn-medium">Select</label>
+
+							<input type="file" id="restore_backupfile" accept=".zip" name="restore_backupfile" style="display:none" required>
+
+							<!-- <input type="file" id="restore_backupfile" accept=".zip" name="restore_backupfile" style="display:none" onchange="$('#btn-restore_backupfile').click();" >
+							<button id="btn-restore_backupfile" class="btn btn-medium btn-primary btn-submit" type="submit" name="restore_backup_file" value="1"  style="display:none"/> -->
+						</div>
+						<a aria-label="Help" class="info-toggle" data-cmd="info-restore_backupfile" href="#notarget"><i class="fas fa-info-circle"></i></a>
+						<div id="info-restore_backupfile" class="help-block-configs help-block-margin legend-info-help hide">
+								<b>Select/upload backup file to restore</b><br/>
+						</div>
+					</div>
+					<br/>
+
+					<label class="control-label">System Config</label>
+					<div class="controls">
+						$_togglebtn_restore_system
+						<span id="info-restore_system" class="help-block-configs help-block-margin legend-info-help hide">
+							<b>Restore system config, including backdrop image and script is present in backup.</b><br/>
+						</span>
+					</div>
+
+					<label class="control-label">CamillaDsp</label>
+					<div class="controls">
+						$_togglebtn_restore_camilladsp
+						<span id="info-restore_camilladsp" class="help-block-configs help-block-margin legend-info-help hide">
+							<b>Restore camilladsp pipeline configurations and ir files.</b><br/>
+						</span>
+					</div>
+
+					<label class="control-label">Radio Stations:</label>
+					<div class="controls">
+					</div>
+					<br/>
+
+					<label class="control-label">moOde</label>
+					<div class="controls">
+						$_togglebtn_restore_radiostations_moode
+						<span id="info-restore_radiostations_moode" class="help-block-configs help-block-margin legend-info-help hide">
+							<b>Restore moOde standard supplied radio stations.</b><br/>
+						</span>
+					</div>
+
+					<label class="control-label">Other</label>
+					<div class="controls">
+						$_togglebtn_restore_radiostations_other
+						<span id="info-restore_radiostations_other" class="help-block-configs help-block-margin legend-info-help hide">
+							<b>Restore user defined radio stations.</b><br/>
+						</span>
+					</div>
+
+					</div>
+					<br/>
+					<div class="control-group">
+						<div class="controls">
+							<!-- <a data-toggle="modal" href="#remove-coeff"><button class="btn btn-medium btn-primary">Delete</button></a>&nbsp;&nbsp; -->
+							<button class="btn btn-medium btn-primary btn-submit" type="submit" name="restore_start" form="restore" value="1">Start Restore</button>
+
+							<!-- <button id="btn-check-coeff" class="btn btn-medium btn-primary btn-submit" type="submit" name="info" value="1" style="display:none" >Info</button> -->
+							<a aria-label="Help" class="info-toggle" data-cmd="info-backup-restore" href="#notarget"><i class="fas fa-info-circle"></i></a>
+							<div id="info-backup-restore" class="help-block-configs help-block-margin legend-info-help hide">
+									<b>Start restore. If system is also restore an automatic reboot will be performed</b>
+							</div>
+						</div>
+					</div>
+			</fieldset>
+		</form>
+
+	</div>
+</div>
+

--- a/www/templates/backup.html
+++ b/www/templates/backup.html
@@ -23,7 +23,7 @@
 <div class="container">
 	<div class="container2">
 		<h1 class="cdsp-config">System Backup/Restore</h1>
-		<form class="form-horizontal" action="" method="post" id="backup" $_backup_visible >
+		<form class="form-horizontal" action="" method="post" id="backup" enctype="multipart/form-data" $_backup_visible >
 
 			<fieldset>
 				<legend>Backup</legend>
@@ -84,8 +84,7 @@
 					<div class="controls">
 						<div class="modal-button-style">
 							<label for="backup_scriptfile" id="choose-backup_scriptfile" class="btn btn-primary btn-medium">Select</label>
-							<input type="file" id="backup_scriptfile" accept=".wav,.txt,.raw,.csv" name="backup_scriptfile" style="display:none" onchange="$('#btn-backup_scriptfile').click();" disabled>
-							<button id="btn-backup_scriptfile" class="btn btn-medium btn-primary btn-submit" type="submit" name="backup_scriptfile" value="1"  style="display:none" disabled/>
+							<input type="file" id="backup_scriptfile" accept=".*,*.*,*" name="backup_scriptfile" style="display:none" >
 						</div>&nbsp;&nbsp;
 						<a aria-label="Help" class="info-toggle" data-cmd="info-backup_scriptfile" href="#notarget"><i class="fas fa-info-circle"></i></a>
 						<div id="info-backup_scriptfile" class="help-block-configs help-block-margin legend-info-help hide">


### PR DESCRIPTION
@moodeaudio @TheOldPresbyope 

Still missing is:

- ~~The implementation to upload script and set wlanip (is already in the backupmanager and is there in the gui but disabled, until php backend is also implemented)~~.
- Forcing correct file rights after restore if required
- Integration into the system gui of moode, two urls available for backup and restore interface:
  - http://moode?action=backup
  - http://moode?action=restore

http://moode?action=backup preview:

![image](https://user-images.githubusercontent.com/1525169/126911227-23324c30-1c15-411a-8677-cac2976d656a.png)

http://moode?action=restore preview:
![image](https://user-images.githubusercontent.com/1525169/126911218-2e3863ec-c0bc-4514-a7e6-1926c6db56bd.png)

With testing the restore mechanisms be aware that you can loose stuff (well you will have it in the backup, but it can't be restored until fixed ;-) if there are still issue with the restore implementation.
