### PR TITLE
Enable optional Spotify/librespot login

### DIFF
--- a/boot/moodecfg.ini.default
+++ b/boot/moodecfg.ini.default
@@ -187,6 +187,8 @@ spotify_normalization_knee = "1"
 spotify_format = "S16"
 spotify_dither = ""
 spotify_volume_range = "60"
+spotify_username = ""
+spotify_password = ""
 
 [Squeezelite]
 squeezelite_PLAYERNAME = "Moode"

--- a/var/local/www/db/moode-sqlite3.db.sql
+++ b/var/local/www/db/moode-sqlite3.db.sql
@@ -477,6 +477,8 @@ INSERT INTO cfg_spotify (id, param, value) VALUES (12, 'normalization_knee', '1'
 INSERT INTO cfg_spotify (id, param, value) VALUES (13, 'format', 'S16');
 INSERT INTO cfg_spotify (id, param, value) VALUES (14, 'dither', '');
 INSERT INTO cfg_spotify (id, param, value) VALUES (15, 'volume_range', '60');
+INSERT INTO cfg_spotify (id, param, value) VALUES (16, 'username', '');
+INSERT INTO cfg_spotify (id, param, value) VALUES (17, 'password', '');
 
 -- Table: cfg_network
 CREATE TABLE cfg_network (id INTEGER PRIMARY KEY, iface CHAR (5), method CHAR (6), ipaddr CHAR (15), netmask CHAR (15), gateway CHAR (15), pridns CHAR (15), secdns CHAR (15), wlanssid CHAR (32), wlansec CHAR (4), wlanpwd CHAR (64), wlan_psk CHAR (64), wlan_country CHAR (2), wlan_channel CHAR (3));

--- a/www/inc/autocfg.php
+++ b/www/inc/autocfg.php
@@ -294,7 +294,7 @@ function autoConfigSettings() {
 		['requires' => ['spotify_bitrate', 'spotify_initial_volume', 'spotify_volume_curve', 'spotify_volume_normalization', 'spotify_normalization_pregain',
 			'spotify_autoplay'],
 			'optionals' => ['spotify_normalization_method', 'spotify_normalization_gain_type', 'spotify_normalization_threshold','spotify_normalization_attack',
-			'spotify_normalization_release', 'spotify_normalization_knee', 'spotify_format', 'spotify_dither', 'spotify_volume_range'],
+			'spotify_normalization_release', 'spotify_normalization_knee', 'spotify_format', 'spotify_dither', 'spotify_volume_range', 'spotify_username', 'spotify_password'],
 			'handler' => function($values, $optionals) {
 				$mergedValues = array_merge($values, $optionals);
 				setDbParams('cfg_spotify', $mergedValues, 'spotify_');

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -2689,10 +2689,18 @@ function startSpotify() {
 		' --normalisation-knee ' . $cfg_spotify['normalization_knee']
 		: '';
 	$autoplay = $cfg_spotify['autoplay'] == 'Yes' ? ' --autoplay' : '';
+	
+	if (!empty($cfg_spotify['username']) && !empty($cfg_spotify['password'])) {
+		$credentials = ' --username ' . $cfg_spotify['username'] . ' --password ' . $cfg_spotify['password'];
+	} else {
+		$credentials = ''; // Could use ternary operator, but this seems easier to read
+	}
+	// End of Options
 
- 	// NOTE: We use --disable-audio-cache because the audio file cache eats disk space.
+	// Build command arguments. NOTE: We use --disable-audio-cache because the audio file cache eats disk space.
 	$cmd = 'librespot' .
 		' --name "' . $_SESSION['spotifyname'] . '"' .
+		$credentials .
 		' --bitrate ' . $cfg_spotify['bitrate'] .
 		' --format ' . $cfg_spotify['format'] .
 		$dither .

--- a/www/spo-config.php
+++ b/www/spo-config.php
@@ -82,6 +82,9 @@ $_select['normalization_threshold'] = $cfg_spotify['normalization_threshold'];
 $_select['normalization_attack'] = $cfg_spotify['normalization_attack'];
 $_select['normalization_release'] = $cfg_spotify['normalization_release'];
 $_select['normalization_knee'] = $cfg_spotify['normalization_knee'];
+// Login credentials
+$_select['username'] = $cfg_spotify['username'];
+$_select['password'] = $cfg_spotify['password'];
 // Autoplay after playlist completes
 $_select['autoplay'] .= "<option value=\"Yes\" " . (($cfg_spotify['autoplay'] == 'Yes') ? "selected" : "") . ">Yes</option>\n";
 $_select['autoplay'] .= "<option value=\"No\" " . (($cfg_spotify['autoplay'] == 'No') ? "selected" : "") . ">No</option>\n";

--- a/www/templates/spo-config.html
+++ b/www/templates/spo-config.html
@@ -155,6 +155,23 @@
 			</div>
 
 			<div class="control-group">
+				<label class="control-label" for="username">Username</label>
+				<div class="controls">
+					<input class="input-large" type="text" id="username" name="config[username]" value="$_select[username]">
+					<a aria-label="Help" class="info-toggle" data-cmd="info_username" href="#notarget"><i class="fas fa-info-circle"></i></a>
+					<span id="info_username" class="help-block-configs help-block-margin hide">
+						Your Spotify credentials; this helps with "local discovery" and can enable remote playback. (For facebook-based login, set a <a href="https://www.spotify.com/account/set-device-password/" target="_blank">device password</a>)
+                    </span>
+				</div>
+			</div>
+			<div class="control-group">
+				<label class="control-label" for="password">Password</label>
+				<div class="controls">
+					<input class="input-large" type="password" name="config[password]" value="$_select[password]">
+				</div>
+			</div>
+
+			<div class="control-group">
 				<label class="control-label" for="autoplay">Autoplay</label>
 				<div class="controls">
 					<select id="autoplay" class="input-large" name="config[autoplay]">


### PR DESCRIPTION
## Overview

Add config options in Spotify to allow login

## Details
This configuration change *should* be all that's needed to enable [librespot](https://github.com/librespot-org/librespot) (the Spotify Connect client) to support user logins. This helps in situations where the local discovery service isn't working, and also (I believe) allows for "remote access" playback. (Tested here with a device accidentally on the wrong wifi network!)

## WARNING

It's a huge faux-pas, but I have **not** tested this! I repeat: **I have not tested this code!** It's borderline-trivial, but, I wanted to put in this PR before investing time in the testing process, in case the PR in general isn't considered worthwhile, adequate, etc.  (I have tested the generated command-line itself, and, the credential caching works well - and your code already handles optionally clearing it!)