### PR TITLE
[Bluetooth] Handle speaker disconnect/connect

### DIFF
--- a/www/blu-config.php
+++ b/www/blu-config.php
@@ -49,10 +49,16 @@ if (isset($_POST['rm_paired_device']) && $_POST['rm_paired_device'] == '1') {
 	$cmd = '-p';
 	sleep(1);
 }
+
+function updateBluetoothSpeakerMACAddress($deviceMac) {
+	sysCmd("sed -i '/device/c\device \"" . $deviceMac . "\"' " . ALSA_PLUGIN_PATH . '/btstream.conf');
+	phpSession('write', 'used_bt_speaker', $deviceMac);
+}
+
 // Connect to device
 if (isset($_POST['connectto_device']) && $_POST['connectto_device'] == '1') {
-	if ($_POST['audioout'] == 'Bluetooth') { // Update MAC address
-		sysCmd("sed -i '/device/c\device \"" . $_POST['paired_device'] . "\"' " . ALSA_PLUGIN_PATH . '/btstream.conf');
+	if ($_POST['audioout'] == 'Bluetooth') {
+		updateBluetoothSpeakerMACAddress($_POST['paired_device']);
 	}
 	phpSession('write', 'audioout', $_POST['audioout']);
 	sysCmd('/var/www/util/blu-control.sh -C ' . '"' . $_POST['paired_device'] . '"');
@@ -66,7 +72,7 @@ if (isset($_POST['change_audioout_bt']) && $_POST['audioout'] != $_SESSION['audi
 	if ($_POST['audioout'] == 'Bluetooth' && (isset($_POST['paired_device']) || isset($_POST['connected_device']))) {
 		// Change to Bluetooth out, update MAC address
 		$device = isset($_POST['paired_device']) ? $_POST['paired_device'] : $_POST['connected_device'];
-		sysCmd("sed -i '/device/c\device \"" . $device . "\"' " . ALSA_PLUGIN_PATH . '/btstream.conf');
+		updateBluetoothSpeakerMACAddress($device);
 
 		phpSession('write', 'audioout', $_POST['audioout']);
 		setAudioOut($_POST['audioout']);

--- a/www/daemon/worker.php
+++ b/www/daemon/worker.php
@@ -1047,112 +1047,118 @@ $status .= ', ALSA/CDSP maxvol: ' . $_SESSION['alsavolume_max_bt'] . '%/' . $_SE
 $status .= ', ALSA outmode: ' . ALSA_OUTPUT_MODE_BT_NAME[$_SESSION['alsa_output_mode_bt']];
 workerLog('worker: Bluetooth:       ' . $status);
 
-// Start airplay renderer
-if ($_SESSION['feat_bitmask'] & FEAT_AIRPLAY) {
-	if (isset($_SESSION['airplaysvc']) && $_SESSION['airplaysvc'] == 1) {
-		$status = 'started';
-		startAirPlay();
-	} else {
-		$status = 'available';
-	}
+// If we are using bluetooth speaker as output, we will let the bluetooth connection starting renderers
+if (isset($_SESSION['audioout']) && $_SESSION['audioout'] == 'Bluetooth') {
+	workerLog('worker: audioout is set to Bluetooth speaker, waiting speaker connection to start renderers');
+	phpSession('write', 'bt_speaker_connected', '0');
 } else {
-	$status = 'n/a';
-}
-workerLog('worker: AirPlay:         ' . $status);
-
-// Start Spotify Connect renderer
-if ($_SESSION['feat_bitmask'] & FEAT_SPOTIFY) {
-	if (isset($_SESSION['spotifysvc']) && $_SESSION['spotifysvc'] == 1) {
-		$status = 'started';
-		startSpotify();
-	} else {
-		$status = 'available';
-	}
-} else {
-	$status = 'n/a';
-}
-workerLog('worker: Spotify Connect: ' . $status);
-
-// Start Deezer Connect renderer
-if ($_SESSION['feat_bitmask'] & FEAT_DEEZER) {
-	if (isset($_SESSION['deezersvc']) && $_SESSION['deezersvc'] == 1) {
-		$status = 'started';
-		startDeezer();
-	} else {
-		$status = 'available';
-	}
-} else {
-	$status = 'n/a';
-}
-workerLog('worker: Deezer Connect:  ' . $status);
-
-// Start Squeezelite renderer
-if ($_SESSION['feat_bitmask'] & FEAT_SQUEEZELITE) {
-	if (isset($_SESSION['slsvc']) && $_SESSION['slsvc'] == 1) {
-		$status = 'started';
-		cfgSqueezelite();
-		startSqueezeLite();
-	} else {
-		$status = 'available';
-	}
-} else {
-	$status = 'n/a';
-}
-workerLog('worker: Squeezelite:     ' . $status);
-
-// Start UPnP renderer
-if ($_SESSION['feat_bitmask'] & FEAT_UPMPDCLI) {
-	if (isset($_SESSION['upnpsvc']) && $_SESSION['upnpsvc'] == 1) {
-		$status = 'started';
-		startUPnP();
-	} else {
-		$status = 'available';
-	}
-} else {
-	$status = 'n/a';
-}
-workerLog('worker: UPnP client:     ' . $status);
-
-// Start Plexamp renderer
-if ($_SESSION['feat_bitmask'] & FEAT_PLEXAMP) {
-	if ($_SESSION['plexamp_installed'] == 'yes') {
-		sysCmd("sed -i '/User=/c \User=" . $_SESSION['user_id'] . "' /etc/systemd/system/plexamp.service");
-		sysCmd("sed -i '/WorkingDirectory=/c \WorkingDirectory=/home/" . $_SESSION['user_id'] . "/plexamp' /etc/systemd/system/plexamp.service");
-		sysCmd("sed -i '/ExecStart=/c \ExecStart=/usr/bin/node /home/" . $_SESSION['user_id'] . "/plexamp/js/index.js' /etc/systemd/system/plexamp.service");
-		if (isset($_SESSION['pasvc']) && $_SESSION['pasvc'] == 1) {
+	// Start airplay renderer
+	if ($_SESSION['feat_bitmask'] & FEAT_AIRPLAY) {
+		if (isset($_SESSION['airplaysvc']) && $_SESSION['airplaysvc'] == 1) {
 			$status = 'started';
-			startPlexamp();
+			startAirPlay();
 		} else {
 			$status = 'available';
 		}
 	} else {
-		$status = 'not installed';
+		$status = 'n/a';
 	}
-} else {
-	$status = 'n/a';
-}
-if (!isset($_SESSION['alsavolume_max_pa'])) {
-	$_SESSION['alsavolume_max_pa'] = $_SESSION['alsavolume_max'];
-}
-$status .= ', ALSA maxvol: ' . $_SESSION['alsavolume_max_pa'] . '%';
-workerLog('worker: Plexamp:         ' . $status);
+	workerLog('worker: AirPlay:         ' . $status);
 
-// Start RoonBridge renderer
-if ($_SESSION['feat_bitmask'] & FEAT_ROONBRIDGE) {
-	if ($_SESSION['roonbridge_installed'] == 'yes') {
-		if (isset($_SESSION['rbsvc']) && $_SESSION['rbsvc'] == 1) {
+	// Start Spotify Connect renderer
+	if ($_SESSION['feat_bitmask'] & FEAT_SPOTIFY) {
+		if (isset($_SESSION['spotifysvc']) && $_SESSION['spotifysvc'] == 1) {
 			$status = 'started';
-			startRoonBridge();
+			startSpotify();
 		} else {
 			$status = 'available';
 		}
 	} else {
-		$status = 'not installed';
+		$status = 'n/a';
 	}
-} else {
-	$status = 'n/a';
+	workerLog('worker: Spotify Connect: ' . $status);
+
+	// Start Deezer Connect renderer
+	if ($_SESSION['feat_bitmask'] & FEAT_DEEZER) {
+		if (isset($_SESSION['deezersvc']) && $_SESSION['deezersvc'] == 1) {
+			$status = 'started';
+			startDeezer();
+		} else {
+			$status = 'available';
+		}
+	} else {
+		$status = 'n/a';
+	}
+	workerLog('worker: Deezer Connect:  ' . $status);
+
+	// Start Squeezelite renderer
+	if ($_SESSION['feat_bitmask'] & FEAT_SQUEEZELITE) {
+		if (isset($_SESSION['slsvc']) && $_SESSION['slsvc'] == 1) {
+			$status = 'started';
+			cfgSqueezelite();
+			startSqueezeLite();
+		} else {
+			$status = 'available';
+		}
+	} else {
+		$status = 'n/a';
+	}
+	workerLog('worker: Squeezelite:     ' . $status);
+
+	// Start UPnP renderer
+	if ($_SESSION['feat_bitmask'] & FEAT_UPMPDCLI) {
+		if (isset($_SESSION['upnpsvc']) && $_SESSION['upnpsvc'] == 1) {
+			$status = 'started';
+			startUPnP();
+		} else {
+			$status = 'available';
+		}
+	} else {
+		$status = 'n/a';
+	}
+	workerLog('worker: UPnP client:     ' . $status);
+
+	// Start Plexamp renderer
+	if ($_SESSION['feat_bitmask'] & FEAT_PLEXAMP) {
+		if ($_SESSION['plexamp_installed'] == 'yes') {
+			sysCmd("sed -i '/User=/c \User=" . $_SESSION['user_id'] . "' /etc/systemd/system/plexamp.service");
+			sysCmd("sed -i '/WorkingDirectory=/c \WorkingDirectory=/home/" . $_SESSION['user_id'] . "/plexamp' /etc/systemd/system/plexamp.service");
+			sysCmd("sed -i '/ExecStart=/c \ExecStart=/usr/bin/node /home/" . $_SESSION['user_id'] . "/plexamp/js/index.js' /etc/systemd/system/plexamp.service");
+			if (isset($_SESSION['pasvc']) && $_SESSION['pasvc'] == 1) {
+				$status = 'started';
+				startPlexamp();
+			} else {
+				$status = 'available';
+			}
+		} else {
+			$status = 'not installed';
+		}
+	} else {
+		$status = 'n/a';
+	}
+	if (!isset($_SESSION['alsavolume_max_pa'])) {
+		$_SESSION['alsavolume_max_pa'] = $_SESSION['alsavolume_max'];
+	}
+	$status .= ', ALSA maxvol: ' . $_SESSION['alsavolume_max_pa'] . '%';
+	workerLog('worker: Plexamp:         ' . $status);
+
+	// Start RoonBridge renderer
+	if ($_SESSION['feat_bitmask'] & FEAT_ROONBRIDGE) {
+		if ($_SESSION['roonbridge_installed'] == 'yes') {
+			if (isset($_SESSION['rbsvc']) && $_SESSION['rbsvc'] == 1) {
+				$status = 'started';
+				startRoonBridge();
+			} else {
+				$status = 'available';
+			}
+		} else {
+			$status = 'not installed';
+		}
+	} else {
+		$status = 'n/a';
+	}
+	workerLog('worker: RoonBridge:      ' . $status);
 }
-workerLog('worker: RoonBridge:      ' . $status);
 
 // Start Multiroom audio
 if ($_SESSION['feat_bitmask'] & FEAT_MULTIROOM) {
@@ -1694,8 +1700,12 @@ while (true) {
 	if ($_SESSION['maint_interval'] != 0) {
 		chkMaintenance();
 	}
-	if ($_SESSION['btsvc'] == '1' && $_SESSION['audioout'] == 'Local') {
-		chkBtActive();
+	if ($_SESSION['btsvc'] == '1') {
+		if($_SESSION['audioout'] == 'Local') {
+			chkBtActive();
+		} else if($_SESSION['audioout'] == 'Bluetooth') {
+			checkBtSpeakerConnected();
+		}
 	}
 	if ($_SESSION['airplaysvc'] == '1') {
 		chkAplActive();
@@ -1805,6 +1815,35 @@ function chkMaintenance() {
 		$GLOBALS['maint_interval'] = $_SESSION['maint_interval'];
 
 		debugLog('Maintenance completed');
+	}
+}
+
+function checkBtSpeakerConnected() {
+	if (!isset($_SESSION['used_bt_speaker'])) {
+		return;
+	}
+	
+	$previously_connected = $_SESSION['bt_speaker_connected'];
+	$result = sysCmd('bt-device -i '.$_SESSION['used_bt_speaker']);
+	// The selected bluetooth speaker is currenctly disconnected
+	if (strpos($result[9], 'Connected: 0') !== false) {
+		if(!$previously_connected)
+		{
+			// Already processed the disconnection
+			return;
+		}
+		phpSession('write', 'bt_speaker_connected', '0');
+		workerLog("worker: checkBtSpeakerConnected(): Speaker ".$_SESSION['used_bt_speaker']." is disconnected we need to stop renderes to prevent issues");
+		stopAllRenderers();
+	} else {
+		if($previously_connected)
+		{
+			// Already processed the [re]connection
+			return;
+		}
+		phpSession('write', 'bt_speaker_connected', '1');
+		workerLog("worker: checkBtSpeakerConnected(): Speaker ".$_SESSION['used_bt_speaker']." is connected, renderers can now work");
+		startAllRenderers();
 	}
 }
 

--- a/www/inc/audio.php
+++ b/www/inc/audio.php
@@ -174,14 +174,12 @@ function setAudioOut($output) {
 	// Update audio out and BT out confs
 	updAudioOutAndBtOutConfs($_SESSION['cardnum'], $_SESSION['alsa_output_mode']);
 
-	// Restart renderers if indicated
-	if ($_SESSION['airplaysvc'] == '1') {
-		stopAirPlay();
-		startAirPlay();
-	}
-	if ($_SESSION['spotifysvc'] == '1') {
-		stopSpotify();
-		startSpotify();
+	// Restart renderers if we are on Local output. Bluetooth is managing by connection
+	if ($output == 'Local') {
+		restartAllRenderers();
+	} else if ($output == 'Bluetooth') {
+		stopAllRenderers();
+		phpSession('write', 'bt_speaker_connected', '0');
 	}
 
 	// Set HTTP server state

--- a/www/inc/renderer.php
+++ b/www/inc/renderer.php
@@ -10,6 +10,55 @@ require_once __DIR__ . '/multiroom.php';
 require_once __DIR__ . '/session.php';
 require_once __DIR__ . '/sql.php';
 
+// GLOBALS
+function restartAllRenderers() {
+	stopAllRenderers();
+	startAllRenderers();
+}
+
+function stopAllRenderers() {
+	if ($_SESSION['airplaysvc'] == 1) {
+		stopAirPlay();
+	}
+	if ($_SESSION['spotifysvc'] == 1) {
+		stopSpotify();
+	}
+	if ($_SESSION['deezersvc'] == 1) {
+		stopDeezer();
+	}
+	if ($_SESSION['slsvc'] == 1) {
+		stopSqueezelite();
+	}
+	if ($_SESSION['pasvc'] == 1) {
+		stopPlexamp();
+	}
+	if ($_SESSION['rbsvc'] == 1) {
+		stopRoonBridge();
+	}
+}
+
+function startAllRenderers() {
+	if ($_SESSION['airplaysvc'] == 1) {
+		startAirPlay();
+	}
+	if ($_SESSION['spotifysvc'] == 1) {
+		startSpotify();
+	}
+	if ($_SESSION['deezersvc'] == 1) {
+		startDeezer();
+	}
+	if ($_SESSION['slsvc'] == 1) {
+		cfgSqueezelite();
+		startSqueezelite();
+	}
+	if ($_SESSION['pasvc'] == 1) {
+		startPlexamp();
+	}
+	if ($_SESSION['rbsvc'] == 1) {
+		startRoonBridge();
+	}
+}
+
 // Bluetooth
 function startBluetooth() {
 	sysCmd('systemctl start hciuart');


### PR DESCRIPTION
Using MusicAssistant, if the renderer raise an error, all the MA provider is in failure
This means that when streaming to a BT speaker, if the speaker is not connected, we need to restart MA 

To fix this I propose in this PR to bind renderers start/stop regarding the bluetooth connection status
Because we don't want to see in our client the speaker if it's finally not available
To make it working you will need to reconnect your speaker the firstime to make the MAC available inside SESSION

Feel free for any comment! 👍