### PR TITLE
Fixed input field and folder-rescan command

### DIFF
--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -3890,6 +3890,13 @@ $('#preferences-modal .h5').click(function(e) {
 	$(this).parent('div.accordian').toggleClass('active');
 });
 
+$('#dbfs').on('keyup', function(e) {
+	if (e.key == 'Enter') {
+		e.preventDefault();
+ 		dbFastSearch();
+	}
+});
+
 // Synchronize times to/from playbar so we don't have to keep countdown timers running which = ugly idle perf
 function syncTimers() {
     var a = $('#countdown-display').text();

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -867,8 +867,8 @@ jQuery(document).ready(function($) { 'use strict';
 	});
 	$('#db-refresh').click(function(e) {
         UI.dbPos[UI.dbPos[10]] = 0;
-        $.getJSON('command/moode.php?cmd=' + UI.dbCmd, {'path': UI.path}, function(data) {
-            renderFolderView(data, UI.path);
+		$.getJSON('command/music-library.php?cmd=lsinfo', {'path': UI.path}, function(data) {
+			renderFolderView(data, UI.path);
         });
 	});
 	$('#db-search-submit').click(function(e) {

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -250,7 +250,7 @@
 				<button aria-label="Home" id="db-home" class="btn"><i class="fas fa-home"></i></button>
 				<button aria-label="Refresh" id="db-refresh" class="btn"><i class="far fa-redo"></i></button>
 				<button aria-label="Search" id="db-advsearch" class="btn" href="#dbsearch-modal" data-toggle="modal"><i class="far fa-search"></i></button>
-				<form id="db-fastsearch" onsubmit="return dbFastSearch();">
+				<form id="db-fastsearch" onsubmit="return false;">
 					<div class="input-append">
 						<input id="dbfs" type="text" value="" placeholder="search">
 					</div>


### PR DESCRIPTION
There fast-search field of the folder view relied on the form's submit method to perform the search. Changed as all the others, to have a keyboard handler.
Also, trying to see the effects of the "rescan" button, I was receiving 404; and a closer look revealed that the command had not been updated to reflect the new source-code paths. Fixed that too.