### PR TITLE
[autocfg] fix multiroom backwards compatibility

### DIFF
--- a/www/inc/autocfg.php
+++ b/www/inc/autocfg.php
@@ -170,14 +170,14 @@ function autoConfigSettings() {
 		'Multiroom',
 		['requires' => ['multiroom_tx'], 'handler' => setPlayerSession],
 		['requires' => ['multiroom_rx'], 'handler' => setPlayerSession],
-		['requires' => ['multiroom_tx_bfr', 'multiroom_tx_host', 'multiroom_tx_port', 'multiroom_tx_sample_rate', 'multiroom_tx_channels',
-			'multiroom_tx_frame_size', 'multiroom_tx_bitrate', 'multiroom_tx_rtprio', 'multiroom_tx_query_timeout',
-			'multiroom_rx_bfr', 'multiroom_rx_host', 'multiroom_rx_port', 'multiroom_rx_sample_rate', 'multiroom_rx_channels', 'multiroom_rx_jitter_bfr',
-			'multiroom_rx_frame_size', 'multiroom_rx_rtprio', 'multiroom_rx_alsa_output_mode', 'multiroom_rx_mastervol_opt_in', 'multiroom_initial_volume'],
-			'handler' => function($optionals) {
-				setDbParams('cfg_multiroom', $optionals, 'multiroom_');
-			}, 'custom_write' => function($optionals) {
-				return getDbParams('cfg_multiroom', $optionals, 'multiroom_');				
+		['requires' => ['multiroom_tx_bfr', 'multiroom_tx_host', 'multiroom_tx_port', 'multiroom_tx_sample_rate', 'multiroom_tx_channels', 'multiroom_tx_frame_size', 'multiroom_tx_bitrate',
+					    'multiroom_rx_bfr', 'multiroom_rx_host', 'multiroom_rx_port',  'multiroom_rx_jitter_bfr', 'multiroom_rx_sample_rate', 'multiroom_rx_channels', 'multiroom_initial_volume'],
+         'optionals' => ['multiroom_tx_rtprio', 'multiroom_tx_query_timeout', 'multiroom_rx_frame_size', 'multiroom_rx_rtprio', 'multiroom_rx_alsa_output_mode', 'multiroom_rx_mastervol_opt_in', 'multiroom_initial_volume'],
+			'handler' => function($values, $optionals) {
+				$mergedValues = array_merge($values, $optionals);
+				setDbParams('cfg_multiroom', $mergedValues, 'multiroom_');
+			}, 'custom_write' => function($values) {
+				return getDbParams('cfg_multiroom', $values, 'multiroom_');
 		}],
 
 		'MPD',


### PR DESCRIPTION
Because adding the new setting to the requires will break backward compatibility of already create backup files.
By moving the new settings to the optionals if will accept older backup files. A newer backup with the new settings will use the optionals to handle the new settings. The export with contain both requires + optional settings. 