### PR TITLE
Add condition to check w_queue in waitWorker

### DIFF
--- a/www/inc/common.php
+++ b/www/inc/common.php
@@ -565,7 +565,7 @@ function waitWorker($caller) {
 	//debugLog('waitWorker(): Start ' . $caller . ', w_active=' . $_SESSION['w_active']);
 	$loopCnt = 0;
 
-	if ($_SESSION['w_active'] == 1) {
+	if ($_SESSION['w_active'] == 1 && $_SESSION['w_queue'] != 'reset_screen_saver') {
 		do {
 			usleep(WAITWORKER_SLEEP);
 			debugLog('waitWorker(): Wait ' . ++$loopCnt . ' for ' . $caller);


### PR DESCRIPTION
Opening Configure from the main player UI and clicking any option (System, Renderers, Network, etc.) causes the browser to hang indefinitely. The page never loads. Navigating directly to the URL (e.g.  http://moode.local/sys-config.php ) works fine — the problem only occurs when clicking from the Configure modal while the player is active.

To fix is , i modified /var/www/inc/common.php modified waitWorker() to skip the wait when the only queued job is reset_screen_saver.