### PR TITLE
Size of the album-art was not pefect

### DIFF
--- a/www/css/media.css
+++ b/www/css/media.css
@@ -334,7 +334,7 @@ body {
 	#trackscontainer span {font-size:1.1rem;}
 	#lib-coverart-meta-area {width:14vw;position:relative;}
 	#songsList {padding-bottom:10rem;}
-	#tagview-text-cover {font-size:1.35rem;height:calc(14vw - 1rem);width:calc(14vw - 1rem);}
+	#tagview-text-cover {font-size:1.35rem;height:calc(15vw - 1em);width:calc(15vw - 1em);}
 	img.lib-artistart {width:inherit;height:inherit;}
 	.lib-numtracks-meta {margin-top:1.5em;}
 

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -411,7 +411,7 @@ code, pre {background-color:inherit;color:inherit;border:none;font-size:.8em;}
 #lib-meta-summary {margin:0 0.5em 0 0.5em;line-height:normal;font-size:.9em;}
 img.lib-coverart {float:left;width:calc(20vw - 1em);box-shadow:0px 0px .2em rgba(0,0,0,0.2);}
 img.lib-coverart.active {box-shadow:0px 0px .2em .1em var(--accentxts);}
-img.lib-artistart {float:left;width:calc(20vw - 1rem);height: calc(20vw - 1rem);box-shadow:0px 0px .2em rgba(0,0,0,0.2);position:absolute;opacity:.4}
+img.lib-artistart {float:left;width:calc(20vw - 1rem);height: calc(20vw - 1rem);box-shadow:0px 0px .2em rgba(0,0,0,0.2);opacity:.4}
 .lib-albumname-meta {margin-top:0px;font-weight:700;text-align:center;}
 .lib-artistname-meta {margin-top:0;text-overflow:ellipsis;white-space:nowrap;overflow:hidden;font-weight:700;text-align:center;cursor:pointer;}
 .lib-albumyear-meta {display:none;text-align:center;}
@@ -697,7 +697,7 @@ input[type='range'].vslide2::-moz-range-track {height:10em;width:2px;border-radi
 .busy-spinner {position:absolute;right:3.25rem;top:.2rem;top:calc(env(safe-area-inset-top) + .2rem);display:none;}
 .busy-spinner svg {stroke:var(--adapttext);height:1rem;width:1rem;}
 .busy-spinner-btn svg {stroke:var(--accentxts);height:1rem;width:1rem;}
-#tagview-text-cover {position:relative;font-size:1.8rem;line-height:1.1em;height:calc(20vw - 1rem);width:calc(20vw - 1rem);background:rgba(64,64,64,.2);box-shadow: 0px 0px .2em rgba(0,0,0,0.2);word-break:break-word;}
+#tagview-text-cover {position:relative;font-size:1.8rem;line-height:1.1em;height:calc(20vw - 1rem);width:calc(20vw - 1rem);background:rgba(64,64,64,.2);box-shadow: 0px 0px .2em rgba(0,0,0,0.2);word-break:break-word;position:absolute;top:0.25em;left:0.25em;}
 .plview-text-cover-div {margin:0 .5em;}
 .plview-text-cover {position:relative;font-size:1.35em;line-height:1.1em;top:calc(6vw - 1rem);width:100%;left:var(--thumbmargin);text-align:center;}
 #station-path {text-align:center;}

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -914,7 +914,7 @@ var renderSongs = function(albumPos) {
             else {
                 var libFilter = '';
             }
-            $('#lib-coverart-img').html('<button class="btn" id="tagview-text-cover" data-toggle="context" data-target="#context-menu-lib-album">' +
+            $('#lib-coverart-img').html('<img class="lib-artistart" src="imagesw/notfound.jpg"/><button class="btn" id="tagview-text-cover" data-toggle="context" data-target="#context-menu-lib-album">' +
                 'Music Collection' + libFilter + '</button>');
         }
 		$('#lib-albumname').html(album);


### PR DESCRIPTION
To see the meaning of this fix you need to watch the album art in the TAG view:

chose an artist with more than one album (don't select any album, though, just the artist in the list on the left) and see how wide(r) is the faded album art underneath the Artist's name text overlay.
now select an album from the list on the right, and notice the album art is (slightly, but still noticeably, to me) smaller
To overcome I made the following:

removed position: Absolute from the IMG tag, and assigned, instead, to the button overlay, and positioned it exactly OVER the IMG
2.To make such button work correctly also when no artist is selected ("Music Collection" scenario) I also added an IMG tag with the imagesw/notfound.jpg
This problem is visible ONLY with the 7'' display, and very, very slightly on my iPhone (7). On the browser, OTOH, is absolutely absent, as the image tag's maxwidth: 100%, takes care of it...

I know it's just cosmetics, and not for everyone, but I am a perfectionist when it comes to graphics; and since I use almost ONLY the 7'' display, I feel frustrated having to live with the little misalignment... ;-)

Of course, it's always up to you whether to include it or not in the upcoming 8.2.5