### PR TITLE
Features/camilladsp v3x

### DIFF
--- a/www/cdsp-config.php
+++ b/www/cdsp-config.php
@@ -62,6 +62,19 @@ else if ($selectedConfig && isset($_POST['check']) && $_POST['check'] == '1') {
 		$_SESSION['notify']['msg'] = 'Configuration has errors.';
 	}
 }
+// Upgrade
+else if ($selectedConfig && isset($_POST['upgrade']) && $_POST['upgrade'] == '1') {
+	$checkResult = $cdsp->upgradeConfigFile($selectedConfig);
+	$selectedConfigLabel = str_replace('.yml', '', $cdsp->getConfigLabel($selectedConfig));
+
+	if($checkResult['valid'] == true) {
+		$_SESSION['notify']['title'] = NOTIFY_TITLE_INFO;
+		$_SESSION['notify']['msg'] = 'Configuration is valid.';
+	} else {
+		$_SESSION['notify']['title'] = NOTIFY_TITLE_ALERT;
+		$_SESSION['notify']['msg'] = 'Configuration has errors.';
+	}
+}
 // Import (Upload)
 else if (isset($_FILES['pipeline_config']) && isset($_POST['import']) && $_POST['import'] == '1') {
 	$configFileBaseName = $_FILES["pipeline_config"]["name"];

--- a/www/inc/cdsp.php
+++ b/www/inc/cdsp.php
@@ -61,9 +61,8 @@ class CamillaDsp {
 
             $ymlCfg = yaml_parse_file($this->getCurrentConfigFileName());
             $ymlCfg['devices']['capture'] = Array(
-                'type' => 'File',
+                'type' => 'Stdin',
                 'channels' => 2,
-                'filename' => '/dev/stdin',
                 'format' => $useFormat);
             $ymlCfg['devices']['playback'] = Array(
                 'type' => 'Alsa',
@@ -264,6 +263,12 @@ class CamillaDsp {
         $result['msg'] = str_replace('Config is', 'Configuration is', $output);
 
         return $result;
+    }
+
+    function upgradeConfigFile($configName) {
+        $configFullPath = $this->CAMILLA_CONFIG_DIR . '/configs/' . $configName;
+        exec("/var/www/util/cdsp_config_update.py ".$configFullPath, $output, $exitcode);
+        return $this->checkConfigFile($configName);
     }
 
     /**

--- a/www/templates/cdsp-config.html
+++ b/www/templates/cdsp-config.html
@@ -206,6 +206,7 @@
 				<button id="btn-import-pipeline" class="btn btn-medium btn-primary btn-submit" type="submit" name="import" value="1"  style="display:none"/>
 
 				<button class="btn btn-medium btn-primary btn-submit config-btn" type="submit" name="check" value="1">Check</button>
+				<button class="btn btn-medium btn-primary btn-submit config-btn" type="submit" name="upgrade" value="1">Upgrade</button>
 				<a aria-label="Help" class="config-info-toggle" data-cmd="info-configuration-actions" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
 				<span id="info-configuration-actions" class="config-help-info">
 					<b>Remove:</b> Delete the selected configuation file.<br>
@@ -214,6 +215,7 @@
 					<b>Download:</b> Download the selected configuation file.<br>
 					<b>Upload:</b> Upload a configuration file. If the file already exists it will be overwritten.<br>
 					<b>Check:</b> Check if the selected configuration is valid.
+					<b>Upgrade:</b> When check fails and version is for older CamillaDSP, try to upgrade the config file.
 					<br><br>
 					<b>Usage notes:</b><br>
 					Changes to the configuration are effective immediately after pausing/stopping playback. If CamillaDSP can't

--- a/www/util/cdsp_config_update.py
+++ b/www/util/cdsp_config_update.py
@@ -1,0 +1,54 @@
+#!/bin/python3
+#
+# Upgrade the camilladsp v2.x configuration to v3.x
+#
+# License : MIT
+# Copyright 2024 @bitlab
+#
+
+import sys
+import yaml
+
+def main():
+    pipelinefilename = sys.argv[1]
+    pipelinefile = open(pipelinefilename)
+    conf = yaml.safe_load(pipelinefile)
+
+    # create copy
+    with open(f'{pipelinefilename[:-4]}.v2.yml', 'w') as file:
+        yaml.dump(conf, file)
+    match conf:
+        case {'devices': {'capture': capture}}:
+            if 'filename' in capture :
+                print('old capture format found, patch it')
+                del capture['filename']
+                capture['type'] = 'Stdin'
+            print(capture)
+    remove_entries = []
+    for entry in conf['pipeline']:
+        if conf[entry] is None:
+            remove_entries.append(entry)
+
+        remove_items = []
+        for item in entry:
+            if entry[item] is None:
+                remove_items.append(item)
+        # remove empty nodes
+        for item in remove_items:
+                del entry[item]
+
+        if 'channel' in entry:
+            print('old channel construction present, patch it')
+            entry['channels']=[entry['channel']]
+            del entry['channel']
+        if 'bypassed' in entry and entry['bypassed'] is None:
+            entry['bypassed'] = False
+        print(entry)
+
+    # remove empty nodes
+    for entry in remove_entries:
+        del conf[entry]
+    with open(f'{pipelinefilename}', 'w') as file:
+        yaml.dump(conf, file)
+if __name__ == "__main__":
+    main()

--- a/www/util/moode_selectactivecdspconfig.py
+++ b/www/util/moode_selectactivecdspconfig.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python3
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright 2024 @bitlab (@bitkeeper Git)
+#
+
+import sys
+from os import system
+import subprocess
+from urllib import request
+from pathlib import Path
+
+if len(sys.argv) == 1 or len(sys.argv) >=4  or (len(sys.argv)==2 and sys.argv[1] == 'set')  or (len(sys.argv)>2 and sys.argv[1] == 'get'):
+    print("moode_selectactivecdspconfig")
+    print("")
+    print("This tool is used to select the active CamillaDSP configfile for moode from external")
+    print("usage:")
+    print("  moode_selectactivecdspconfig get")
+    print("  moode_selectactivecdspconfig set <configfile>")
+    if len(sys.argv) == 1:
+       print("missing command: get | set")
+    elif len(sys.argv) == 2 and sys.argv[1] == 'set':
+        print("ERROR: missing argument with the CamillaDSP configuration file")
+    else:
+        print("ERROR: unexpected number of arguments")
+    exit(1)
+
+cmd = sys.argv[1]
+
+if cmd == 'set':
+    cdsp_configuration_filename = Path(sys.argv[2]).name
+
+    print( f'CamillaDSP active config: {cdsp_configuration_filename}')
+
+    # Convert string to byte
+    data = f'cdspconfig={cdsp_configuration_filename}'.encode('utf-8')
+
+    # Post Method is invoked if data != None
+    req =  request.Request('http://127.0.0.1/command/camilla.php?cmd=cdsp_set_config', data=data)
+    req.add_header('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8')
+
+    # Response
+    resp = request.urlopen(req)
+elif cmd == 'get':
+
+    args = "/usr/local/bin/moodeutl -q 'select * from cfg_system'|grep 'camilladsp|'"
+    result = subprocess.check_output(args, shell=True, text=True)
+    active_config = result.split('|')[2]
+    if active_config == 'off':
+        active_config = ''
+    else:
+        active_config = f'/usr/share/camilladsp/configs/{active_config}'
+    print(active_config)
+else:
+    print('unexpected command')
+    exit(1)


### PR DESCRIPTION
CamillaDSP 3.x break the configuration files as used with mooOde.

The PR provides:
* Script `www/util/cdsp_config_update.py` for migrating a configuration file.
* Add an action to update a specific configuration:
![image](https://github.com/user-attachments/assets/e75fda7f-77bc-4125-824f-bdbb60f4fa81)

* When selecting an active configuration set the capture device in the new style.

Draft until CamillaDSP 3 is released and related camilladsp packages with pkgbuild are also finished.