### PR TITLE
Set volume at 100% to 0dB instead of +4dB for HDMI 1 and HDMI 2

### DIFF
--- a/www/util/sysutil.sh
+++ b/www/util/sysutil.sh
@@ -76,9 +76,9 @@ if [[ $1 = "get-alsavol" || $1 = "set-alsavol" ]]; then
 		exit
 	else
 		# Set-alsavol (Note: % is appended to LEVEL)
-		AMIXNAME=$(sqlite3 $SQLDB "select value from cfg_system where param='amixname'")
+		ADEVNAME=$(sqlite3 $SQLDB "select value from cfg_system where param='adevname'")
 		MIXER_TYPE=$(sqlite3 $SQLDB "select value from cfg_mpd where param='mixer_type'")
-		if [[ $3 = "100" && $AMIXNAME = "HDMI" && ( $MIXER_TYPE = "software" || $MIXER_TYPE = "none" ) ]]; then
+		if [[ $3 = "100" && ($ADEVNAME = "Pi HDMI 1" || $ADEVNAME = "Pi HDMI 2") && ( $MIXER_TYPE = "software" || $MIXER_TYPE = "none" ) ]]; then
 			LEVEL="0dB"
 		else
 			LEVEL="$3%"


### PR DESCRIPTION
This was implemented before (See #275 and #298) but broke due to mixer name change from "HDMI" to "PCM" for Raspberry PI HDMI devices.
I assume this happened, when the 2nd HDMI port was introduced for the Raspberry Pi 4.

I only own a Raspberry 3b+ and 4.
The bug was present on both and the fix works on both.
The device names `Pi HDMI 1` and `Pi HDMI 2` are used throughout the Moode codebase, so I assume they can be used reliably.
This fix should continue to work, even if the Raspberry Pi foundation changes the name of the HDMI mixers or sound devices, so this implementation should be future proof.