### PR TITLE
Fixes/loudness use check

### DIFF
--- a/usr/share/camilladsp/configs/loudness.yml
+++ b/usr/share/camilladsp/configs/loudness.yml
@@ -6,18 +6,14 @@ devices:
   capture:
     type: File
     channels: 2
-    filename: "/dev/stdin"
+    filename: /dev/stdin
     format: S16LE
   playback:
     type: Alsa
     channels: 2
-    device: "plughw:0,0"
+    device: plughw:0,0
     format: S32LE
 filters:
-  Volume:
-    parameters:
-      ramp_time: 200
-    type: Volume
   loudness:
     parameters:
       high_boost: 3
@@ -51,11 +47,9 @@ pipeline:
 - channel: 0
   names:
   - loudness
-  - Volume
   type: Filter
 - channel: 1
   names:
   - loudness
-  - Volume
   type: Filter
-... 
+...

--- a/www/inc/cdsp.php
+++ b/www/inc/cdsp.php
@@ -577,8 +577,9 @@ function isMPD2CamillaDSPVolSyncEnabled() {
 
 function doesCamillaDSPCfgHaveVolFilter($configFile = null) {
 	$configFile = empty($configFile) ? '/usr/share/camilladsp/working_config.yml' : '/usr/share/camilladsp/configs/' . $configFile;
-	$result = sysCmd('fgrep -o "type: Volume" "' . $configFile . '"');
-	return ($result[0] == 'type: Volume' && $_SESSION['camilladsp'] !='off');
+	$resultVol = sysCmd('fgrep -o "type: Volume" "' . $configFile . '"');
+    $resultLdn = sysCmd('fgrep -o "type: Loudness" "' . $configFile . '"');
+	return (($resultVol[0] == 'type: Volume' || $resultLdn[0] == 'type: Loudness' ) && $_SESSION['camilladsp'] !='off');
 }
 
 function updateCamillaDSPCfg($newMode, $currentMode, $cdsp) {


### PR DESCRIPTION
`doesCamillaDSPCfgHaveVolFilter` only checks if a volume filter is present, but the config for loudness doesn't have volume filter. Only a loudness filter, so lets also allow cdsp volume control when a loudness filter is present.

Includes also an updated loudness configuration.