### PR TITLE
add dmix output mode option

### DIFF
--- a/www/inc/constants.php
+++ b/www/inc/constants.php
@@ -267,7 +267,7 @@ const ALSA_RESERVED_NAMES = array(ALSA_LOOPBACK_DEVICE, ALSA_DUMMY_DEVICE);
 const ALSA_DEFAULT_MIXER_NAME_I2S = 'Digital';
 const ALSA_DEFAULT_MIXER_NAME_INTEGRATED = 'PCM';
 // ALSA output mode names
-const ALSA_OUTPUT_MODE_NAME = array('plughw' => 'Default', 'hw' => 'Direct', 'iec958' => 'IEC958');
+const ALSA_OUTPUT_MODE_NAME = array('plughw' => 'Default', 'hw' => 'Direct', 'iec958' => 'IEC958', 'dmix' => 'Mix');
 const ALSA_OUTPUT_MODE_BT_NAME = array('_audioout' => 'Standard', 'plughw' => 'Compatibility');
 // ALSA HDMI IEC958
 const ALSA_IEC958_DEVICE = 'default:vc4hdmi';

--- a/www/snd-config.php
+++ b/www/snd-config.php
@@ -484,6 +484,7 @@ if ($_SESSION['pi_modelnum'] >= 3 && isHDMIDevice($_SESSION['adevname'])) {
 } else {
 	$_select['alsa_output_mode'] .= "<option value=\"plughw\" " . (($_SESSION['alsa_output_mode'] == 'plughw') ? "selected" : "") . ">" . ALSA_OUTPUT_MODE_NAME['plughw'] . "</option>\n";
 	$_select['alsa_output_mode'] .= "<option value=\"hw\" " . (($_SESSION['alsa_output_mode'] == 'hw') ? "selected" : "") . ">" . ALSA_OUTPUT_MODE_NAME['hw'] . "</option>\n";
+	$_select['alsa_output_mode'] .= "<option value=\"dmix\" " . (($_SESSION['alsa_output_mode'] == 'dmix') ? "selected" : "") . ">" . ALSA_OUTPUT_MODE_NAME['dmix'] . "</option>\n";
 	$_alsa_output_mode = $_SESSION['alsa_output_mode'] . ':' . $_SESSION['cardnum'] . ',0';
 }
 // Loopback

--- a/www/templates/snd-config.html
+++ b/www/templates/snd-config.html
@@ -163,6 +163,7 @@
 				<span id="info-alsa-output-mode" class="config-help-info">
 					<b>Default: </b>ALSA "plughw" plugin which performs format conversions if needed to match audio device requirements.<br>
 					<b>Direct: </b>ALSA "hw" plugin which does not perform format conversions. The audio device must accept the given format.<br>
+					<b>Mix: </b>ALSA "dmix" plugin which provides software mixing of multiple audio streams. This mode is not compatible with CamillaDSP.<br>
 					<b>IEC958: </b>ALSA "iec958" plugin which provides IEC958_SUBFRAME_LE format for HDMI audio.<br>
 					These modes apply to MPD, Bluetooth (inbound), AirPlay, Spotify Connect, Squeezelite and the Equalizers.
 				</span>


### PR DESCRIPTION
Add [dmix](https://www.alsa-project.org/alsa-doc/alsa-lib/pcm_plugins.html#pcm_plugins_dmix) plug type as ALSA audio output.

<img width="1255" height="509" alt="image" src="https://github.com/user-attachments/assets/c3406467-f0cd-4c35-bd68-dbc080ef0511" />