### PR TITLE
fixed donate URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ moOde provides a beautifully designed and responsive user interface, an extensiv
 
 Take a moment to consider making a donation via PayPal. The financial support helps our project remain active so we can continue to provide great software to the wonderful Raspberry Pi audio community.
 
-[![button](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/donate?token=x9E3-KenEsFEG8NxhTgu_0ZWaz_YniISrPH6SkNA7LR0UahIZvD4aSidDbr2i4etPGcQ2plNtZFGh1eI)
+[![button](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/donate?token=2uEyi9fcuMrYEyNpIMY9yoXF_iwjWB2f5tPXJUjhDcBKTpNEqLv2txPyLR724c6oSYZLlbjjCFHkCPuA)
 
 Tim Curtis © 2014
 


### PR DESCRIPTION
I noticed the donate URL on the readme.md was not valid.  Found a valid URL on the moode audio forums and thought I would update the readme.