### PR TITLE
Cover view without playbar

### DIFF
--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -464,6 +464,7 @@ body.cvwide #ss-metadata {float:left;top:15vh;left:100vh;text-align:left;font-si
 body.cvwide #ss-current-album-div {text-overflow:ellipsis;white-space:nowrap;overflow: hidden;}*/
 body.cvwide #ss-currentalbum {margin:0!important;}
 body.cvwide-xmeta #ss-extra-metadata {display:block;color:var(--textvariant);font-size:.85em;}
+body:not(.cvpb) #ss-coverart-url img {width:calc(100vh - 3em);height:calc(100vh - 3em);}
 /* misc */
 #btn-ra-search-reset, #btn-pl-search-reset {display:none;}
 #splash {height:100vh;width:100vw;z-index:11111;position:fixed;background:rgba(32,32,32,0.95);backdrop-filter:blur(5px);-webkit-backdrop-filter:blur(5px);display:none;}

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -465,6 +465,7 @@ body.cvwide #ss-current-album-div {text-overflow:ellipsis;white-space:nowrap;ove
 body.cvwide #ss-currentalbum {margin:0!important;}
 body.cvwide-xmeta #ss-extra-metadata {display:block;color:var(--textvariant);font-size:.85em;}
 body:not(.cvpb) #ss-coverart-url img {width:calc(100vh - 3em);height:calc(100vh - 3em);}
+body:not(.cvpb) #ss-metadata {left:calc(100vh + 2em);}
 /* misc */
 #btn-ra-search-reset, #btn-pl-search-reset {display:none;}
 #splash {height:100vh;width:100vw;z-index:11111;position:fixed;background:rgba(32,32,32,0.95);backdrop-filter:blur(5px);-webkit-backdrop-filter:blur(5px);display:none;}


### PR DESCRIPTION
If we chose not to show the playbar in CoverView, this basically means there is more room for the cover-art itself, so just resized the img tag accordingly if body is :not(.cvpb); this improves the user experience for the extra-wide display. 