### PR TITLE
[autocfggen] fix hang when (indirect) called from web interface

### DIFF
--- a/www/command/autocfggen.php
+++ b/www/command/autocfggen.php
@@ -29,8 +29,13 @@
 
 require_once dirname(__FILE__) . '/../inc/playerlib.php';
 
-playerSession('open', '' ,'');
-session_write_close();
+$_SESSION = [];
+$dbh  = cfgdb_connect();
+$params = cfgdb_read('cfg_system', $dbh);
+
+foreach ($params as $row) {
+  $_SESSION[$row['param']] = $row['value'];
+}
 
 print(autoconfigExtract());
 ?>


### PR DESCRIPTION
Replaced playerSession with direc read of the db instead.