### PR TITLE
[camilladsp] make the status of the pipeline editor persist a boot

### DIFF
--- a/www/inc/cdsp.php
+++ b/www/inc/cdsp.php
@@ -389,9 +389,11 @@ class CamillaDsp {
 
     function changeCamillaStatus($enable) {
         if($enable) {
+            sysCmd("sudo systemctl enable camillagui");
             sysCmd("sudo systemctl start camillagui");
         }else {
             sysCmd("sudo systemctl stop camillagui");
+            sysCmd("sudo systemctl disable camillagui");
         }
     }
 


### PR DESCRIPTION
 To safe resource, the pipeline editor was always disabled after a start. But actually this was very anoying, tweaked it now that when started the service will also be enabled after a restart.