### PR TITLE
Always generate mpd.conf on startup of worker

### DIFF
--- a/www/command/worker.php
+++ b/www/command/worker.php
@@ -335,21 +335,28 @@ else {
 workerLog('worker: -- Audio config');
 //
 
+$ignoreUpdateMpdDevice = False; // when true ignore update device, only generate mpd conf
 // Update MPD config
 if ($_SESSION['multiroom_tx'] == 'Off') {
 	// NOTE: Only do this for I2S (non-hotplug devices) or if in-place update applied
 	if ($_SESSION['i2sdevice'] != 'None' || $_SESSION['i2soverlay'] != 'None' || $_SESSION['inplace_upd_applied'] == '1') {
-		updMpdConf($_SESSION['i2sdevice']);
+		$ignoreUpdateMpdDevice = False;
 		$mpd_conf_upd_msg = 'MPD conf updated';
 		playerSession('write', 'inplace_upd_applied', '0');
 	}
 	else {
-		$mpd_conf_upd_msg = 'MPD conf update skipped (USB device)';
+		$ignoreUpdateMpdDevice = True;
+		updMpdConf($_SESSION['i2sdevice'], True);
+		$mpd_conf_upd_msg = 'MPD conf updated, device update skipped (USB device)';
 	}
 }
 else {
 	$mpd_conf_upd_msg = 'MPD conf update skipped (Tx On)';
+	$ignoreUpdateMpdDevice = True;
 }
+updMpdConf($_SESSION['i2sdevice'], $updateMpdDevice);
+
+
 workerLog('worker: ' . $mpd_conf_upd_msg);
 
 // Ensure audio output is unmuted for these devices

--- a/www/inc/playerlib.php
+++ b/www/inc/playerlib.php
@@ -1887,7 +1887,7 @@ function sdbquery($querystr, $dbh) {
 	}
 }
 
-function updMpdConf($i2sdevice) {
+function updMpdConf($i2sdevice, $ignoreNotFoundDevice = False) {
 	$mpdcfg = sdbquery("SELECT param, value FROM cfg_mpd WHERE value!=''", cfgdb_connect());
 	$patch_id = explode('_p0x', $_SESSION['mpdver'])[1];
 
@@ -1979,7 +1979,11 @@ function updMpdConf($i2sdevice) {
 	playerSession('write', 'amixname', getMixerName($i2sdevice));
 	$adevname = ($_SESSION['i2sdevice'] == 'None' && $_SESSION['i2soverlay'] == 'None') ? getDeviceNames()[$cardnum] :
 		($_SESSION['i2sdevice'] != 'None' ? $_SESSION['i2sdevice'] : $_SESSION['i2soverlay']);
-	playerSession('write', 'adevname', $adevname);
+
+	if ( $adevname != '' || $ignoreNotFoundDevice == False ) {
+		playerSession('write', 'adevname', $adevname);
+	}
+
 	$hwmixer = $mixertype == 'hardware' ? getMixerName($i2sdevice) : '';
 
 	$result = sysCmd('/var/www/command/util.sh get-alsavol ' . '"' . $_SESSION['amixname'] . '"');


### PR DESCRIPTION
This makes it possible to:
* Not need any long to  provide a default mpd.conf
* Also always have an up2date config (after a backup restore)
* Restore the functionality of Developer tweaks(mpd config merge) again

But also skip device handling when USB is used to not break the USB device handling.