### PR TITLE
Crossfeed: correct Jan Meier and add Liqube preset

### DIFF
--- a/www/snd-config.php
+++ b/www/snd-config.php
@@ -539,7 +539,7 @@ if ($_crossfeed_ctl_disabled == '') {
 	$_select['crossfeed'] .= "<option value=\"700 3.0\" " . (($_SESSION['crossfeed'] == '700 3.0') ? "selected" : "") . ">700 Hz 3.0 dB</option>\n";
 	$_select['crossfeed'] .= "<option value=\"700 4.5\" " . (($_SESSION['crossfeed'] == '700 4.5') ? "selected" : "") . ">700 Hz 4.5 dB</option>\n";
 	$_select['crossfeed'] .= "<option value=\"800 6.0\" " . (($_SESSION['crossfeed'] == '800 6.0') ? "selected" : "") . ">800 Hz 6.0 dB</option>\n";
-	$_select['crossfeed'] .= "<option value=\"650 10.0\" " . (($_SESSION['crossfeed'] == '650 10.0') ? "selected" : "") . ">650 Hz 10.0 dB</option>\n";
+	$_select['crossfeed'] .= "<option value=\"650 9.5\" " . (($_SESSION['crossfeed'] == '650 9.5') ? "selected" : "") . ">650 Hz 9.5 dB</option>\n";
 }
 // Polarity inversion
 $autoClick = " onchange=\"autoClick('#btn-set-invert-polarity');\" " . $_invpolarity_ctl_disabled;

--- a/www/snd-config.php
+++ b/www/snd-config.php
@@ -539,6 +539,7 @@ if ($_crossfeed_ctl_disabled == '') {
 	$_select['crossfeed'] .= "<option value=\"700 3.0\" " . (($_SESSION['crossfeed'] == '700 3.0') ? "selected" : "") . ">700 Hz 3.0 dB</option>\n";
 	$_select['crossfeed'] .= "<option value=\"700 4.5\" " . (($_SESSION['crossfeed'] == '700 4.5') ? "selected" : "") . ">700 Hz 4.5 dB</option>\n";
 	$_select['crossfeed'] .= "<option value=\"800 6.0\" " . (($_SESSION['crossfeed'] == '800 6.0') ? "selected" : "") . ">800 Hz 6.0 dB</option>\n";
+	$_select['crossfeed'] .= "<option value=\"730 6.2\" " . (($_SESSION['crossfeed'] == '730 6.2') ? "selected" : "") . ">730 Hz 6.2 dB</option>\n";
 	$_select['crossfeed'] .= "<option value=\"650 9.5\" " . (($_SESSION['crossfeed'] == '650 9.5') ? "selected" : "") . ">650 Hz 9.5 dB</option>\n";
 }
 // Polarity inversion

--- a/www/templates/snd-config.html
+++ b/www/templates/snd-config.html
@@ -361,7 +361,7 @@
 					- Approximates a virtual speaker placement with azimuth 30 degrees at about 3 meters distance.<br>
 					<b>800 Hz, 6.0 dB - Chu Moy</b><br>
 					- Approximates a Chu Moy modified Linkwitz crossfeeder.<br>
-					<b>650 Hz, 10.0 dB - Jan Meier</b><br>
+					<b>650 Hz, 9.5 dB - Jan Meier</b><br>
 					- Approximates a Jan Meier natural crossfeeder. Lowest crossfeed level, highest separation.<br>
                 </span>
 			</div>

--- a/www/templates/snd-config.html
+++ b/www/templates/snd-config.html
@@ -361,6 +361,8 @@
 					- Approximates a virtual speaker placement with azimuth 30 degrees at about 3 meters distance.<br>
 					<b>800 Hz, 6.0 dB - Chu Moy</b><br>
 					- Approximates a Chu Moy modified Linkwitz crossfeeder.<br>
+					<b>730 Hz, 6.2 dB - Liqube</b><br>
+					- Approximates Resonic's fine-tuned "Liqube" crossfeeder.<br>
 					<b>650 Hz, 9.5 dB - Jan Meier</b><br>
 					- Approximates a Jan Meier natural crossfeeder. Lowest crossfeed level, highest separation.<br>
                 </span>


### PR DESCRIPTION
1. Correct the Jan Meier approximation for the bs2b crossfeeder should be 9.5 dB in level, instead of 10.0. Source: https://bs2b.sourceforge.net
2. Add a 730 Hz, 6.2 dB preset following Resonic's "Liqube" setting. Source: https://resonic.at/tools/bs2br