### PR TITLE
Add IPv6 listen directive to the nginx config

### DIFF
--- a/etc/nginx/nginx.overwrite.conf
+++ b/etc/nginx/nginx.overwrite.conf
@@ -69,6 +69,7 @@ http {
 
 	server {
 		listen 80;
+		listen [::]:80;
 
 		location / {
 			root /var/www;


### PR DESCRIPTION
The current configuration does not bind to port 80 for IPv6 interfaces. Adding a new listen directive for IPv6 will allow this server to better function in a dual-stack environment.