### PR TITLE
Add playlist import/export and Browse-view management to the WebUI

### DIFF
--- a/www/command/playlist.php
+++ b/www/command/playlist.php
@@ -16,6 +16,56 @@ chkVariables($_GET, array('item'));
 chkVariables($_POST, array('path'));
 
 switch ($_GET['cmd']) {
+	case 'export_playlist':
+		// Stream a playlist's .m3u file as a download
+		$plName = isset($_GET['name']) ? basename(html_entity_decode($_GET['name'])) : '';
+		$plFile = MPD_PLAYLIST_ROOT . $plName . '.m3u';
+		if ($plName === '' || strpos($plName, '..') !== false || !file_exists($plFile)) {
+			http_response_code(404);
+			exit();
+		}
+		header('Content-Description: File Transfer');
+		header('Content-Type: audio/x-mpegurl');
+		header('Content-Disposition: attachment; filename="' . $plName . '.m3u"');
+		header('Content-Length: ' . filesize($plFile));
+		header('Pragma: no-cache');
+		header('Expires: 0');
+		readfile($plFile);
+		exit();
+	case 'import_playlist':
+		// Upload a .m3u file as a new playlist
+		if (!isset($_FILES['playlist_file']) || $_FILES['playlist_file']['error'] !== UPLOAD_ERR_OK
+			|| !is_uploaded_file($_FILES['playlist_file']['tmp_name'])) {
+			echo json_encode(array('status' => 'error', 'msg' => 'Upload failed'));
+			break;
+		}
+		$origName = basename($_FILES['playlist_file']['name']);
+		$ext = strtolower(pathinfo($origName, PATHINFO_EXTENSION));
+		if ($ext !== 'm3u' && $ext !== 'm3u8') {
+			echo json_encode(array('status' => 'error', 'msg' => 'Only .m3u playlists are supported'));
+			break;
+		}
+		$plName = pathinfo($origName, PATHINFO_FILENAME);
+		if ($plName === '' || preg_match('/["\\\\$`\/]/', $plName) || strpos($plName, '..') !== false) {
+			echo json_encode(array('status' => 'error', 'msg' => 'Invalid playlist name'));
+			break;
+		}
+		if ($_FILES['playlist_file']['size'] <= 0 || $_FILES['playlist_file']['size'] > 5 * 1024 * 1024) {
+			echo json_encode(array('status' => 'error', 'msg' => 'File is empty or too large'));
+			break;
+		}
+		$plFile = MPD_PLAYLIST_ROOT . $plName . '.m3u';
+		if (file_exists($plFile)) {
+			echo json_encode(array('status' => 'error', 'msg' => 'A playlist with this name already exists'));
+			break;
+		}
+		// MPD_PLAYLIST_ROOT is root-owned so copy via sysCmd (root), then match the
+		// owner/perms convention used when a playlist file is first created above
+		sysCmd('cp "' . $_FILES['playlist_file']['tmp_name'] . '" "' . $plFile . '"');
+		sysCmd('chmod 0777 "' . $plFile . '"');
+		sysCmd('chown root:root "' . $plFile . '"');
+		echo json_encode(array('status' => 'ok', 'name' => $plName));
+		break;
 	case 'set_plcover_image':
 		if (submitJob($_GET['cmd'], $_POST['name'] . ',' . $_POST['blob'], '', '')) {
 			echo json_encode('job submitted');

--- a/www/command/playlist.php
+++ b/www/command/playlist.php
@@ -32,26 +32,69 @@ switch ($_GET['cmd']) {
 		header('Expires: 0');
 		readfile($plFile);
 		exit();
+	case 'analyze_import':
+		// Classify the entries of an uploaded .m3u so unknown local paths can be remapped.
+		// When a 'remap' is supplied, it is applied before validating, so the same endpoint
+		// also serves the modal's "Test" button (re-check paths after remapping).
+		$content = isset($_POST['content']) ? $_POST['content'] : '';
+		if ($content === '' || strlen($content) > 5 * 1024 * 1024) {
+			echo json_encode(array('status' => 'error', 'msg' => 'File is empty or too large'));
+			break;
+		}
+		$knownDirs = knownPlaylistDirs();
+		$remap = isset($_POST['remap']) ? json_decode($_POST['remap'], true) : array();
+		if (!is_array($remap)) {
+			$remap = array();
+		}
+		foreach ($remap as $old => $new) {
+			if (!in_array($new, $knownDirs, true)) {
+				unset($remap[$old]);
+			}
+		}
+		$total = 0;
+		$okLocal = 0;
+		$urlCount = 0;
+		$remapped = 0;
+		$groups = array(); // unknown prefix => count + sample
+		foreach (preg_split('/\r\n|\r|\n/', $content) as $line) {
+			$line = trim($line);
+			if ($line === '' || isMetaEntry($line)) {
+				continue;
+			}
+			$total++;
+			if (isUrlEntry($line)) {
+				$urlCount++;
+				continue;
+			}
+			$line = applyPathRemap($line, $remap, $remapped);
+			$prefix = unknownPathPrefix($line);
+			if ($prefix === '') {
+				$okLocal++;
+			} else {
+				if (!isset($groups[$prefix])) {
+					$groups[$prefix] = array('prefix' => $prefix, 'count' => 0, 'sample' => $line);
+				}
+				$groups[$prefix]['count']++;
+			}
+		}
+		$unknown = array();
+		foreach ($groups as $g) {
+			$g['suggested'] = suggestKnownDir($g['prefix'], $knownDirs);
+			$unknown[] = $g;
+		}
+		echo json_encode(array('status' => 'ok', 'total' => $total, 'ok_local' => $okLocal,
+			'url_count' => $urlCount, 'remapped' => $remapped, 'unknown' => $unknown, 'known_dirs' => $knownDirs));
+		break;
 	case 'import_playlist':
-		// Upload a .m3u file as a new playlist
-		if (!isset($_FILES['playlist_file']) || $_FILES['playlist_file']['error'] !== UPLOAD_ERR_OK
-			|| !is_uploaded_file($_FILES['playlist_file']['tmp_name'])) {
-			echo json_encode(array('status' => 'error', 'msg' => 'Upload failed'));
+		// Write an uploaded .m3u as a new playlist, applying optional path remapping
+		$content = isset($_POST['content']) ? $_POST['content'] : '';
+		if ($content === '' || strlen($content) > 5 * 1024 * 1024) {
+			echo json_encode(array('status' => 'error', 'msg' => 'File is empty or too large'));
 			break;
 		}
-		$origName = basename($_FILES['playlist_file']['name']);
-		$ext = strtolower(pathinfo($origName, PATHINFO_EXTENSION));
-		if ($ext !== 'm3u' && $ext !== 'm3u8') {
-			echo json_encode(array('status' => 'error', 'msg' => 'Only .m3u playlists are supported'));
-			break;
-		}
-		$plName = pathinfo($origName, PATHINFO_FILENAME);
+		$plName = isset($_POST['name']) ? basename(html_entity_decode($_POST['name'])) : '';
 		if ($plName === '' || preg_match('/["\\\\$`\/]/', $plName) || strpos($plName, '..') !== false) {
 			echo json_encode(array('status' => 'error', 'msg' => 'Invalid playlist name'));
-			break;
-		}
-		if ($_FILES['playlist_file']['size'] <= 0 || $_FILES['playlist_file']['size'] > 5 * 1024 * 1024) {
-			echo json_encode(array('status' => 'error', 'msg' => 'File is empty or too large'));
 			break;
 		}
 		$plFile = MPD_PLAYLIST_ROOT . $plName . '.m3u';
@@ -59,12 +102,57 @@ switch ($_GET['cmd']) {
 			echo json_encode(array('status' => 'error', 'msg' => 'A playlist with this name already exists'));
 			break;
 		}
-		// MPD_PLAYLIST_ROOT is root-owned so copy via sysCmd (root), then match the
-		// owner/perms convention used when a playlist file is first created above
-		sysCmd('cp "' . $_FILES['playlist_file']['tmp_name'] . '" "' . $plFile . '"');
+		// Accept only remap targets that are real known dirs (defends against crafted POSTs)
+		$remap = isset($_POST['remap']) ? json_decode($_POST['remap'], true) : array();
+		if (!is_array($remap)) {
+			$remap = array();
+		}
+		$knownDirs = knownPlaylistDirs();
+		foreach ($remap as $old => $new) {
+			if (!in_array($new, $knownDirs, true)) {
+				unset($remap[$old]);
+			}
+		}
+		$dropInvalid = isset($_POST['drop_invalid']) && $_POST['drop_invalid'] == '1';
+
+		$out = array();
+		$imported = 0;
+		$remapped = 0;
+		$dropped = 0;
+		foreach (preg_split('/\r\n|\r|\n/', $content) as $line) {
+			$line = trim($line);
+			if ($line === '') {
+				continue;
+			}
+			if (isMetaEntry($line) || isUrlEntry($line)) {
+				$out[] = $line;
+				if (isUrlEntry($line)) {
+					$imported++;
+				}
+				continue;
+			}
+			$line = applyPathRemap($line, $remap, $remapped);
+			if (file_exists(MPD_MUSICROOT . $line)) {
+				$out[] = $line;
+				$imported++;
+			} else if ($dropInvalid) {
+				$dropped++;
+			} else {
+				$out[] = $line;
+				$imported++;
+			}
+		}
+
+		// MPD_PLAYLIST_ROOT is root-owned so stage in a www-data temp then copy via
+		// sysCmd (root), matching the owner/perms convention used elsewhere here
+		$tmpFile = tempnam(sys_get_temp_dir(), 'plimport');
+		file_put_contents($tmpFile, implode("\n", $out) . "\n");
+		sysCmd('cp "' . $tmpFile . '" "' . $plFile . '"');
 		sysCmd('chmod 0777 "' . $plFile . '"');
 		sysCmd('chown root:root "' . $plFile . '"');
-		echo json_encode(array('status' => 'ok', 'name' => $plName));
+		unlink($tmpFile);
+		echo json_encode(array('status' => 'ok', 'name' => $plName,
+			'imported' => $imported, 'remapped' => $remapped, 'dropped' => $dropped));
 		break;
 	case 'set_plcover_image':
 		if (submitJob($_GET['cmd'], $_POST['name'] . ',' . $_POST['blob'], '', '')) {
@@ -409,4 +497,81 @@ function markItemAsFavorite($item) {
 	}
 
 	return $msg;
+}
+
+// Playlist import helpers (path validation and remapping)
+
+// A metadata line (#EXTGENRE, #EXTIMG, #EXTM3U, #EXTINF, ...)
+function isMetaEntry($line) {
+	return $line !== '' && $line[0] == '#';
+}
+// A remote stream / radio station (never path-rewritten)
+function isUrlEntry($line) {
+	return preg_match('#^https?://#i', $line) == 1;
+}
+// Longest existing prefix of a local entry + the first missing segment, or '' if
+// the whole path resolves under the MPD music root (= present in the Folder view)
+function unknownPathPrefix($path) {
+	$accum = '';
+	foreach (explode('/', $path) as $seg) {
+		$test = $accum == '' ? $seg : $accum . '/' . $seg;
+		if (file_exists(MPD_MUSICROOT . $test)) {
+			$accum = $test;
+		} else {
+			return $test;
+		}
+	}
+	return '';
+}
+// Known roots and their immediate subdirs (the Folder view roots/shares), depth <= 2
+function knownPlaylistDirs() {
+	$dirs = array();
+	foreach (ROOT_DIRECTORIES as $root) {
+		if ($root == 'RADIO') {
+			continue;
+		}
+		$rootPath = MPD_MUSICROOT . $root;
+		if (is_dir($rootPath)) {
+			$dirs[] = $root;
+			foreach (scandir($rootPath) as $sub) {
+				if ($sub != '.' && $sub != '..' && is_dir($rootPath . '/' . $sub)) {
+					$dirs[] = $root . '/' . $sub;
+				}
+			}
+		}
+	}
+	return $dirs;
+}
+// Best replacement guess for an unknown prefix: a single same-root share, else ''
+function suggestKnownDir($prefix, $knownDirs) {
+	$root = explode('/', $prefix)[0];
+	$shares = array();
+	$bareRoot = array();
+	foreach ($knownDirs as $dir) {
+		if ($dir === $root) {
+			$bareRoot[] = $dir;
+		} else if (strpos($dir, $root . '/') === 0) {
+			$shares[] = $dir;
+		}
+	}
+	if (count($shares) == 1) {
+		return $shares[0];
+	}
+	if (count($shares) == 0 && count($bareRoot) == 1) {
+		return $bareRoot[0];
+	}
+	return '';
+}
+// Apply the longest matching prefix remap rule to a local entry
+function applyPathRemap($path, $remap, &$remapped) {
+	foreach ($remap as $old => $new) {
+		if ($old === '' || $new === '') {
+			continue;
+		}
+		if ($path === $old || strpos($path, $old . '/') === 0) {
+			$remapped++;
+			return $new . substr($path, strlen($old));
+		}
+	}
+	return $path;
 }

--- a/www/js/notify.js
+++ b/www/js/notify.js
@@ -50,6 +50,8 @@ function notify(title, tag, arg3, arg4 = '') {
 		new_playlist: 'Playlist has been created. ',
 		upd_playlist: 'Playlist has been updated. ',
 		del_playlist: 'Playlist has been deleted. ',
+		import_playlist: 'Playlist has been imported. ',
+		import_playlist_error: 'Import failed. ',
 		// Radio view
 		validation_check: 'Validation check. ',
 		creating_station: 'Creating new station... ',
@@ -130,7 +132,8 @@ function notify(title, tag, arg3, arg4 = '') {
 		// Playback
 		play_here_config_error: 'HTTP streaming must be ON and encoder set to LAME (MP3).',
 		// Playlist view
-		// no_tags
+		import_playlist: 'Playlist has been imported. ',
+		import_playlist_error: 'Import failed. ',
 		// Radio view
 		validation_check: 'Validation check. ',
 		blank_entries: 'Name or URL is blank. ',

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -97,6 +97,27 @@ const DEFAULT_RX_COVER = 'images/default-rx-cover.jpg';
 const DEFAULT_PLAYLIST_COVER = '/var/www/images/default-playlist-cover.jpg';
 const DEFAULT_NOTFOUND_COVER = '/var/www/images/default-notfound-cover.jpg';
 
+// Playlist cover thumbnail failed to load (e.g. an imported playlist with no cover
+// file) → replace the broken image with a default playlist icon. Also drop the
+// text-cover overlay, which would be redundant with the .playlist-name shown below.
+function plCoverFallback(img) {
+	var thumb = img.parentNode;
+	if (thumb) {
+		// Centre the thumbnail box horizontally (it isn't, with just the icon)
+		thumb.style.marginLeft = 'auto';
+		thumb.style.marginRight = 'auto';
+	}
+	var textCover = thumb ? thumb.querySelector('.plview-text-cover-div') : null;
+	if (textCover) {
+		textCover.parentNode.removeChild(textCover);
+	}
+	img.outerHTML = '<i class="fa-solid fa-sharp fa-list-music" style="display:flex;align-items:center;justify-content:center;width:100%;height:100%;font-size:calc(var(--thumbimagesize)/2);"></i>';
+}
+// Same default icon for the small cover preview in the Edit-playlist modal
+function plPreviewFallback(img) {
+	img.outerHTML = '<i class="fa-solid fa-sharp fa-list-music" style="font-size:32px;line-height:1;"></i>';
+}
+
 var UI = {
     knob: null,
     path: '',
@@ -2489,7 +2510,7 @@ function renderPlaylistView () {
             // Construct playlist entries
             var imgUrl = playlists[i].cover == 'local' || playlists[i].cover == 'default' ? 'imagesw/playlist-covers/' + playlists[i].name + '.jpg' : playlists[i].cover;
     		output += '<li id="pl-entry-' + (i + 1) + '" data-path="' + playlists[i].name + '">';
-    		output += '<div class="db-icon db-song db-browse db-action">' + plViewLazy + encodeURIComponent(imgUrl) + '">';
+    		output += '<div class="db-icon db-song db-browse db-action">' + plViewLazy + encodeURIComponent(imgUrl) + '" onerror="plCoverFallback(this)">';
             output += playlists[i].cover == 'default' ? '<div class="plview-text-cover-div"><span class="plview-text-cover">' + playlists[i].name + '</span></div>' : '';
             output += '</div><div class="cover-menu" data-toggle="context" data-target="#context-menu-playlist-item"></div></div><div class="db-entry db-song db-browse"></div>';
             output += '<span class="playlist-name">' + playlists[i].name + '</span>';
@@ -3137,7 +3158,7 @@ $(document).on('click', '.context-menu a', function(e) {
                 $('#edit-playlist-name').val(path);
                 $('#edit-plcoverimage').val('');
                 $('#info-toggle-edit-plcoverimage').css('margin-left','60px');
-                $('#preview-edit-plcoverimage').html('<img src="../imagesw/playlist-covers/' + path + '.jpg">');
+                $('#preview-edit-plcoverimage').html('<img src="../imagesw/playlist-covers/' + path + '.jpg" onerror="plPreviewFallback(this)">');
                 $('#edit-playlist-tags').css('margin-top', '20px');
                 $('#edit-playlist-genre').val(data['genre']);
 

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -1962,6 +1962,8 @@ function sendQueueCmd(cmd, path) {
 function renderFolderView(data, path, searchstr) {
 	UI.path = path;
     $('#db-path').text(path);
+    // Import targets the playlists at the root, so only offer it there
+    $('#btn-db-import').toggle(path == '');
 
 	// Separate out dirs, playlists, files, exclude the RADIO folder
 	var dirs = [];
@@ -2921,6 +2923,9 @@ $(document).on('click', '.context-menu a', function(e) {
         //
         // Context menu items
         //
+        case 'export_playlist':
+            window.location = 'command/playlist.php?cmd=export_playlist&name=' + encodeURIComponent(path);
+            break;
         case 'add_item':
         case 'play_item':
         case 'clear_play_item':

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -933,37 +933,130 @@ jQuery(document).ready(function($) { 'use strict';
 			renderFolderView(data, UI.path);
         });
 	});
-	$('#btn-db-import').click(function(e) {
+	$('#btn-db-import, #btn-pl-import').click(function(e) {
 		$('#db-import-file').val('');
 		$('#db-import-file').click();
 	});
+	var importPlaylistContent = ''; // holds the .m3u text between analyze and commit
 	$('#db-import-file').change(function(e) {
 		if (this.files.length == 0) {
 			return;
 		}
-		var formData = new FormData();
-		formData.append('playlist_file', this.files[0]);
-		$.ajax({
-			url: 'command/playlist.php?cmd=import_playlist',
-			type: 'POST',
-			data: formData,
-			processData: false,
-			contentType: false,
-			dataType: 'json',
-			success: function(data) {
-				if (data.status == 'ok') {
-					notify(NOTIFY_TITLE_INFO, 'import_playlist', NOTIFY_DURATION_SHORT);
-					$('#btn-pl-refresh').click();
-					$('#db-refresh').click();
-				} else {
+		var file = this.files[0];
+		var defaultName = file.name.replace(/\.m3u8?$/i, '');
+		var reader = new FileReader();
+		reader.onload = function(ev) {
+			importPlaylistContent = ev.target.result;
+			// Phase A: ask the server which local paths it can't resolve
+			$.post('command/playlist.php?cmd=analyze_import', {'content': importPlaylistContent}, function(data) {
+				if (data.status != 'ok') {
 					notify(NOTIFY_TITLE_ALERT, 'import_playlist_error', data.msg);
+				} else if (data.unknown.length == 0) {
+					// All paths known (or URLs) -> import straight away
+					commitImportPlaylist(defaultName, {}, false);
+				} else {
+					openImportModal(defaultName, data);
 				}
-			},
-			error: function() {
-				notify(NOTIFY_TITLE_ALERT, 'import_playlist_error', '');
+			}, 'json');
+		};
+		reader.readAsText(file);
+	});
+	// custom_radio.js (the moOde toggle wiring) is only in the config bundle, not the
+	// main index, so wire this modal's ON/OFF toggle ourselves.
+	function wireImportToggle() {
+		var $toggle = $('#import-playlist-modal .toggle');
+		var $radios = $toggle.find('input');
+		// Colour the ON knob with the theme accent like the config pages do. The index's
+		// setColors() sets the accentColor global but doesn't paint the toggle knob (it
+		// normally has no toggles), so replicate scripts-configs.js here.
+		if (typeof accentColor === 'string' && accentColor.charAt(0) == '#') {
+			var knob = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='30' height='30'><circle fill='%23" + accentColor.substr(1) + "' cx='14' cy='14.5' r='11.5'/></svg>";
+			document.body.style.setProperty('--toggleon', 'url("' + knob + '")');
+		}
+		$toggle.toggleClass('toggle-off', !$radios.eq(0).is(':checked'));
+		$radios.off('click.imptoggle').on('click.imptoggle', function() {
+			$toggle.toggleClass('toggle-off');
+		});
+	}
+	function openImportModal(name, data) {
+		$('#import-pl-name').val(name);
+		// default OFF = keep unresolved entries
+		$('#toggle-import-drop-1').prop('checked', false);
+		$('#toggle-import-drop-2').prop('checked', true);
+		wireImportToggle();
+		var html = '';
+		for (var i = 0; i < data.unknown.length; i++) {
+			var u = data.unknown[i];
+			var opts = '<option value="">(keep original path)</option>';
+			for (var j = 0; j < data.known_dirs.length; j++) {
+				var d = encodeHTMLEntities(data.known_dirs[j]);
+				opts += '<option value="' + d + '"' + (data.known_dirs[j] == u.suggested ? ' selected' : '') + '>' + d + '</option>';
+			}
+			html += '<div class="control-group import-pl-row" data-prefix="' + encodeHTMLEntities(u.prefix) + '">'
+				+ '<label class="control-label">' + encodeHTMLEntities(u.prefix) + '</label>'
+				+ '<div class="controls"><select class="import-pl-select selectpicker config-select-large">' + opts + '</select>'
+				+ '<span class="config-input-after">(' + u.count + ' track' + (u.count > 1 ? 's' : '') + ')</span></div>'
+				+ '</div>';
+		}
+		$('#import-pl-remap').html(html);
+		$('#import-pl-remap .selectpicker').selectpicker(); // moOde-styled dropdowns
+		renderImportReport(data);
+		$('#import-playlist-modal').modal();
+	}
+	function renderImportReport(data) {
+		var unknownTotal = 0;
+		var prefixes = [];
+		for (var k = 0; k < data.unknown.length; k++) {
+			unknownTotal += data.unknown[k].count;
+			prefixes.push(data.unknown[k].prefix);
+		}
+		var msg = (data.ok_local + data.url_count) + ' of ' + data.total + ' entries resolve';
+		msg += unknownTotal > 0 ? ' · ' + unknownTotal + ' still unresolved (' + prefixes.join(', ') + ')'
+			: ' · all good';
+		$('#import-pl-report').text(msg);
+	}
+	function currentImportRemap() {
+		var remap = {};
+		$('#import-pl-remap .import-pl-row').each(function() {
+			var target = $(this).find('.import-pl-select').val();
+			if (target) {
+				remap[$(this).attr('data-prefix')] = target;
 			}
 		});
+		return remap;
+	}
+	// Re-validate the entries against the box with the current remap choices
+	$('#btn-test-import').click(function(e) {
+		$.post('command/playlist.php?cmd=analyze_import',
+			{'content': importPlaylistContent, 'remap': JSON.stringify(currentImportRemap())},
+			function(data) {
+				if (data.status == 'ok') {
+					renderImportReport(data);
+				}
+			}, 'json');
 	});
+	$('#btn-import-playlist').click(function(e) {
+		var dropInvalid = !$('#import-playlist-modal .toggle').hasClass('toggle-off');
+		commitImportPlaylist($('#import-pl-name').val(), currentImportRemap(), dropInvalid);
+	});
+	function commitImportPlaylist(name, remap, dropInvalid) {
+		$.post('command/playlist.php?cmd=import_playlist', {
+			'name': name,
+			'content': importPlaylistContent,
+			'remap': JSON.stringify(remap),
+			'drop_invalid': dropInvalid ? '1' : '0'
+		}, function(data) {
+			if (data.status != 'ok') {
+				notify(NOTIFY_TITLE_ALERT, 'import_playlist_error', data.msg);
+				return;
+			}
+			var extra = data.imported + ' track' + (data.imported > 1 ? 's' : '')
+				+ (data.dropped > 0 ? ', ' + data.dropped + ' removed' : '');
+			notify(NOTIFY_TITLE_INFO, 'import_playlist', extra, NOTIFY_DURATION_SHORT);
+			$('#btn-pl-refresh').click();
+			$('#db-refresh').click();
+		}, 'json');
+	}
 	$('#db-search-results').click(function(e) {
 		$('.database li').removeClass('active');
 		$('#db-search-results').css('font-weight', 'bold');

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -734,6 +734,7 @@ jQuery(document).ready(function($) { 'use strict';
                 $.get('command/playlist.php?cmd=save_queue_to_playlist&name=' + plName, function() {
     				notify(NOTIFY_TITLE_INFO, 'queue_saved', NOTIFY_DURATION_SHORT);
                     $('#btn-pl-refresh').click();
+                    $('#db-refresh').click();
                 });
 			}
 		} else {
@@ -931,6 +932,37 @@ jQuery(document).ready(function($) { 'use strict';
 		$.getJSON('command/music-library.php?cmd=lsinfo', {'path': UI.path}, function(data) {
 			renderFolderView(data, UI.path);
         });
+	});
+	$('#btn-db-import').click(function(e) {
+		$('#db-import-file').val('');
+		$('#db-import-file').click();
+	});
+	$('#db-import-file').change(function(e) {
+		if (this.files.length == 0) {
+			return;
+		}
+		var formData = new FormData();
+		formData.append('playlist_file', this.files[0]);
+		$.ajax({
+			url: 'command/playlist.php?cmd=import_playlist',
+			type: 'POST',
+			data: formData,
+			processData: false,
+			contentType: false,
+			dataType: 'json',
+			success: function(data) {
+				if (data.status == 'ok') {
+					notify(NOTIFY_TITLE_INFO, 'import_playlist', NOTIFY_DURATION_SHORT);
+					$('#btn-pl-refresh').click();
+					$('#db-refresh').click();
+				} else {
+					notify(NOTIFY_TITLE_ALERT, 'import_playlist_error', data.msg);
+				}
+			},
+			error: function() {
+				notify(NOTIFY_TITLE_ALERT, 'import_playlist_error', '');
+			}
+		});
 	});
 	$('#db-search-results').click(function(e) {
 		$('.database li').removeClass('active');
@@ -1255,6 +1287,7 @@ jQuery(document).ready(function($) { 'use strict';
         $.post('command/playlist.php?cmd=del_playlist', {'path': UI.dbEntry[0]}, function() {
             notify(NOTIFY_TITLE_INFO, 'del_playlist', NOTIFY_DURATION_SHORT);
             $('#btn-pl-refresh').click();
+            $('#db-refresh').click();
         });
 	});
     // Delete/Move playlist items(s)

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -232,7 +232,7 @@
 				<button aria-label="Home" id="db-home" class="btn"><i class="fa-solid fa-sharp fa-home"></i></button>
 				<button aria-label="Refresh" id="db-refresh" class="btn"><i class="fa-regular fa-sharp fa-redo"></i></button>
 				<button aria-label="Search" id="db-advsearch" class="btn" href="#dbsearch-modal" data-toggle="modal"><i class="fa-regular fa-sharp fa-search"></i></button>
-				<button aria-label="Import Playlist" id="btn-db-import" class="btn"><i class="fa-regular fa-sharp fa-upload"></i></button>
+				<button aria-label="Import Playlist" id="btn-db-import" class="btn"><i class="fa-regular fa-sharp fa-download"></i></button>
 				<input id="db-import-file" type="file" accept=".m3u,.m3u8" class="hide">
 				<form id="db-fastsearch" onsubmit="return false;">
 					<div class="input-append">
@@ -281,6 +281,7 @@
 				<button aria-label="Playlist Manager" id="btn-pl-manager" class="btn"><i class="fa-solid fa-sharp fa-gear-complex"></i></button>
 				<button aria-label="Refresh" id="btn-pl-refresh" class="btn"><i class="fa-regular fa-sharp fa-redo"></i></button>
 				<button aria-label="New Playlist" id="btn-pl-new" class="btn"><i class="fa-regular fa-sharp fa-plus"></i></button>
+				<button aria-label="Import Playlist" id="btn-pl-import" class="btn"><i class="fa-regular fa-sharp fa-download"></i></button>
 				<form id="pl-search" class="" method="post" onSubmit="return false;">
 					<div class="input-append">
 						<input id="pl-filter" type="text" value="" placeholder="search">
@@ -522,6 +523,47 @@
 	<div class="modal-footer">
 		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
 		<button aria-label="Save" id="btn-save-queue-to-playlist" class="btn btn-primary" data-dismiss="modal">Save</button>
+	</div>
+</div>
+
+<!-- IMPORT PLAYLIST -->
+<div id="import-playlist-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="import-playlist-modal-label" aria-hidden="true">
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<h3 id="import-playlist-modal-label">Import playlist</h3>
+	</div>
+	<div class="modal-body">
+		<form id="import-playlist-form" method="post" onsubmit="return false;">
+			<div class="control-group">
+				<label class="control-label" for="import-pl-name">Playlist name</label>
+				<div class="controls">
+					<input id="import-pl-name" type="text" value="">
+				</div>
+			</div>
+			<div class="control-group">
+				<label class="control-label">Unknown paths</label>
+				<div class="controls">
+					<span class="help-block">Some tracks point to folders that don't exist on this player. Map each to a known folder, or leave it to keep the original path.</span>
+				</div>
+			</div>
+				<div id="import-pl-remap"></div>
+			<div class="control-group">
+				<div class="controls">
+					<button id="btn-test-import" type="button" class="btn btn-primary btn-small config-btn-set">Test paths</button>
+					<span id="import-pl-report" class="help-block" style="display:inline-block;margin-left:.6rem;"></span>
+					<div style="margin-top:.5rem;">
+						<div class="toggle">
+							<label class="toggle-radio toggle-import-drop" for="toggle-import-drop-2">ON </label><input type="radio" name="import_drop" id="toggle-import-drop-1" value="on">
+							<label class="toggle-radio toggle-import-drop" for="toggle-import-drop-1">OFF</label><input type="radio" name="import_drop" id="toggle-import-drop-2" value="off" checked="checked">
+						</div>
+						<span class="config-toggle-after">Remove unresolved entries</span>
+					</div>
+				</div>
+			</div>
+		</form>
+	</div>
+	<div class="modal-footer">
+		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Import" id="btn-import-playlist" class="btn btn-primary" data-dismiss="modal">Import</button>
 	</div>
 </div>
 
@@ -2807,7 +2849,7 @@
 			<li><a href="#notarget" data-cmd="play_item"><i class="fa-regular fa-sharp fa-play sx"></i> Play</a></li>
 			<!--li><a href="#notarget" data-cmd="clear_add_item"><i class="fa-regular fa-sharp fa-plus-square sx"></i> Clear/Add</a></li-->
 			<li><a href="#notarget" data-cmd="clear_play_item"><i class="fa-regular fa-sharp fa-chevron-square-right sx"></i> Clear/Play</a></li>
-			<li class="menu-separator"><a href="#notarget" data-cmd="export_playlist"><i class="fa-regular fa-sharp fa-download sx"></i> Export</a></li>
+			<li class="menu-separator"><a href="#notarget" data-cmd="export_playlist"><i class="fa-regular fa-sharp fa-upload sx"></i> Export</a></li>
 			<li><a href="#notarget" data-cmd="delete_playlist"><i class="fa-regular fa-sharp fa-trash sx"></i> Delete</a></li>
 		</ul>
 	</div>
@@ -2903,7 +2945,7 @@
 			<li class="menu-separator"><a href="#notarget" data-cmd="play_item_next"><i class="fa-regular fa-sharp fa-play-circle sx"></i> Play next</a></li>
 			<!--li><a href="#notarget" data-cmd="clear_add_item"><i class="fa-regular fa-sharp fa-plus-square sx"></i> Clear/Add</a></li-->
 			<li><a href="#notarget" data-cmd="edit_playlist"><i class="fa-regular fa-sharp fa-edit sx"></i> Edit playlist</a></li>
-			<li><a href="#notarget" data-cmd="export_playlist"><i class="fa-regular fa-sharp fa-download sx"></i> Export playlist</a></li>
+			<li><a href="#notarget" data-cmd="export_playlist"><i class="fa-regular fa-sharp fa-upload sx"></i> Export playlist</a></li>
 			<li><a href="#notarget" data-cmd="delete_playlist"><i class="fa-regular fa-sharp fa-trash sx"></i> Delete playlist</a></li>
 		</ul>
 	</div>

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -232,6 +232,8 @@
 				<button aria-label="Home" id="db-home" class="btn"><i class="fa-solid fa-sharp fa-home"></i></button>
 				<button aria-label="Refresh" id="db-refresh" class="btn"><i class="fa-regular fa-sharp fa-redo"></i></button>
 				<button aria-label="Search" id="db-advsearch" class="btn" href="#dbsearch-modal" data-toggle="modal"><i class="fa-regular fa-sharp fa-search"></i></button>
+				<button aria-label="Import Playlist" id="btn-db-import" class="btn"><i class="fa-regular fa-sharp fa-upload"></i></button>
+				<input id="db-import-file" type="file" accept=".m3u,.m3u8" class="hide">
 				<form id="db-fastsearch" onsubmit="return false;">
 					<div class="input-append">
 						<input id="dbfs" type="text" value="" placeholder="search">
@@ -2804,7 +2806,9 @@
 			<li><a href="#notarget" data-cmd="add_item"><i class="fa-regular fa-sharp fa-plus sx"></i> Add</a></li>
 			<li><a href="#notarget" data-cmd="play_item"><i class="fa-regular fa-sharp fa-play sx"></i> Play</a></li>
 			<!--li><a href="#notarget" data-cmd="clear_add_item"><i class="fa-regular fa-sharp fa-plus-square sx"></i> Clear/Add</a></li-->
-			<li class="menu-separator"><a href="#notarget" data-cmd="clear_play_item"><i class="fa-regular fa-sharp fa-chevron-square-right sx"></i> Clear/Play</a></li>
+			<li><a href="#notarget" data-cmd="clear_play_item"><i class="fa-regular fa-sharp fa-chevron-square-right sx"></i> Clear/Play</a></li>
+			<li class="menu-separator"><a href="#notarget" data-cmd="export_playlist"><i class="fa-regular fa-sharp fa-download sx"></i> Export</a></li>
+			<li><a href="#notarget" data-cmd="delete_playlist"><i class="fa-regular fa-sharp fa-trash sx"></i> Delete</a></li>
 		</ul>
 	</div>
 
@@ -2899,6 +2903,7 @@
 			<li class="menu-separator"><a href="#notarget" data-cmd="play_item_next"><i class="fa-regular fa-sharp fa-play-circle sx"></i> Play next</a></li>
 			<!--li><a href="#notarget" data-cmd="clear_add_item"><i class="fa-regular fa-sharp fa-plus-square sx"></i> Clear/Add</a></li-->
 			<li><a href="#notarget" data-cmd="edit_playlist"><i class="fa-regular fa-sharp fa-edit sx"></i> Edit playlist</a></li>
+			<li><a href="#notarget" data-cmd="export_playlist"><i class="fa-regular fa-sharp fa-download sx"></i> Export playlist</a></li>
 			<li><a href="#notarget" data-cmd="delete_playlist"><i class="fa-regular fa-sharp fa-trash sx"></i> Delete playlist</a></li>
 		</ul>
 	</div>


### PR DESCRIPTION
## What

Saved playlists are standard `.m3u` files under `/var/lib/mpd/playlists`, but the
WebUI offered no way to get them in or out, nor to delete them from the Browse
view. This adds, entirely additively:

- **Export** — download a saved playlist as `.m3u`, from the Export item on both
  the Browse saved-playlist menu and the Playlist-view menu. Streamed by
  `command/playlist.php`, mirroring the existing CamillaDSP config download.
- **Import** — upload a `.m3u` as a new playlist, via an upload button in the
  Browse toolbar (shown only at the root). Server-side validation of extension,
  path traversal, size and name collision; written with the same owner/perms
  convention as in-app playlist creation.
- **Delete** — a Delete item on the Browse saved-playlist menu, reusing the
  existing delete-playlist confirmation modal and `del_playlist` command.
- **Refresh fix** — both the Playlist view and the Browse folderlist now refresh
  after a playlist is added or removed (import, *Save Queue to playlist*, delete),
  so the change shows without a manual refresh.

## Implementation notes

- No new dependencies; reuses existing patterns (CamillaDSP download, the
  delete-playlist modal, `addItemToQueue`/`getPlaylists`).
- 2 commits: backend endpoints, then UI wiring.

## Testing

Validated on a running moOde player:
- Export: correct `audio/x-mpegurl` + `Content-Disposition`; non-existent → 404;
  path traversal blocked.
- Import: valid `.m3u` accepted; duplicate name and non-`.m3u` rejected; file
  written `0777 root:root` and loadable by MPD.
- Delete: confirmation modal, folderlist refreshed.
- Import button hidden when not at the Browse root or Playlists root.


<img width="1275" height="924" alt="2" src="https://github.com/user-attachments/assets/bfb41861-d038-4df5-b0cc-56fcb52a3d21" />

<img width="677" height="752" alt="image" src="https://github.com/user-attachments/assets/01dba164-c0aa-4722-917b-8e0df93990ec" />

<img width="1016" height="655" alt="image" src="https://github.com/user-attachments/assets/9ca5335b-aa66-4778-ac0d-e11236bd17de" />

