### PR TITLE
Make librespot v5 work with autoplay enabled

### DIFF
--- a/www/inc/renderer.php
+++ b/www/inc/renderer.php
@@ -122,7 +122,10 @@ function startSpotify() {
 		' --normalisation-release ' . $cfgSpotify['normalization_release'] .
 		' --normalisation-knee ' . $cfgSpotify['normalization_knee']
 		: '';
-	$autoplay = $cfgSpotify['autoplay'] == 'Yes' ? ' --autoplay' : '';
+
+	// v0.4.x: Requires just --autoplay
+	// v0.5.x: Requires --autoplay on/off, if not specified, uses the client setting
+	$autoplay = $cfgSpotify['autoplay'] == 'Yes' ? $cfgSpotify['ap_fallback'] == 'Yes' ? ' --autoplay' : ' --autoplay on' : '';
 
 	// Logging
 	$logging = $_SESSION['debuglog'] == '1' ? ' -v > ' . LIBRESPOT_LOG : ' > /dev/null';


### PR DESCRIPTION
When you use librespot v5, it does not start with the autoplay config option enabled.
Fix is based on the `AP Fallback` option, because it says which one is for v5.

Without this change:
![image](https://github.com/user-attachments/assets/9ee6d60f-7c97-467a-ac36-fda70835e454)

With this change:
![image](https://github.com/user-attachments/assets/8deb714b-319c-46b0-b0a4-7e5e1a3a9431)
