### PR TITLE
[pirev.py] Return -1 for unrecognised revision codes instead of crashing

### DIFF
--- a/www/util/pirev.py
+++ b/www/util/pirev.py
@@ -139,6 +139,10 @@ def decode_new_style_code(code):
         }
     else:
         # Original was code&0x17 but this returned the entry for 0x004 when code = 0x00e
+        if code not in OLD_REVISION_CODES:
+            # Not a valid Pi revision code. Return a sentinel instead of raising a
+            # KeyError so callers can detect an unrecognised / non-Pi board.
+            return -1
         old_rev = OLD_REVISION_CODES[code]
         rev_info = {
             "type": old_rev[0],
@@ -171,14 +175,25 @@ def main():
 
     if args.code:
         code = int(args.code if "0x" == args.code[:2] else "0x" + args.code, 16)
+        rev_info = decode_new_style_code(code)
     else:
         # NOTE: In otp_dump the Pi5 revcode is on line 32 while < Pi5 is on line 30.
         #cmd = "vcgencmd otp_dump | awk -F: '/^30:/{print substr($2,3)}'"
         # Alternate command for obtaining the revision code.
         cmd = "cat /proc/cpuinfo | awk -F': ' '/Revision/ {print $2}'"
-        code = int("0x" + subprocess.run(cmd, shell=True, text=True, capture_output=True).stdout.rstrip(), 16)
+        revcode = subprocess.run(cmd, shell=True, text=True, capture_output=True).stdout.rstrip()
+        if revcode == "":
+            # No Revision line in /proc/cpuinfo (not a Raspberry Pi).
+            rev_info = -1
+        else:
+            code = int("0x" + revcode, 16)
+            rev_info = decode_new_style_code(code)
 
-    rev_info = decode_new_style_code(code)
+    if rev_info == -1:
+        # Revision code is absent or not a recognised Pi code (decoding it would
+        # otherwise raise KeyError). Print a sentinel instead of crashing.
+        print("-1")
+        return
 
     info_text = ''
     if args.rcode or args.all or args.code:


### PR DESCRIPTION
Small robustness-only change: no behaviour change on a real Pi, it just keeps
`pirev.py` from crashing on revision codes it can't decode.
Can be help for future developments

### Problem
`pirev.py` raises an unhandled exception for revision codes it can't decode:
- `decode_new_style_code()` looks up `OLD_REVISION_CODES[code]` for old-style
  codes, raising `KeyError` for any code not in the table.
- `main()` decodes `int("0x" + revcode, 16)` unconditionally, so a missing
  `Revision` line (empty revcode) fails too.

Callers that capture the command output then store a Python traceback where a
model number/type is expected.

### Fix
Return/print a `-1` sentinel in those cases instead of raising:
- `decode_new_style_code()` returns `-1` when `code` is not in `OLD_REVISION_CODES`.
- `main()` prints `-1` when there is no `Revision` line or the decode returned `-1`.

Real-Pi behaviour is unchanged — a valid revision code decodes exactly as
before (`a02082` → `0xa02082  3B  1.2  1GB  Sony UK  BCM2837  3  1`).
