### PR TITLE
If not playing don't say "file not found"

### DIFF
--- a/www/inc/music-library.php
+++ b/www/inc/music-library.php
@@ -573,9 +573,11 @@ function getEncodedAt($songData, $displayFormat, $calledFromGenLib = false) {
 		// DSD file
 		$result = sysCmd('mediainfo --Inform="Audio;file:///var/www/mediainfo.tpl" ' . '"' . MPD_MUSICROOT . $songData['file'] . '"');
 		$encodedAt = 'DSD ' . ($result[1] == '' ? '?' : formatRate($result[1]) . ' MHz');
+	} else if ($songData['file'] == '') {
+		return 'Not playing';
 	} else {
 		// PCM file
-		if ($songData['file'] == '' || !file_exists(MPD_MUSICROOT . $songData['file'])) {
+		if (!file_exists(MPD_MUSICROOT . $songData['file'])) {
 			return 'File does not exist';
 		}
 		// Mediainfo


### PR DESCRIPTION
The scenarios for EMPTY FILE NAME and FILE NOT FOUND were handled at the same level in the "Encoded at:" field of the PLAYBACK tab of the audio info modal...
Now, if the filename is empty (no playback) the display id "Not Playing" instead of "File does not exist"