### PR TITLE
Use systemd automounts for mounting music sources

### DIFF
--- a/www/inc/common.php
+++ b/www/inc/common.php
@@ -148,9 +148,23 @@ function mountmonLog($msg, $mode = 'a') {
 	fclose($fh);
 }
 
-// Execute shell command
-function sysCmd($cmd) {
-	exec('sudo ' . $cmd . " 2>&1", $output);
+// Execute shell command as root
+function sysCmd($cmd, &$resultCode = NULL) {
+	if (isset($resultCode)) {
+		exec('sudo ' . $cmd . " 2>&1", $output, $resultCode);
+	} else {
+		exec('sudo ' . $cmd . " 2>&1", $output);
+	}
+	return $output;
+}
+
+// Execute shell command as current user
+function sysCmdUser($cmd, &$resultCode = NULL) {
+	if (isset($resultCode)) {
+		exec($cmd . " 2>&1", $output, $resultCode);
+	} else {
+		exec($cmd . " 2>&1", $output);
+	}
 	return $output;
 }
 


### PR DESCRIPTION
fixes #545 

I eyeballed most of the things here as I have no real idea of the big picture yet. Especially the error handling is something I don't know how it's supposed to be done. Anyway I would appreciate if you could take a look, I tested it on my setup and it seems to work fine. 

I guess a point for discussion would be the migration of existing installations. A simple backup/restore of the config could work as the previous solution was not really persistent (meaning no extra files anywhere). But I haven't tested that.

What this whole change does is that it replaces the manual `mount` and `umount` calls with systemd mount/automount units. I didn't want to break any API so it's a little more complicated than it could be in the end.
If this gets approved it would be a good idea to remove most of the calls to `sourceMount('mount',....)` etc. because they shouldn't be necessary anymore as mounting happens automatically through systemd. When this is done the respective code in `music-source.php` could be cleaned up and removed.   