### PR TITLE
Feature/camilladsp volume

### DIFF
--- a/etc/alsa/conf.d/camilladsp.overwrite.conf
+++ b/etc/alsa/conf.d/camilladsp.overwrite.conf
@@ -4,6 +4,10 @@ pcm.camilladsp {
     cpath "/usr/local/bin/camilladsp"
     config_out "/usr/share/camilladsp/working_config.yml"
 
+    # use a state file for restoring last volume settings on start
+    vol_file "/var/lib/cdsp/camilladsp_volume_state"
+    camilla_exit_cmd "/usr/local/bin/store_camilladsp_vol"
+
     # config_cdsp says to use the new CamillaDSP internal substitutions.
     # When config_cdsp is set to an integer != 0 the hw_params and
     # extra samples are passed to CamillaDSP on the command line as

--- a/usr/share/camilladsp/configs/loudness.yml
+++ b/usr/share/camilladsp/configs/loudness.yml
@@ -1,0 +1,58 @@
+devices:
+  samplerate: 44100
+  chunksize: 1024
+  queuelimit: 1
+  capture:
+    type: File
+    channels: 2
+    filename: "/dev/stdin"
+    format: S16LE
+  playback:
+    type: Alsa
+    channels: 2
+    device: "plughw:0,0"
+    format: S32LE
+filters:
+  Volume:
+    parameters:
+      ramp_time: 200
+    type: Volume
+  loudness:
+    parameters:
+      high_boost: 3
+      low_boost: 6
+      ramp_time: 200
+      reference_level: -6
+    type: Loudness
+mixers:
+  stereo:
+    channels:
+      in: 2
+      out: 2
+    mapping:
+    - dest: 0
+      mute: false
+      sources:
+      - channel: 0
+        gain: -3
+        inverted: false
+        mute: false
+    - dest: 1
+      mute: false
+      sources:
+      - channel: 1
+        gain: -3
+        inverted: false
+        mute: false
+pipeline:
+- name: stereo
+  type: Mixer
+- channel: 0
+  names:
+  - loudness
+  - Volume
+  type: Filter
+- channel: 1
+  names:
+  - loudness
+  - Volume

--- a/usr/share/camilladsp/configs/volumecontrol.yml
+++ b/usr/share/camilladsp/configs/volumecontrol.yml
@@ -1,0 +1,52 @@
+---
+devices:
+  samplerate: 44100
+  chunksize: 1024
+  queuelimit: 1
+  capture:
+    type: File
+    channels: 2
+    filename: "/dev/stdin"
+    format: S16LE
+  playback:
+    type: Alsa
+    channels: 2
+    device: "plughw:0,0"
+    format: S32LE
+filters:
+  Volume:
+    parameters:
+      ramp_time: 200
+    type: Volume
+mixers:
+  stereo:
+    channels:
+      in: 2
+      out: 2
+    mapping:
+    - dest: 0
+      mute: false
+      sources:
+      - channel: 0
+        gain: -3
+        inverted: false
+        mute: false
+    - dest: 1
+      mute: false
+      sources:
+      - channel: 1
+        gain: -3
+        inverted: false
+        mute: false
+pipeline:
+- name: stereo
+  type: Mixer
+- channel: 0
+  names:
+  - Volume
+  type: Filter
+- channel: 1
+  names:
+  - Volume
+  type: Filter
+...

--- a/var/local/www/db/moode-sqlite3.db.sql
+++ b/var/local/www/db/moode-sqlite3.db.sql
@@ -141,7 +141,7 @@ INSERT INTO cfg_system (id, param, value) VALUES (76, 'p3bt', '1');
 INSERT INTO cfg_system (id, param, value) VALUES (77, 'cardnum', '0');
 INSERT INTO cfg_system (id, param, value) VALUES (78, 'btsvc', '0');
 INSERT INTO cfg_system (id, param, value) VALUES (79, 'btname', 'Moode Bluetooth');
-INSERT INTO cfg_system (id, param, value) VALUES (80, 'RESERVED_80', '');
+INSERT INTO cfg_system (id, param, value) VALUES (80, 'camilladsp_volume_sync', 'off');
 INSERT INTO cfg_system (id, param, value) VALUES (81, 'feat_bitmask', '97206');
 INSERT INTO cfg_system (id, param, value) VALUES (82, 'library_recently_added', '2592000000');
 INSERT INTO cfg_system (id, param, value) VALUES (83, 'btactive', '0');
@@ -237,6 +237,7 @@ INSERT INTO cfg_system (id, param, value) VALUES (172, 'library_onetouch_pl', 'N
 INSERT INTO cfg_system (id, param, value) VALUES (173, 'scnsaver_mode', 'Cover');
 INSERT INTO cfg_system (id, param, value) VALUES (174, 'scnsaver_layout', 'Default');
 INSERT INTO cfg_system (id, param, value) VALUES (175, 'scnsaver_xmeta', 'No');
+
 
 -- Table: cfg_theme
 CREATE TABLE cfg_theme (id INTEGER PRIMARY KEY, theme_name CHAR (32), tx_color CHAR (32), bg_color CHAR (32), mbg_color CHAR (32));

--- a/www/audioinfo.php
+++ b/www/audioinfo.php
@@ -245,6 +245,9 @@ elseif ($_SESSION['mpdmixer'] == 'software') {
 elseif ($_SESSION['mpdmixer'] == 'none') {
 	$_volume_mixer = 'Fixed (0dB output)';
 }
+elseif ($_SESSION['mpdmixer'] == 'null' && $_SESSION['camilladsp'] != 'off' && $_SESSION['camilladsp_volume_sync'] != 'off') {
+	$_volume_mixer = 'CamillaDSP';
+}
 elseif ($_SESSION['mpdmixer'] == 'null') {
 	$_volume_mixer = 'Null (External control)';
 }

--- a/www/inc/autocfg.php
+++ b/www/inc/autocfg.php
@@ -221,6 +221,7 @@ function autoConfigSettings() {
 		['requires' => ['camilladsp_quickconv'], 'handler' => setphpSession],
 		['requires' => ['cdsp_fix_playback'], 'handler' => setphpSession],
 		['requires' => ['camilladsp'], 'handler' => setphpSession],
+		['requires' => ['camilladsp_volume_sync'], 'handler' => setphpSession],
 
 		'Parametric EQ',
 		['requires' => [ 'eqp12_curve_name', 'eqp12_settings', 'eqp12_active'], 'handler' => function($values) {

--- a/www/inc/mpd.php
+++ b/www/inc/mpd.php
@@ -895,3 +895,7 @@ function parseDir($path) {
 
 	return $result;
 }
+
+function isMpd2CamillaDspVolSyncModeEnabled() {
+	return ($_SESSION['mpdmixer'] == 'none' && $_SESSION['camilladdsp'] !='off' && $_SESSION['camilladsp_volume_sync'] != 'off');
+}


### PR DESCRIPTION
This PR will make it possible to sync CamillaDSP volume to the current MPD volume.

Benefit:

- Can use CamillaDSP volume filter (+ dither is needed)
- Is that it will be later in the audio chain then using the current software volume of MPD.
- And because the volume silder of CamillaDSP is used also the Loudness filter can be used.

The implementation makes use of [mpd2cdspvolume](https://github.com/bitkeeper/mpd2cdspvolume)
On the moode side an additional MPD Volume Type 'CamillaDSP' will be avialable at the Audio configuration page.
Only available when CamillaDSP is used with moOde (=configuration selected).

When the CamillaDSP volume type is selected the following is happing:

- In the background MPD mixer type 'null' is used.
- The mpd2cdspvolume service is started


