### PR TITLE
Include elapsed and duration time to 'currentsong'

### DIFF
--- a/www/daemon/worker.php
+++ b/www/daemon/worker.php
@@ -2429,7 +2429,8 @@ function updExtMetaFile() {
 				$fileData['album'] != $current['album'] ||
 				$fileData['volume'] != $volknob ||
 				$fileData['mute'] != $_SESSION['volmute'] ||
-				$fileData['outrate'] != $current['output']
+				$fileData['outrate'] != $current['output'] ||
+				$fileData['elapsed'] != $current['elapsed']
 			) {
 				//workerLog('worker: Update currentsong.txt file (MPD)');
 				$fh = fopen(CURRENTSONG_TXT_TMP, 'w');
@@ -2451,6 +2452,8 @@ function updExtMetaFile() {
 				$data .= 'volume=' . $volknob . "\n";
 				$data .= 'mute=' . $volmute . "\n";
 				$data .= 'state=' . $current['state'] . "\n";
+				$data .= 'elapsed=' . $current['elapsed'] . "\n";
+				$data .= 'duration=' . $current['time'] . "\n";
 				fwrite($fh, $data);
 				fclose($fh);
 				rename(CURRENTSONG_TXT_TMP, CURRENTSONG_TXT);


### PR DESCRIPTION
Hey, 
I have one proposal for an improvement which would personally help me: If available (in mpd, not possible in AirPlay I believe) the elapsed time and the total duration is written to currentsong (txt and API). 
I am using this information for a lastfm scrobbler I have written. Since the duration is not available the scrobbler can not set a minumum listening time based on the information in the currentsong.txt