### PR TITLE
Fix artist may be displayed as undefined or null

### DIFF
--- a/www/inc/mpd.php
+++ b/www/inc/mpd.php
@@ -663,6 +663,7 @@ function enhanceMetadata($current, $sock, $caller = '') {
 		} else {
 			// Song file, UPnP URL or Podcast
 			$current['artist'] = isset($song['Artist']) ? $song['Artist'] : 'Unknown artist';
+			$current['albumartist'] = isset($song['AlbumArtist']) ? $song['AlbumArtist'] : 'Unknown artist';
 			$current['title'] = isset($song['Title']) ? $song['Title'] : pathinfo(basename($song['file']), PATHINFO_FILENAME);
 			$current['album'] = isset($song['Album']) ? htmlspecialchars($song['Album']) : 'Unknown album';
 			$current['disc'] = isset($song['Disc']) ? $song['Disc'] : 'Disc tag missing';

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -1219,7 +1219,15 @@ function renderPlayqueue(state) {
 					}
 					// Line 2 artist, album
 					output += '<span class="pll2">';
-					output += (typeof(data[i].Artist) === 'undefined') ? data[i].AlbumArtist : data[i].Artist;
+					if(typeof(data[i].Artist === 'undefined') && typeof(data[i].AlbumArtist) === 'undefined') {
+						output += 'Unknown artist';
+					}
+					else if(typeof(data[i].Artist) === 'undefined') {
+						output += data[i].AlbumArtist;
+					}
+					else {
+						output += data[i].Artist;
+					}
 				}
 
                 output += '</span></div></li>';


### PR DESCRIPTION
This PR fixes following issue.

### Issue:
When playing audio file that does not have id3tag,

- Playlist shows 'undefined' as an artist.
- Player shows 'null' as an artist.

### moOde Version
Release 8.1.2

### Environment
Raspi: Pi-3B 1.2 1GB
Audio: Pi HDMI 1

### How to reproduce:
Play mp3 or flac file that does not have id3tag.

### Detail of changes:
Playlist shows artist at
https://github.com/moode-player/moode/blob/69eabe8d63f9f7ab285bb7ad35936ea7c2fd6284/www/js/playerlib.js#L1254
but AlbumArtist may be undefined.
To prevent showing 'undefined', I added checking whether AlbumArtist is undefined or not.

Player shows artist at
https://github.com/moode-player/moode/blob/69eabe8d63f9f7ab285bb7ad35936ea7c2fd6284/www/js/playerlib.js#L872-L873
but albumartist may be null.
To prevent showing 'null', I added albumartist element to the array that is returned from enhanceMetadata().

### Effect:
Show artist as 'Unknown artist' even if playing file that does not have id3tag.