### PR TITLE
[camilladsp] Quick select of camilladsp configuration in top header

### DIFF
--- a/www/command/moode.php
+++ b/www/command/moode.php
@@ -822,6 +822,29 @@ else {
 		case 'clientip':
 			echo json_encode($_SERVER['REMOTE_ADDR']);
 			break;
+
+		case 'camilladsp_setconfig':
+			if ( isset($_POST['cdspconfig']) ) {
+				require_once dirname(__FILE__) . '/../inc/cdsp.php';
+				$cdsp = new CamillaDsp($_SESSION['camilladsp'], $_SESSION['cardnum'], $_SESSION['camilladsp_quickconv']);
+				$currentMode = $_SESSION['camilladsp'];
+				$newMode = $_POST['cdspconfig'];
+				playerSession('write', 'camilladsp', $newMode);
+				$cdsp->selectConfig($newMode);
+				if ($_SESSION['cdsp_fix_playback'] == 'Yes' ) {
+					$cdsp->setPlaybackDevice($_SESSION['cardnum'], $_SESSION['alsa_output_mode']);
+				}
+
+				if ( $_SESSION['camilladsp'] != $currentMode && ( $_SESSION['camilladsp'] == 'off' || $currentMode == 'off')) {
+					submitJob('camilladsp', $newMode, 'CamillaDSP ' . $cdsp->getConfigLabel($newMode), '');
+				} else {
+					$cdsp->reloadConfig();
+				}
+			}
+			else {
+				$msg = 'Error: missing camilladsp config name';
+			}
+			break;
 	}
 }
 

--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -105,7 +105,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 .help-block-modal {margin:0 !important;}
 /* dropdown menus */
 #menu-top .dropdown-menu, .viewswitch .dropdown-menu {min-width:15rem;} /* Make this one a bit wider */
-#current-tab, #menu-header {font-size:1em;}
+#current-tab, #menu-header, #menu-cdsp {font-size:1em;}
 .dropdown-menu > li > a, .viewswitch .btn {text-align:left;line-height:2.75rem;margin:0;padding:0 .5em;background:none;color:var(--adapttext);font-size:1em;font-family:system-ui, "Avenir Next", "Lato";white-space:nowrap;border-radius:0;}
 /*body.no-touch .dropdown-menu > li > a {font-size:1rem;line-height:2em}*/
 .dropdown-menu > li:last-child a, .viewswitch .btn:last-child {padding-bottom:.35em;}
