### PR TITLE
The timer is being activated also for PAUSE

### DIFF
--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -1963,7 +1963,7 @@ function updKnobAndTimeTrack() {
 		}
 	}
 
-    if (MPD.json['state'] === 'play' || MPD.json['state'] === 'pause') {
+    if (MPD.json['state'] === 'play') {
         // Move these out of the timer
 		var tt = $('#timetrack');
 		var ti = $('#time');
@@ -1989,6 +1989,10 @@ function updKnobAndTimeTrack() {
 			}
         }, delta * 1000);
     }
+    else if (MPD.json['state'] === 'pause' ) {
+		syncTimers();
+		$('#time, #timetrack, #playbar-timetrack').val(GLOBAL.initTime * 10).trigger('change');
+	}
 }
 
 // Fill in timeline color as song plays


### PR DESCRIPTION
I just found a problem with the PAUSE mode, introduced by the fix to the playbar: the playback timer was being activated in both cases: PLAY and PAUSE (I mistakenly thought that was just a Timeout, not an Interval...).
