### PR TITLE
Fix long artist name not wrapping

### DIFF
--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -701,7 +701,7 @@ input[type='range'].vslide2::-moz-range-track {height:10em;width:2px;border-radi
 .busy-spinner {position:absolute;right:3.25rem;top:.2rem;top:calc(env(safe-area-inset-top) + .2rem);display:none;}
 .busy-spinner svg {stroke:var(--adapttext);height:1rem;width:1rem;}
 .busy-spinner-btn svg {stroke:var(--accentxts);height:1rem;width:1rem;}
-#tagview-text-cover {position:relative;font-size:1.8rem;line-height:1.1em;height:calc(20vw - 1rem);width:calc(20vw - 1rem);background:rgba(64,64,64,.2);box-shadow: 0px 0px .2em rgba(0,0,0,0.2);}
+#tagview-text-cover {position:relative;font-size:1.8rem;line-height:1.1em;height:calc(20vw - 1rem);width:calc(20vw - 1rem);background:rgba(64,64,64,.2);box-shadow: 0px 0px .2em rgba(0,0,0,0.2);word-break: break-word;}
 .plview-text-cover-div {margin:0 .5em;}
 .plview-text-cover {position:relative;font-size:1.35em;line-height:1.1em;top:calc(6vw - 1rem);width:100%;left:var(--thumbmargin);text-align:center;}
 #station-path {text-align:center;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -130,7 +130,7 @@ html {background-color:inherit;}
 #volume-popup {display:none;height:100vh;width:100vw;background-color:var(--modalbkdr);}
 #volpad {position:fixed;top:calc(50% - 2.75rem - env(safe-area-inset-bottom));left:50%;/*width:30%;*/transform:translate(-50%, -50%);z-index:10001;}
 #volume-popup .modal-footer {position:absolute;bottom:calc(env(safe-area-inset-bottom) + 10vh);width:inherit;border:none;}
-#volume-popup .modal-footer button {width:20%;color:var(--adapttext);left:calc(50% - .5em);transform:translate(-50%);position:fixed;font-size:1.2rem;z-index:10001;}
+#volume-popup .modal-footer button {width:20%;color:var(--adapttext);left:calc(50% - 1.0em);transform:translate(-50%);position:fixed;font-size:1.2rem;z-index:10001;}
 #volcontrol-2, #inpsrctick {height:25vw;width:25vw;padding:2em;}
 #volumeup-2, #volumedn-2 {font-size:3.1vw;}
 #volume-popup .volume-display {font-size:3.5vw;font-weight:500;margin-top:0;}


### PR DESCRIPTION
If the artist name is very long, e.g. BADBADNOTGOOD, and it has multiple albums, upon selecting it in TAG view, its name will overflow the cover area. Set word-break: accordingly.