### PR TITLE
Fix volume control responsiveness (display freeze/jump + knob drag flooding)

### DIFF
--- a/www/engine-mpd.php
+++ b/www/engine-mpd.php
@@ -53,6 +53,7 @@ if ($_GET['state'] == $status['state']) {
 		$event = explode("\n", $resp)[0];
 		$status = getMpdStatus($sock);
 		$status['idle_timeout_event'] = $event;
+		$status['idle_mixer_changed'] = (strpos($resp, 'changed: mixer') !== false) ? '1' : '0';
 		$status['empd_socket_timeout'] = $sockTimeout;
 		scriptLog('Event (' . $event . ')');
 	}

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -1081,10 +1081,16 @@ function renderUIVol() {
 
 	// Load session vars (required for multi-client)
     $.getJSON('command/cfg-table.php?cmd=get_cfg_system', function(data) {
+        var localVol = SESSION.json['volknob'];
+        var localMute = SESSION.json['volmute'];
     	if (data === false) {
             console.log('renderUIVol(): No data returned from get_cfg_system');
     	} else {
             SESSION.json = data;
+        }
+        if (Date.now() - (GLOBAL.volLastChange || 0) < 1500) {
+            SESSION.json['volknob'] = localVol;
+            SESSION.json['volmute'] = localMute;
         }
 
         // Volume type
@@ -1137,10 +1143,16 @@ function renderUI() {
 
     // Load session vars (required for multi-client)
     $.getJSON('command/cfg-table.php?cmd=get_cfg_system', function(data) {
+        var localVol = SESSION.json['volknob'];
+        var localMute = SESSION.json['volmute'];
         if (data === false) {
             console.log('renderUI(): No data returned from get_cfg_system');
     	} else {
             SESSION.json = data;
+        }
+        if (Date.now() - (GLOBAL.volLastChange || 0) < 1500) {
+            SESSION.json['volknob'] = localVol;
+            SESSION.json['volmute'] = localMute;
         }
 
         // Debug notification (appears above cover art)
@@ -2711,6 +2723,8 @@ function setVolume(level, event) {
 	level = level > GLOBAL.mpdMaxVolume ? GLOBAL.mpdMaxVolume : level;
 	level = level < 0 ? 0 : level;
 
+	GLOBAL.volLastChange = Date.now();
+
     var async = true;
 
     /*console.log('setVolume(): ' +
@@ -2723,6 +2737,10 @@ function setVolume(level, event) {
 	if (SESSION.json['volmute'] == '0') {
         //console.log('sendVolCmd(): unmute (volknob ' + SESSION.json['volknob'] + ')');
 		SESSION.json['volknob'] = level.toString();
+		if (event != 'knob_change') {
+			$('#volume, #volume-2').val(level).trigger('change');
+		}
+		$('.volume-display div, .mpd-volume-level').text(level);
 		sendVolCmd('POST', 'upd_volume', {'volknob': SESSION.json['volknob'], 'event': event}, async);
     } else {
         // Muted

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -26,6 +26,8 @@ const FEAT_PEPPYDISPLAY = 131072;	// y Peppy display
 //						-------
 //						  228279
 
+const VOL_KNOB_DEBOUNCE = 150; // ms, coalesce a knob drag's intermediate values
+
 // Notifications
 const NOTIFY_TITLE_INFO = '<i class="fa fa-solid fa-sharp fa-circle-check" style="color:#27ae60;"></i> Info';
 const NOTIFY_TITLE_ALERT = '<i class="fa fa-solid fa-sharp fa-circle-xmark" style="color:#e74c3c;"></i> Alert';
@@ -2745,7 +2747,15 @@ function setVolume(level, event) {
 			$('#volume, #volume-2').val(level).trigger('change');
 		}
 		$('.volume-display div, .mpd-volume-level').text(level);
-		sendVolCmd('POST', 'upd_volume', {'volknob': SESSION.json['volknob'], 'event': event}, async);
+		if (event == 'knob_change') {
+			clearTimeout(GLOBAL.volKnobTimer);
+			GLOBAL.volKnobTimer = setTimeout(function() {
+				sendVolCmd('POST', 'upd_volume', {'volknob': SESSION.json['volknob'], 'event': event}, async);
+			}, VOL_KNOB_DEBOUNCE);
+		} else {
+			clearTimeout(GLOBAL.volKnobTimer);
+			sendVolCmd('POST', 'upd_volume', {'volknob': SESSION.json['volknob'], 'event': event}, async);
+		}
     } else {
         // Muted
 		if (level == 0 && event == 'mute')	{

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -349,6 +349,10 @@ function engineMpd() {
     					if (MPD.json['date']) MPD.json['date'] = MPD.json['date'].slice(0,4); // should fix in php but...
     					renderUI();
     				}
+
+    				if (MPD.json['idle_mixer_changed'] == '1' && MPD.json['idle_timeout_event'] != 'changed: mixer') {
+    					renderUIVol();
+    				}
                 }
 
     			engineMpd();


### PR DESCRIPTION
## Demo

changing volume rapiddly on vol + and vol - button then using slider

**Before** — the displayed value freezes then jumps:

[before.webm](https://github.com/user-attachments/assets/1c955111-5cc9-4679-95f0-1d6456662792)

**After** — the value tracks every step smoothly:

[after.webm](https://github.com/user-attachments/assets/9154636e-282c-450a-9e8f-81db89498978)

## Problem

When changing the volume with the +/- buttons or by dragging the volume
knob, the volume readout (`.volume-display`) does not reliably track the
change: the number freezes for a few clicks and then jumps to catch up, the
+/- button can stay stuck in its `active` state, and dragging the knob
across a wide range lags for several seconds before the volume settles.

## Steps to reproduce

1. Play a track so MPD is active.
2. Click the + (or -) button quickly several times in a row, or drag the
   volume knob across a wide range (e.g. 10 → 90 → 10).
3. Observe: the displayed number freezes for a few steps then jumps to catch
   up (and can briefly bounce backward), the +/- button can stay highlighted,
   and a wide knob drag takes several seconds to settle.

Most visible with a hardware mixer + USB DAC, but reproducible with a
software mixer too.

## Root cause

The volume readout is only refreshed by `renderUIVol()`, which runs when the
MPD `changed: mixer` idle event arrives via the `engine-mpd.php` long-poll.
Four issues compound:

1. **No optimistic update.** `setVolume()` updates `SESSION.volknob` and
   POSTs `upd_volume`, but never touches the display. The readout depends
   100% on the server round-trip. MPD coalesces several quick mixer changes
   into a single idle event, and the long-poll can't keep up with the input
   rate, so `renderUIVol()` runs far less often than the user clicks → the
   number appears frozen, then jumps.

2. **Stale reconciliation bounce.** `renderUIVol()`/`renderUI()` re-read
   `volknob` from `cfg_system` asynchronously, but `upd_volume` writes
   `cfg_system` asynchronously too. A render firing mid-adjustment reads a
   lagging value and overwrites both the display and `SESSION.volknob`
   backward, so the next click even starts from the wrong value.

3. **Coalesced mixer event lost.** `engine-mpd.php` uses only the first line
   of the idle response (`explode("\n", $resp)[0]`), but a single `idle`
   read clears *all* pending subsystems in MPD. When a mixer change is
   coalesced behind another subsystem (e.g. `changed: player` when the volume
   is changed at a track boundary), `changed: mixer` is dropped and the
   volume UI never refreshes for that change.

4. **Knob-drag command flood.** The volume knob's `change` callback fires for
   every intermediate value while dragging, and each call sent an
   `upd_volume` command. A 10→90→10 drag queued ~160 MPD/amixer commands and
   took several seconds to drain, so the knob felt unresponsive.

## Fix

- `setVolume()` updates the display immediately with the level the client
  already knows, instead of waiting for the round-trip.
- A `GLOBAL.volLastChange` timestamp makes `renderUIVol()`/`renderUI()` keep
  the client's `volknob`/`volmute` for 1.5 s after a local change, so a
  lagging `cfg_system` read can't bounce it backward. Server reconciliation
  (multi-client / external volume changes) resumes once the user stops.
- `engine-mpd.php` exposes `idle_mixer_changed`, and `engineMpd()` also calls
  `renderUIVol()` when the mixer changed but wasn't the primary idle event.
- The knob's `change` command is debounced (`VOL_KNOB_DEBOUNCE = 150 ms`):
  the display still tracks the drag optimistically in real time, but only the
  settled value is sent. The +/- buttons are unaffected and any pending knob
  send is cancelled when a button is pressed.

## Testing

Validated on a Raspberry Pi 3B running moOde 10.2.4, both desktop browser and
the local-display kiosk, with **hardware** and **software** MPD mixers. Fast
and spaced bursts, up and down, and wide knob drags: the number tracks every
change monotonically, no freeze, no backward bounce, and the knob applies a
single settled command instead of a multi-second queue. Reconciliation
(multi-client / external `mpc volume`) still works after a short idle.

## Known limitation

The dB readout (`.volume-display-db`) still updates only on the render
round-trip (its `mapped_db_vol` is computed server-side), so it can lag one
render behind during a fast burst before catching up.
