### PR TITLE
Performed htmlspecialchars translation at mpd response level

### DIFF
--- a/www/command/audioinfo.php
+++ b/www/command/audioinfo.php
@@ -122,7 +122,7 @@ function parseTrackInfo($resp) {
 					$genres .= $value . ', ';
 					break;
 				case 'Album':
-					$array[7] = array($element => htmlspecialchars($value));
+					$array[7] = array($element => $value);
 					break;
 				case 'Disc':
 					$array[8] = array($element => $value);

--- a/www/inc/mpd.php
+++ b/www/inc/mpd.php
@@ -70,7 +70,7 @@ function readMpdResp($sock) {
 	while (false !== ($str = fgets($sock, 1024)) && !feof($sock)) {
 		if (strncmp(MPD_RESPONSE_OK, $str, strlen(MPD_RESPONSE_OK)) == 0) {
 			$resp = $resp == '' ? $str : $resp;
-			return $resp;
+			return htmlspecialchars($resp);
 		}
 
 		if (strncmp(MPD_RESPONSE_ERR, $str, strlen(MPD_RESPONSE_ERR)) == 0) {
@@ -87,7 +87,7 @@ function readMpdResp($sock) {
 		debugLog('readMpdResp(): Error: fgets failure (' . explode("\n", $resp)[0] . ')');
 	}
 
-	return $resp;
+	return htmlspecialchars($resp);
 }
 function closeMpdSock($sock) {
 	sendMpdCmd($sock, 'close');
@@ -292,7 +292,7 @@ function formatMpdQueryResults($resp) {
 					$array[$idx]['playlist'] = $value;
 				}
 			} else {
-				$array[$idx][$element] = htmlspecialchars($value);
+				$array[$idx][$element] = $value;
 				$array[$idx]['TimeMMSS'] = formatSongTime($array[$idx]['Time']);
 			}
 
@@ -624,7 +624,7 @@ function enhanceMetadata($current, $sock, $caller = '') {
 			// iTunes aac or aiff file
 			$current['artist'] = isset($song['Artist']) ? $song['Artist'] : 'Unknown artist';
 			$current['title'] = $song['Name'];
-			$current['album'] = isset($song['Album']) ? htmlspecialchars($song['Album']) : 'Unknown album';
+			$current['album'] = isset($song['Album']) ? $song['Album'] : 'Unknown album';
 			$current['coverurl'] = '/coverart.php/' . rawurlencode($song['file']);
 			$current['thumb_hash'] = md5(dirname($song['file']));
 		} else if (substr($song['file'], 0, 4) == 'http' && !isset($current['duration'])) {
@@ -666,7 +666,7 @@ function enhanceMetadata($current, $sock, $caller = '') {
 			// Song file, UPnP URL or Podcast
 			$current['artist'] = isset($song['Artist']) ? $song['Artist'] : 'Unknown artist';
 			$current['title'] = isset($song['Title']) ? $song['Title'] : pathinfo(basename($song['file']), PATHINFO_FILENAME);
-			$current['album'] = isset($song['Album']) ? htmlspecialchars($song['Album']) : 'Unknown album';
+			$current['album'] = isset($song['Album']) ? $song['Album'] : 'Unknown album';
 			$current['disc'] = isset($song['Disc']) ? $song['Disc'] : 'Disc tag missing';
 			if (substr($song['file'], 0, 4) == 'http') {
 				if (isset($_SESSION[$song['file']])) {

--- a/www/inc/music-library.php
+++ b/www/inc/music-library.php
@@ -259,7 +259,7 @@ function genLibrary($flat) {
 				//'conductor' => ($flatData['Conductor'] ? $flatData['Conductor'] : 'Conductor tag missing'),
 				'year' => getTrackYear($flatData),
 				'time' => $flatData['Time'],
-				'album' => ($flatData['Album'] ? htmlspecialchars($flatData['Album']) : 'Unknown Album'),
+				'album' => ($flatData['Album'] ? $flatData['Album'] : 'Unknown Album'),
 				'genre' => ($flatData['Genre'] ? $flatData['Genre'] : array('Unknown')), // @Atair: 'Unknown' genre has to be an array
 				'time_mmss' => formatSongTime($flatData['Time']),
 				'last_modified' => $flatData['Last-Modified'],
@@ -444,7 +444,7 @@ function genLibraryUTF8Rep($flat) {
 				//'conductor' => utf8rep(($flatData['Conductor'] ? $flatData['Conductor'] : 'Conductor tag missing')),
 				'year' => utf8rep(getTrackYear($flatData)),
 				'time' => utf8rep($flatData['Time']),
-				'album' => utf8rep(($flatData['Album'] ? htmlspecialchars($flatData['Album']) : 'Unknown Album')),
+				'album' => utf8rep(($flatData['Album'] ? $flatData['Album'] : 'Unknown Album')),
 				'genre' => utf8repArray(($flatData['Genre'] ? $flatData['Genre'] : array('Unknown'))), // @Atair: 'Unknown' genre has to be an array
 				'time_mmss' => utf8rep(formatSongTime($flatData['Time'])),
 				'last_modified' => $flatData['Last-Modified'],

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -4057,7 +4057,7 @@ function setLibMenuAndHeader () {
 		}
 	}
 
-    $('#menu-header').text(headerText);
+    $('#menu-header').html(headerText);
 }
 
 function lazyLode(view, skip, force) {


### PR DESCRIPTION
In order to have more coverage on special html characters - more or less intentionally put - in the audio-files metadata, moved the specific translations at mpd response level; this should guarantee no html re-interpretation on tag content.

Also, the html element showing the by-artist / by-advanced-search filtered library had its TEXT, and not its HTML, filled with the filter, causing the special characters to be shown as ampersand-mnemonics instead of their visual representation. FIXED.