### PR TITLE
getUserID - fix for in-place update

### DIFF
--- a/www/inc/common.php
+++ b/www/inc/common.php
@@ -287,7 +287,7 @@ function setAltBackLink() {
 function getUserID() {
 	// Check for and delete '/home/pi' if it has no userid. This dir is created
 	// by the moode-player package install during in-place update.
-	if (file_exists('/home/pi/') && empty(sysCmd('grep "pi" /etc/passwd'))) {
+	if (file_exists('/home/pi/') && empty(sysCmd('grep ":/home/pi:" /etc/passwd'))) {
 		sysCmd('rm -rf /home/pi/');
 	}
 


### PR DESCRIPTION
To avoid misunderstandings and misinterpretation of the entry 'pi,' we should look for the directory name instead of the word 'pi'.