### PR TITLE
Update playlist.php

### DIFF
--- a/www/command/playlist.php
+++ b/www/command/playlist.php
@@ -192,50 +192,60 @@ function getPlaylists() {
 }
 // Return playlist metadata and items
 function getPlaylistContents($plName) {
-	$plFile = MPD_PLAYLIST_ROOT . $plName . '.m3u';
-	$dbh = sqlConnect();
-	$sock = getMpdSock('command/playlist.php');
-
-	$genre = '';
-	$cover = 'default';
-	$items = array();
-
-	if (false === ($plItems = file($plFile, FILE_IGNORE_NEW_LINES))) {
-		workerLog('getPlaylistContents(): File read failed on ' . $plFile);
-	} else {
-		// Parse genre and cover (first 2 lines) and create item {name, path, line2}
-		foreach($plItems as $item) {
-			if (strpos($item, '#EXTGENRE') !== false) {
-				$genre = explode(':', $item)[1];
-			} else if (strpos($item, '#EXTIMG') !== false) {
-				$cover = explode(':', $item)[1];
-			} else {
-				if (substr($item, 0, 4) == 'http') {
-					// Radio station
-					$result = sqlQuery("SELECT name FROM cfg_radio WHERE station='" . SQLite3::escapeString($item) . "'", $dbh);
-					if ($result === true) {
-						// Query successful but no result, set name to URL
-						$name = $item;
-					} else {
-						// Query successful and non-empty result
-						$name = $result[0]['name'];
-					}
-					$line2 = DEFAULT_STATION_NAME;
-				} else {
-					// Song file
-					sendMpdCmd($sock, 'lsinfo "' . $item . '"');
-					$tags = parseDelimFile(readMpdResp($sock), ': ');
-					$name = $tags['Title'] ? $tags['Title'] : 'Unknown title';
-					$line2 = ($tags['Album'] ? $tags['Album'] : 'Unknown album') . ' - ' .
-						($tags['Artist'] ? $tags['Artist'] : 'Unknown artist');
-				}
-
-				array_push($items, array('name' => $name, 'path' => $item, 'line2' => $line2));
-			}
-		}
-	}
-
-	return array('genre' => $genre, 'cover' => $cover, 'items' => $items);
+        $plFile = MPD_PLAYLIST_ROOT . $plName . '.m3u';
+        $dbh = sqlConnect();
+        $sock = getMpdSock('command/playlist.php');
+        $genre = '';
+        $cover = 'default';
+        $items = array();
+        $extinfTitle = null;
+        if (false === ($plItems = file($plFile, FILE_IGNORE_NEW_LINES))) {
+                workerLog('getPlaylistContents(): File read failed on ' . $plFile);
+        } else {
+                // Parse genre and cover and create item {name, path, line2}
+                foreach($plItems as $item) {
+                        if (strpos($item, '#EXTGENRE') !== false) {
+                                $genre = explode(':', $item)[1];
+                        } else if (strpos($item, '#EXTIMG') !== false) {
+                                $cover = explode(':', $item)[1];
+                        } else if (strpos($item, '#EXTINF') !== false) {
+                                // Extract title from "#EXTINF:-1,Episode title here"
+                                $extinfTitle = strpos($item, ',') !== false ? trim(substr($item, strpos($item, ',') + 1)) : null;
+                        } else if (substr($item, 0, 1) === '#') {
+                                // Skip all other # lines (#EXTM3U, #PLAYLIST, etc.)
+                                continue;
+                        } else {
+                                if (substr($item, 0, 4) == 'http') {
+                                        // Radio station or podcast episode
+                                        if ($extinfTitle) {
+                                                // Use title from preceding #EXTINF line
+                                                $name = $extinfTitle;
+                                                $extinfTitle = null;
+                                        } else {
+                                                $result = sqlQuery("SELECT name FROM cfg_radio WHERE station='" . SQLite3::escapeString($item) . "'", $dbh);
+                                                if ($result === true) {
+                                                        // Query successful but no result, set name to URL
+                                                        $name = $item;
+                                                } else {
+                                                        // Query successful and non-empty result
+                                                        $name = $result[0]['name'];
+                                                }
+                                        }
+                                        $line2 = 'Radio Station';
+                                } else {
+                                        // Song file
+                                        sendMpdCmd($sock, 'lsinfo "' . $item . '"');
+                                        $tags = parseDelimFile(readMpdResp($sock), ': ');
+                                        $name = $tags['Title'] ? $tags['Title'] : 'Unknown title';
+                                        $line2 = ($tags['Album'] ? $tags['Album'] : 'Unknown album') . ' - ' .
+                                                ($tags['Artist'] ? $tags['Artist'] : 'Unknown artist');
+                                        $extinfTitle = null;
+                                }
+                                array_push($items, array('name' => $name, 'path' => $item, 'line2' => $line2));
+                        }
+                }
+        }
+        return array('genre' => $genre, 'cover' => $cover, 'items' => $items);
 }
 // Return playlist metadata
 function getPlaylistMetadata($plName) {


### PR DESCRIPTION
M3U parser ignoring #EXTINF titles in getPlaylistContents() #EXTINF and other standard M3U comment lines were being passed to MPD's lsinfo, returning no tags and displaying as "Unknown title" in the Edit Playlist view, and only showed MP3 adress in Playing. This also caused slowdown as MPD attempted to resolve each comment line as a stream. #EXTINF titles are now parsed and applied to the following URL entry. All other unrecognised # lines are skipped. No change to behaviour for song file playlists or radio stations.