### PR TITLE
Fixed switch to track's folder navigation

### DIFF
--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -2894,21 +2894,24 @@ $(document).on('click', '.context-menu a', function(e) {
             });
             break;
 		case 'go_to_folder':
-            // get track complete filename
-            $.getJSON('command/queue.php?cmd=get_playqueue_item_tag&songpos=' + UI.dbEntry[0] + '&tag=file', function(trackPath) {
-                if (trackPath != '') {
-                    trackPath = trackPath.slice(0, trackPath.lastIndexOf('/')); // just the path / cue
-                    // set the depth of the path for backwards navigation
-                    UI.dbPos[10] = trackPath.split('/').length;
-                    // read folder contents
-                    $.getJSON('command/music-library.php?cmd=lsinfo', { 'path': trackPath }, function(folderContents) {
-                        // switch to Folder view
-                        renderFolderView(folderContents, trackPath);
-                        currentView = 'playback,folder';
-                        $('#coverart-url').click();
-                    });
-               }
-            });
+            // check for radio station
+			if ($('#pq-' + (UI.dbEntry[0] + 1) + ' .pll2').html().substr(0, 2) != '<i') {
+                // get track complete filename
+                $.getJSON('command/queue.php?cmd=get_playqueue_item_tag&songpos=' + UI.dbEntry[0] + '&tag=file', function(trackPath) {
+                    if (trackPath != '') {
+                        trackPath = trackPath.slice(0, trackPath.lastIndexOf('/')); // just the path / cue
+                        // set the depth of the path for backwards navigation
+                        UI.dbPos[10] = trackPath.split('/').length;
+                        // read folder contents
+                        $.getJSON('command/music-library.php?cmd=lsinfo', { 'path': trackPath }, function(folderContents) {
+                            // switch to Folder view
+                            renderFolderView(folderContents, trackPath);
+                            currentView = 'playback,folder';
+                            $('#coverart-url').click();
+                        });
+                    }
+                });
+            }
             break;
         case 'playqueue_top':
             if (UI.mobile) {

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -2894,21 +2894,22 @@ $(document).on('click', '.context-menu a', function(e) {
             });
             break;
 		case 'go_to_folder':
-			var pqItem = '#pq-' + (UI.dbEntry[0] + 1);
-			var micIcon = $(pqItem + ' .pll2').html().substr(0, 2) == '<i';
-			var artist = $(pqItem + ' .pll2').text().split(' - ')[0];
-			var album = $(pqItem + ' .pll2').text().split(' - ')[1]
-			// Only song files
-			if (!micIcon) {
-				// Switch to Folder view
-				currentView = 'playback,folder';
-				$('#coverart-url').click();
-				// Execute Advanced search
-				$('#dbsearch-artist').val(artist);
-				$('#dbsearch-album').val(album);
-				$('#db-search-submit').click();
-			}
-			break;
+            // get track complete filename
+            $.getJSON('command/queue.php?cmd=get_playqueue_item_tag&songpos=' + UI.dbEntry[0] + '&tag=file', function(trackPath) {
+                if (trackPath != '') {
+                    trackPath = trackPath.slice(0, trackPath.lastIndexOf('/')); // just the path / cue
+                    // set the depth of the path for backwards navigation
+                    UI.dbPos[10] = trackPath.split('/').length;
+                    // read folder contents
+                    $.getJSON('command/music-library.php?cmd=lsinfo', { 'path': trackPath }, function(folderContents) {
+                        // switch to Folder view
+                        renderFolderView(folderContents, trackPath);
+                        currentView = 'playback,folder';
+                        $('#coverart-url').click();
+                    });
+               }
+            });
+            break;
         case 'playqueue_top':
             if (UI.mobile) {
         		itemPos = $('#playqueue ul li:nth-child(1)').position().top;


### PR DESCRIPTION
1. first, got the track's complete file name
2. got its folder contents
3. set the path's depth to allow backwards navigation
4. switched to folder view
only one thing: the parent folder scrolling into view, when navigating backwards, does not work because it's too complicated to reconstruct...