### PR TITLE
Fix flac coverart may not be displayed

### DIFF
--- a/www/inc/Zend/Media/Flac.php
+++ b/www/inc/Zend/Media/Flac.php
@@ -67,6 +67,9 @@ final class Zend_Media_Flac
     /** The picture metadata block */
     const PICTURE        = 6;
 
+    /** The invalid metadata block */
+    const INVALID	 = 127;
+
     /** @var Zend_Io_Reader */
     private $_reader;
 
@@ -113,9 +116,6 @@ final class Zend_Media_Flac
             throw new Zend_Media_Flac_Exception('Not a valid FLAC bitstream');
         }
 
-		// r44d failsafe to prevent corrupt header from causing endless loop
-		$count = 1;
-
         while (true) {
             $offset = $this->_reader->getOffset();
             $last = ($tmp = $this->_reader->readUInt8()) >> 7 & 0x1;
@@ -161,18 +161,22 @@ final class Zend_Media_Flac
             default:
                 // break intentionally omitted
             }
+
+            // Failsafe to prevent corrupt header from causing endless loop
+            // Exit loop if invalid type was found
+            if($type == self::INVALID) {
+                break;
+            }
+            // Exit loop if next offset is out of file
+            else if($this->_reader->getSize() < ($offset + 4 /* header */ + $size)) {
+                break;
+            }
             $this->_reader->setOffset($offset + 4 /* header */ + $size);
 
             // Jump off the loop if we reached the end of metadata blocks
             if ($last === 1) {
                 break;
             }
-
-			// r44d exit loop if > 7 iterations
-			$count++;
-			if ($count > 7) {
-                break;
-			}
         }
     }
 


### PR DESCRIPTION
This PR fixes following problem.

### Problem:
Flac coverart may not be displayed.

### moOde Version
Release 8.1.2

### Environment
Raspi: Pi-3B 1.2 1GB
Audio: Pi HDMI 1

### How to reproduce:
Play flac file that have 7 or more metadata block before PICTURE metablock.

### Detail of changes:
To prevent corrupt header from causing endless loop, only first 7 metadata blocks are processed and others are ignored here:
https://github.com/moode-player/moode/blob/0fbbe1e76cbfcfa2a2c1d44ecb99398b0123de18/www/inc/Zend/Media/Flac.php#L171-L175
but sometimes flac has multiple APPLICATION metadata block like this
```
[STREAMINFO]
[VORBIS_COMMENT]
[SEEKTABLE]
[APPLICATION]
[APPLICATION]
[APPLICATION]
[APPLICATION]
[APPLICATION]
[PICTURE]
[PADDING]
```
This is not corrupted flac and compatible with flac specification.

So I made changes instead of counting metadata block to prevent endless loop with coruupted files.

- Check whether metadata indicates 'invalid'.
According to the flac specification, BLOCK_TYPE 127 indicates 'invalid' to avoid confution with a frame sync code.
So if metadata block type was 127, the flac is able to be regarded as corrupted file.

- Check whether current file offset is in the file.
If Last-metadata-block flag is still 0 until the end of file, the flac is able to be regarded as corrupted file.

### Effect:
Coverart is displayed when playing flac file that have 7 or more metadata block before PICTURE metablock. 
