### PR TITLE
[alsa.php]: Fix hardware mixer for HiFiBerry DAC2 HD set by name

### DIFF
--- a/www/inc/alsa.php
+++ b/www/inc/alsa.php
@@ -286,9 +286,9 @@ function getAlsaHwParams($cardNum) {
 		}
 
 		// Rates: '44100 (44100/1)' etc
-	 	$rate = substr($array['rate'], 0, strpos($array['rate'], ' (')); // Could use: explode(' ', $array['rate'])
-	 	$array['rate'] = formatRate($rate);
-	 	$floatRate = (float)$rate;
+		$rate = substr($array['rate'], 0, strpos($array['rate'], ' (')); // Could use: explode(' ', $array['rate'])
+		$array['rate'] = formatRate($rate);
+		$floatRate = (float)$rate;
 
 		if (substr($array['format'], 0, 3) == 'DSD') {
 			// Native DSD: 'DSD_U16_BE', 'DSD_U32_BE' format designators

--- a/www/inc/alsa.php
+++ b/www/inc/alsa.php
@@ -20,7 +20,10 @@ function getAlsaMixerName($deviceName) {
 			$mixerName = 'Channels';
 		} else if ($deviceName == 'HiFiBerry DAC+ DSP') {
 			$mixerName = 'DSPVolume';
-		} else if ($_SESSION['i2soverlay'] == 'hifiberry-dacplushd') {
+		} else if
+			$deviceName == 'HiFiBerry DAC2 HD' ||
+			$_SESSION['i2soverlay'] == 'hifiberry-dacplushd'
+		) {
 			$mixerName = 'DAC';
 		} else if ($deviceName == 'MERUS(tm) Amp piHAT ZW') {
 			$mixerName = 'A.Mstr Vol';


### PR DESCRIPTION
- Fix hardware mixer for `HiFiBerry DAC2 HD` set by name
- Fix whitespace

Fixes #725 