### PR TITLE
Pause rewind stop playbar fixes

### DIFF
--- a/www/inc/mpd.php
+++ b/www/inc/mpd.php
@@ -586,6 +586,7 @@ function enhanceMetadata($current, $sock, $caller = '') {
 	$current['performer'] = $song['Performer'];
 	$current['albumartist'] = $song['AlbumArtist'];
 	$current['artist_count'] = $song['artist_count'];
+	$current['comment'] = $song['Comment'];
 
 	// Cover hash and mapped db volume
 	if ($caller == 'engine_mpd_php') {
@@ -598,6 +599,7 @@ function enhanceMetadata($current, $sock, $caller = '') {
 		$current['artist'] = '';
 		$current['title'] = '';
 		$current['album'] = '';
+		$current['comment'] = '';
 		$current['coverurl'] = DEF_COVER;
 		debugLog('enhanceMetadata(): error: currentsong file is NULL');
 	} else {

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -1902,9 +1902,12 @@ function updKnobAndTimeTrack() {
 		if (UI.mobile) {
 			$('#m-total, #m-countdown, #playbar-mcount').text('00:00');
 			$('#playbar-mtotal').html('&nbsp;/&nbsp;00:00');
+			$('#timeline').hide();
 		}
         else {
 			$('#playbar-total, #playbar-countdown, #countdown-display').html('00:00');
+			$('#playbar-timeline').css('display', 'none');
+			$('#playbar-title').css('padding-bottom', '0');
 		}
 	}
 	// Radio station (never has a duration)
@@ -1930,7 +1933,7 @@ function updKnobAndTimeTrack() {
 		}
 	}
 
-    if (MPD.json['state'] === 'play') {
+    if ((MPD.json['state'] === 'play') || (MPD.json['state'] === 'pause')) {
         // Move these out of the timer
 		var tt = $('#timetrack');
 		var ti = $('#time');


### PR DESCRIPTION
Clearing the play queue changes the player status to STOP, which shouldn't show the play-bar/progress-bar (as may be seen on startup, if nothing is in the queue).
Also, pressing the BACK/PREV button, especially on the screen-saver view, didn't reposition the tick on the progress-bar to its "zero" position: pressing PREV during playback => rewinds to zero and puts the player into PAUSE.