### PR TITLE
Fix librespot volume_range max value.

### DIFF
--- a/www/templates/spo-config.html
+++ b/www/templates/spo-config.html
@@ -70,10 +70,10 @@
 				</div>
 				<label class="control-label" for="volume_range">Volume range (dB)</label>
 				<div class="controls">
-					<input class="input-large" type="number" min="0" max="120" id="volume_range" name="config[volume_range]" value="$_select[volume_range]" required>
+					<input class="input-large" type="number" min="0" max="100" id="volume_range" name="config[volume_range]" value="$_select[volume_range]" required>
 					<a aria-label="Help" class="info-toggle" data-cmd="info_volume_range" href="#notarget"><i class="fas fa-info-circle"></i></a>
 					<span id="info_volume_range" class="help-block-configs help-block-margin hide">
-						Range of the volume control in dB from 0-120. Default is 60. This setting is used to adjust the steepness of the volume curve and influences the usable range of the volume slider.
+						Range of the volume control in dB from 0-100. Default is 60. This setting is used to adjust the steepness of the volume curve and influences the usable range of the volume slider.
                     </span>
 				</div>
 			</div>


### PR DESCRIPTION
Making fix to match librespot's [volume_range max value](https://github.com/librespot-org/librespot/blob/dev/src/main.rs#L325). If entering value more than 100 in moOde's settings, librespot will fail to open. 