### PR TITLE
fix: border radius on hovered menu items

### DIFF
--- a/www/css/moode.css
+++ b/www/css/moode.css
@@ -95,7 +95,7 @@ li.modal-dropdown-text:focus {color:#eee;}
     font-family:'Lato',sans-serif;white-space:nowrap;border-radius:0;}
 .dropdown-menu > li:last-child a, .viewswitch .btn:last-child {padding-bottom:.35em;}
 .dropdown-menu > li:first-child a, .viewswitch .btn:first-child {padding-top:.35em;}
-.dropdown-menu {float:right;position:absolute;min-width:13.5rem;left:auto;border:none;list-style:none outside none;background-color:var(--adaptmbg);box-shadow:0px 4px 10px rgba(0, 0, 0, 0.4);border-radius:.5em;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);z-index:1000;white-space:normal;padding:0;}
+.dropdown-menu {float:right;position:absolute;min-width:13.5rem;left:auto;border:none;list-style:none outside none;background-color:var(--adaptmbg);box-shadow:0px 4px 10px rgba(0, 0, 0, 0.4);border-radius:.5em;overflow:hidden;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);z-index:1000;white-space:normal;padding:0;}
 .dropdown-menu.open {padding:0;margin:0;}
 .bootstrap-select .dropdown-menu {background-color:transparent;}
 .btn-group.open.bootstrap-select .btn.dropdown-toggle {background-color:rgba(128,128,128,0.3);box-shadow:none;border-radius:4px;}


### PR DESCRIPTION
The `dropdown-menu` has rounded borders, but on hovering the first and last item do not apply a border-radius, so they don't have rounded borders.

<img width="297" height="479" alt="Screenshot 2026-03-15 at 20 09 06" src="https://github.com/user-attachments/assets/ae9c6401-1352-4ae7-9833-673079ee814b" />


Hiding the overflow fixes this problem.