@@ -254,7 +254,7 @@ li.modal-dropdown-text:focus {color:#eee;}
 	/*.dropdown-menu {min-width:180px;}*/
 	#menu-top .dropdown-menu, .viewswitch .dropdown-menu {min-width:16rem;} /* Make this one a bit wider */
 	#context-menu-playback .dropdown-menu {min-width:15rem;} /* Make this one a bit wider */
-	#lib-album-search input, #lib-album-search input, #current-tab, #menu-header {font-size:1.11rem;}
+	#lib-album-search input, #lib-album-search input, #current-tab, #menu-header, #menu-cdsp {font-size:1.11rem;}
 	.dropdown-menu > li > a, .viewswitch .btn {font-size:1.16rem;line-height:2.75em;}
 	#playback-panel, #content {position:relative;}
 	.modal-body{padding:0 .75rem;max-height:80vh;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -54,7 +54,7 @@ html, body {background-attachment:fixed;background-size:cover;height:100%;color:
 	--npicon: url('../images/4band-npicon/audiow.svg');
 }
 
-.btn, .lib-entry, .dropdown, #menu-header, div#playbar-title, #coverart-url {-webkit-tap-highlight-color: rgba(0, 0, 0, 0);-webkit-user-select: none;-webkit-touch-callout: none;}
+.btn, .lib-entry, .dropdown, #menu-header, #menu-cdsp, div#playbar-title, #coverart-url {-webkit-tap-highlight-color: rgba(0, 0, 0, 0);-webkit-user-select: none;-webkit-touch-callout: none;}
 .btn:active {color:var(--textvariant);} /* this needs to be a separate rule */
 
 html {background-color:inherit;}
@@ -314,6 +314,7 @@ img.coverart {border-style:none;border-radius:.1em;box-shadow:0 .1em .2em rgba(3
 .viewswitch .btn.no-icon {padding-left:1rem;}
 #current-tab {font-size:1.1rem;font-weight:600;height:2.75rem;line-height:2.75rem;}
 #current-tab i {font-size:.7rem;margin-left:2px;}
+#menu-dsp {font-size:.7rem;margin-left:2px;}
 .ui-pnotify {font-size:1.1rem;top:33%;left:50%;transform:translate(-50%, -50%);box-shadow:0px 2px 10px rgba(50, 50, 50, 0.5)}
 .ui-pnotify .ui-pnotify-shadow {-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none;}
 .ui-pnotify-container {background-position:0 0;padding:2em;backdrop-filter: blur(5px);-webkit-backdrop-filter: blur(5px);height: 100%;margin: 0;border-radius:.75em;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -167,6 +167,7 @@ html {background-color:inherit;}
 #mbrand, #mblur {font-weight:600;position:absolute;left:50%;top:-.25rem;}
 #mbrand {color:var(--adapttext);text-shadow: 0 0 0.25rem rgba(0,0,0,0.5);transform:translate(-50%);}
 #mblur {letter-spacing:-.56em;color:transparent;text-shadow:0 0 2px var(--btnshade4);transform:translate(calc(-50% - .28em));opacity:.75;}
+#dropdown-cdsp {right: 4em !important;}
 #menu-settings i {color:var(--accentxts);font-size:.65em;}
 #menu-bottom {/*display:flex;*/bottom:.2rem;bottom:calc(env(safe-area-inset-bottom) + .2rem);width:40%;margin:0 auto;background-color:transparent;color:inherit;z-index:990;line-height:normal;font-size:inherit;backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);}
 #menu-bottom ul {display:flex;margin:0;width:100%;}

--- a/www/header.php
+++ b/www/header.php
@@ -182,8 +182,8 @@
 			<ul class="dropdown-menu" role="menu" aria-labelledby="menu-settings_x">
 					<?php
 					foreach ($cdsp_configs as $config_file=>$config_name) {
-						$fa_selected = ($_SESSION['camilladsp'] == $config_file) ? 'fa-volume-up ' : '';
-						echo '<li class="context-menu"><a href="#notarget" data-cmd="camilladsp_config" data-cdspconfig="'.$config_file.'" data-cdsplabel="'.$config_name.'"><i class="fas ' . $fa_selected . 'sx"></i>'.$config_name.'</a></li>';
+						$fa_selected = ($_SESSION['camilladsp'] == $config_file) ? 'fa-check' : '';
+						echo '<li class="context-menu"><a href="#notarget" data-cmd="camilladsp_config" data-cdspconfig="'.$config_file.'" data-cdsplabel="'.$config_name.'"><i class="fal ' . $fa_selected . '"></i>'.$config_name.'</a></li>';
 					}
 					?>
 			</ul>

--- a/www/header.php
+++ b/www/header.php
@@ -164,7 +164,35 @@
 
 		<div id="menu-header"></div>
         <div id="multiroom-sender" class="context-menu"><a class="btn" href="#notarget" data-cmd="multiroom-rx-modal"><i class="fas fa-rss"></i></a></div>
-        <div aria-label="Busy" class="busy-spinner"><svg xmlns='http://www.w3.org/2000/svg' width='42' height='42' viewBox='0 0 42 42' stroke='#fff'><g fill='none' fill-rule='evenodd'><g transform='translate(3 3)' stroke-width='4'><circle stroke-opacity='.35' cx='18' cy='18' r='18'/><path d='M36 18c0-9.94-8.06-18-18-18'><animateTransform attributeName='transform' type='rotate' from='0 18 18' to='360 18 18' dur='1s' repeatCount='indefinite'/></path></g></g></svg></div>
+
+
+		<?php
+			if ($section == 'index' && $_SESSION['camilladsp'] != "off") {
+				require_once dirname(__FILE__) . '/inc/cdsp.php';
+				$cdsp = new CamillaDsp($_SESSION['camilladsp'], $_SESSION['cardnum'], $_SESSION['camilladsp_quickconv']);
+				$cdsp_configs = $cdsp->getAvailableConfigs();
+				$select_config_label = $cdsp_configs[$_SESSION['camilladsp']];
+		?>
+		<div class="dropdown" id="dropdown-cdsp">
+			<a aria-label="Menu" class="dropdown-toggle btn" id="menu-cdsp" role="button" data-toggle="dropdown" data-target="#" href="#notarget">
+				<?php
+				echo '<div id="mcdsp">' . $select_config_label . '</div>';
+				?>
+			</a>
+			<ul class="dropdown-menu" role="menu" aria-labelledby="menu-settings_x">
+					<?php
+					foreach ($cdsp_configs as $config_file=>$config_name) {
+						$fa_selected = ($_SESSION['camilladsp'] == $config_file) ? 'fa-volume-up ' : '';
+						echo '<li class="context-menu"><a href="#notarget" data-cmd="camilladsp_config" data-cdspconfig="'.$config_file.'" data-cdsplabel="'.$config_name.'"><i class="fas ' . $fa_selected . 'sx"></i>'.$config_name.'</a></li>';
+					}
+					?>
+			</ul>
+		</div>
+		<?php
+			}
+		?>
+
+		<div aria-label="Busy" class="busy-spinner"><svg xmlns='http://www.w3.org/2000/svg' width='42' height='42' viewBox='0 0 42 42' stroke='#fff'><g fill='none' fill-rule='evenodd'><g transform='translate(3 3)' stroke-width='4'><circle stroke-opacity='.35' cx='18' cy='18' r='18'/><path d='M36 18c0-9.94-8.06-18-18-18'><animateTransform attributeName='transform' type='rotate' from='0 18 18' to='360 18 18' dur='1s' repeatCount='indefinite'/></path></g></g></svg></div>
 
 		<!-- MAIN MENU -->
 		<div class="dropdown">

--- a/www/header.php
+++ b/www/header.php
@@ -174,10 +174,11 @@
 				$select_config_label = $cdsp_configs[$_SESSION['camilladsp']];
 		?>
 		<div class="dropdown" id="dropdown-cdsp">
-			<a aria-label="Menu" class="dropdown-toggle btn" id="menu-cdsp" role="button" data-toggle="dropdown" data-target="#" href="#notarget">
+			<a aria-label="Menu" style="display:none;" class="dropdown-toggle btn" id="menu-cdsp" role="button" data-toggle="dropdown" data-target="#" href="#notarget">
 				<?php
-				echo '<div id="mcdsp">' . $select_config_label . '</div>';
+				echo $select_config_label;
 				?>
+				<i class="fas fa-chevron-down"></i>
 			</a>
 			<ul class="dropdown-menu" role="menu" aria-labelledby="menu-settings_x">
 					<?php

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -2308,6 +2308,27 @@ $(document).on('click', '.context-menu a', function(e) {
             }, 'json');
         }
 	}
+	else if ($(this).data('cmd') == 'camilladsp_config') {
+		console.log("selected camilladsp config "+ $(this).data('cdspconfig'));
+		var selected_config = $(this).data('cdspconfig'),
+		    selected_label = $(this).data('cdsplabel');
+
+		$.ajax({
+			type: 'POST',
+			url: 'command/moode.php?cmd=camilladsp_setconfig',
+			async: true,
+			cache: false,
+			data: {'cdspconfig': selected_config } ,
+			success: function(result) {
+				$('#mcdsp').html(selected_label);
+				$(".fa-volume-up").attr('class', 'fas sx'); // reset active indicator in list
+				$("a[data-cdspconfig='"+selected_config+"'] .fas").attr('class', 'fas fa-volume-up sx'); // set active indicator in list
+			},
+			error: function() {
+				debugLog('camilladsp_setconfig "' + $(this).data('cdspconfig') + '" failed');
+			}
+		});
+	}
 
 	// MAIN MENU
 

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -1727,6 +1727,7 @@ function renderRadioView() {
 		element.innerHTML = output;
 		if (currentView == 'radio') lazyLode('radio');
 
+		if (currentView.indexOf('playback') != -1 ) $('#menu-cdsp').show();
     });
 }
 
@@ -2320,7 +2321,7 @@ $(document).on('click', '.context-menu a', function(e) {
 			cache: false,
 			data: {'cdspconfig': selected_config } ,
 			success: function(result) {
-				$('#mcdsp').html(selected_label);
+				$('#menu-cdsp').html(selected_label+'<i class="fas fa-chevron-down"></i>');
 				$("a[data-cdspconfig] .fa-check").attr('class', 'fal'); // reset active indicator in list
 				$("a[data-cdspconfig='"+selected_config+"'] .fal").attr('class', 'fal fa-check'); // set active indicator in list
 			},
@@ -3459,7 +3460,7 @@ $('#coverart-url, #playback-switch').click(function(e){
 	$('#menu-top').css('backdrop-filter', '');
 	$('#menu-bottom, .viewswitch').css('display', 'flex');
     $('#multiroom-sender').hide();
-
+	$('#menu-cdsp').hide();
     syncTimers();
 
 	if (currentView == 'tag') {
@@ -3520,6 +3521,7 @@ $('#playbar-switch, #playbar-cover, #playbar-title').click(function(e){
 		$('#playback-controls').css('display', '');
         $('#addfav-li').hide();
         SESSION.json['multiroom_tx'] == 'On' ? $('#multiroom-sender').show() : $('#multiroom-sender').hide();
+		$('#menu-cdsp').show();
 		if (UI.mobile) {
             // Make sure playlist is hidden and controls are showing
 			showMenuTopW = false;

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -2321,8 +2321,8 @@ $(document).on('click', '.context-menu a', function(e) {
 			data: {'cdspconfig': selected_config } ,
 			success: function(result) {
 				$('#mcdsp').html(selected_label);
-				$(".fa-volume-up").attr('class', 'fas sx'); // reset active indicator in list
-				$("a[data-cdspconfig='"+selected_config+"'] .fas").attr('class', 'fas fa-volume-up sx'); // set active indicator in list
+				$("a[data-cdspconfig] .fa-check").attr('class', 'fal'); // reset active indicator in list
+				$("a[data-cdspconfig='"+selected_config+"'] .fal").attr('class', 'fal fa-check'); // set active indicator in list
 			},
 			error: function() {
 				debugLog('camilladsp_setconfig "' + $(this).data('cdspconfig') + '" failed');


### PR DESCRIPTION
**Case:**
On my main listing system I use multiple headphones and speakers.
Each uses one or more camilladsp configs. Before start listing I want to know which config is active and if needed swich to/between different configs.

**Usage:**

When camilladsp is turned off everything is still the same.

But when CamillaDSP is turned on the name of the configuration appear on top left fromthe main menu:

![image](https://user-images.githubusercontent.com/1525169/133924531-80a5c062-5271-4a12-acf3-ed41c132cd93.png)

When you click the config a popup menu appears where you can select a different config (current active is indicated with a speaker icon):

![image](https://user-images.githubusercontent.com/1525169/133924544-719b0921-bd71-408c-b499-b45712211903.png)

When switching between configs the change is almost right away.

