### PR TITLE
Added powersave governor.

### DIFF
--- a/www/sys-config.php
+++ b/www/sys-config.php
@@ -329,6 +329,7 @@ $_select['browsertitle'] = $_SESSION['browsertitle'];
 // SYSTEM MODIFICATIONS
 
 // CPU governor
+$_select['cpugov'] .= "<option value=\"powersave\" " . (($_SESSION['cpugov'] == 'powersave') ? "selected" : "") . ">PowerSave</option>\n";
 $_select['cpugov'] .= "<option value=\"ondemand\" " . (($_SESSION['cpugov'] == 'ondemand') ? "selected" : "") . ">On-demand</option>\n";
 $_select['cpugov'] .= "<option value=\"performance\" " . (($_SESSION['cpugov'] == 'performance') ? "selected" : "") . ">Performance</option>\n";
 

--- a/www/templates/sys-config.html
+++ b/www/templates/sys-config.html
@@ -81,6 +81,7 @@
 					<button class="btn btn-primary btn-small set-button btn-submit" type="submit" name="update_cpugov" value="novalue">Set</button>
 					<a aria-label="Help" class="info-toggle" data-cmd="info-cpugov" href="#notarget"><i class="fas fa-info-circle"></i></a>
 					<span id="info-cpugov" class="help-block-configs help-block-margin hide">
+						<b>PowerSave:</b> Run the CPU at the minimum frequency.<br>
 						<b>On-demand:</b> Scale CPU frequency from min to max based on load.<br>
 						<b>Performance:</b> Run the CPU at max frequency.<br>
 					</span>


### PR DESCRIPTION
I have my moode installed on a rpi3 which is connected to a 5V/0.5A power source. I use it because is very low noise power source and is also very convenient. It works fine 99% of the time while listening high-res files, but when I try to update volumio and the CPU usage goes high files on the SD-card get corrupted because of insufficient power. 
Limiting the multiplier to it's minimum solves this issue for me, but is very annoying to configure it manually and setup a crontab to overwrite the moode configuration. So I added the powersave config on the System Config to have a fast solution to whoever incurs in SD card data corruption due to low current power source.
It also heats less and 600Mhz are more than enough to handle all the workloads in moode.
I don't have the time to test it, please give it a try.
Cheers 