### PR TITLE
Audio file,s no cue, no track num

### DIFF
--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -1428,6 +1428,10 @@ function renderFolderView(data, path, searchstr) {
 	element.innerHTML = '';
 
 	for (i = 0; i < data.length; i++) {
+		// chosing to have MPD ignore CUE parsing means that the folder contents will include them, so here we must ignore them too.
+		if (SESSION.json['cuefiles_ignore'] == '1' && data[i].file && data[i].file.endsWith('.cue')) {
+			continue;
+		}
     	if (data[i].directory) {
             var cueVirtualDir = false;
     		output += '<li id="db-' + (i + 1) + '" data-path="' + data[i].directory + '">';
@@ -1477,7 +1481,7 @@ function renderFolderView(data, path, searchstr) {
     			output += '<li id="db-' + (i + 1) + '" data-path="' + data[i].file + '">';
     			output += '<div class="db-icon db-song db-action">'; // Hack to enable entire line click for context menu
     			output += '<a class="btn" href="#notarget" data-toggle="context" data-target="#context-menu-folder-item">';
-                output += data[i].Track + '</a></div>';
+                output += (data[i].Track ? data[i].Track : "•") + '</a></div>';
     			output += '<div class="db-entry db-song" data-toggle="context" data-target="#context-menu-folder-item"><div>';
                 output += data[i].Title + ' <span class="songtime">' + data[i].TimeMMSS + '</span></div>';
     		}

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -770,15 +770,6 @@ var renderSongs = function(albumPos) {
         // Render the song list
         lastAlbum = '';
         lastDisc = '';
-
-        // For cue format omit the audio file which otherwise will show up as a bogus album header.
-        // Typically the audio file in cue format will not have a track number since it's considered to be the whole album.
-        var cueFormats = ['flac', 'wav', 'aiff'];
-        var file0Ext = filteredSongs[0].file.substring(filteredSongs[0].file.lastIndexOf('.') + 1, filteredSongs[0].file.length);
-        if ($.inArray(file0Ext, cueFormats) != -1 && filteredSongs[0].tracknum == '') {
-            filteredSongs.shift();
-        }
-
 		for (i = 0; i < filteredSongs.length; i++) {
 			var songyear = filteredSongs[i].year ? filteredSongs[i].year.slice(0, 4) : ' ';
 


### PR DESCRIPTION
- skipped the CUE files if ignoring them at MPD level in FOLDER VIEW
- always accepting pure audio files in ALBUM / TAG VIEW

NOTE
Not always the case, but when toggling the "Ignore CUE files" in the library settings, the operations to be performed in order to have the library properly rebuilt is the following:

1. LIBRARY SETTINGS - toggle the "Ignore CUE files" option to your like
2. LIBRARY SETTINGS - clear the library cache
3. AUDIO SETTINGS - restart MPD
4. go back to moOde, perform a library update.

