### PR TITLE
Pause rewind stop playbar fixes

### DIFF
--- a/www/inc/mpd.php
+++ b/www/inc/mpd.php
@@ -586,6 +586,7 @@ function enhanceMetadata($current, $sock, $caller = '') {
 	$current['performer'] = $song['Performer'];
 	$current['albumartist'] = $song['AlbumArtist'];
 	$current['artist_count'] = $song['artist_count'];
+	$current['comment'] = $song['Comment'];
 
 	// Cover hash and mapped db volume
 	if ($caller == 'engine_mpd_php') {
@@ -598,6 +599,7 @@ function enhanceMetadata($current, $sock, $caller = '') {
 		$current['artist'] = '';
 		$current['title'] = '';
 		$current['album'] = '';
+		$current['comment'] = '';
 		$current['coverurl'] = DEF_COVER;
 		debugLog('enhanceMetadata(): error: currentsong file is NULL');
 	} else {

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -1902,9 +1902,12 @@ function updKnobAndTimeTrack() {
 		if (UI.mobile) {
 			$('#m-total, #m-countdown, #playbar-mcount').text('00:00');
 			$('#playbar-mtotal').html('&nbsp;/&nbsp;00:00');
+			$('#timeline').hide();
 		}
         else {
 			$('#playbar-total, #playbar-countdown, #countdown-display').html('00:00');
+			$('#playbar-timeline').css('display', 'none');
+			$('#playbar-title').css('padding-bottom', '0');
 		}
 	}
 	// Radio station (never has a duration)
@@ -1930,7 +1933,7 @@ function updKnobAndTimeTrack() {
 		}
 	}
 
-    if (MPD.json['state'] === 'play') {
+    if ((MPD.json['state'] === 'play') || (MPD.json['state'] === 'pause')) {
         // Move these out of the timer
 		var tt = $('#timetrack');
 		var ti = $('#time');

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -877,8 +877,11 @@ function renderUI() {
     		$('#currentsong').html(genSearchUrl(MPD.json['artist'] == 'Unknown artist' ? MPD.json['albumartist'] : MPD.json['artist'], MPD.json['title'], MPD.json['album']));
             $('#currentartist').html((MPD.json['artist'] == 'Unknown artist' ? MPD.json['albumartist'] : MPD.json['artist']) + moreArtistsEllipsis);
             // Playbar
-            $('#playbar-currentsong, #ss-currentsong').html((MPD.json['artist'] == 'Unknown artist' ? MPD.json['albumartist'] :
-                MPD.json['artist']) + moreArtistsEllipsis + ' - ' + MPD.json['title']);
+			var textArtistTitle = (MPD.json['artist'] == 'Unknown artist' ? MPD.json['albumartist'] : MPD.json['artist']);
+			if ('' != textArtistTitle) {
+				textArtistTitle += moreArtistsEllipsis + ' - ' + MPD.json['title'];
+			}
+			$('#playbar-currentsong, #ss-currentsong').html(textArtistTitle);
             $('#playbar-currentalbum, #ss-currentalbum').html(MPD.json['album']);
         }
 


### PR DESCRIPTION
Removed the dash between artist and track if empty (nothing playing)
Hidden the progress-bar upon STOP (clear queue)
Properly repositioned the progress-bar upon pressing BACK/PREV while playing: resets song to zero time and enters PAUSE mode.