### PR TITLE
Added disc and track to the current track check

### DIFF
--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -4663,7 +4663,7 @@ function setNpIcon() {
         $('#songsList .lib-entry-song .songtrack').removeClass('lib-track-npicon');
         if (MPD.json['artist'] != 'Radio station' && $('#songsList li').length > 0) {
             for (i = 0; i < filteredSongs.length; i++) {
-                if (filteredSongs[i].title == MPD.json['title'] && filteredSongs[i].album == MPD.json['album'] && filteredSongs[i].tracknum == MPD.json['track'] && filteredSongs[i].disc == MPD.json['disc']) {
+                if (filteredSongs[i].title == MPD.json['title'] && filteredSongs[i].album == MPD.json['album'] && filteredSongs[i].tracknum == MPD.json['track'] && (MPD.json['disc'] == "Disc tag missing" || filteredSongs[i].disc == MPD.json['disc'])) {
                     $('#lib-song-' + (i + 1) + ' .lib-entry-song .songtrack').addClass('lib-track-npicon');
                     break;
                 }

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -4663,7 +4663,7 @@ function setNpIcon() {
         $('#songsList .lib-entry-song .songtrack').removeClass('lib-track-npicon');
         if (MPD.json['artist'] != 'Radio station' && $('#songsList li').length > 0) {
             for (i = 0; i < filteredSongs.length; i++) {
-                if (filteredSongs[i].title == MPD.json['title'] && filteredSongs[i].album == MPD.json['album']) {
+                if (filteredSongs[i].title == MPD.json['title'] && filteredSongs[i].album == MPD.json['album'] && filteredSongs[i].tracknum == MPD.json['track'] && filteredSongs[i].disc == MPD.json['disc']) {
                     $('#lib-song-' + (i + 1) + ' .lib-entry-song .songtrack').addClass('lib-track-npicon');
                     break;
                 }

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -832,7 +832,7 @@ var renderSongs = function(albumPos) {
             }
 
 			var composer = filteredSongs[i].composer == 'Composer tag missing' ? '</span>' : '<br><span class="songcomposer">' + filteredSongs[i].composer + '</span></span>';
-			var npIcon = (filteredSongs[i].title == MPD.json['title'] && filteredSongs[i].album == MPD.json['album'] && filteredSongs[i].disc == MPD.json['disc'] && filteredSongs[i].tracknum == MPD.json['track'] && MPD.json['state'] == 'play') ? ' lib-track-npicon' : '';
+            var npIcon = (filteredSongs[i].title == MPD.json['title'] && filteredSongs[i].album == MPD.json['album'] && (MPD.json['disc'] == "Disc tag missing" || filteredSongs[i].disc == MPD.json['disc']) && filteredSongs[i].tracknum == MPD.json['track'] && MPD.json['state'] == 'play') ? ' lib-track-npicon' : '';
 
             output += albumDiv
                 + discDiv

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -832,7 +832,7 @@ var renderSongs = function(albumPos) {
             }
 
 			var composer = filteredSongs[i].composer == 'Composer tag missing' ? '</span>' : '<br><span class="songcomposer">' + filteredSongs[i].composer + '</span></span>';
-			var npIcon = (filteredSongs[i].title == MPD.json['title'] && filteredSongs[i].album == MPD.json['album'] && MPD.json['state'] == 'play') ? ' lib-track-npicon' : '';
+			var npIcon = (filteredSongs[i].title == MPD.json['title'] && filteredSongs[i].album == MPD.json['album'] && filteredSongs[i].disc == MPD.json['disc'] && filteredSongs[i].tracknum == MPD.json['track'] && MPD.json['state'] == 'play') ? ' lib-track-npicon' : '';
 
             output += albumDiv
                 + discDiv


### PR DESCRIPTION
The cycle sets the icon class, but since it is generating the list it does not break (like in the playback queue), so two equal titles of the same album always got marked.
I added the check for tracknum and disc. (there's only one place where it is set in the tag view, and that's when the list is being generated)

Actually, IMO replacing the title with the track number should be enough; but including also the disc number makes it work for separate CUE discs, where each disc begins with track number 1.

P.S.
I swear I have seen such icon also in the folder view; although cannot find any code that sets it... I'm probably dreaming of it...