### PR TITLE
sys-config: populate the CPU governor list from the kernel

### DIFF
--- a/www/sys-config.php
+++ b/www/sys-config.php
@@ -430,8 +430,26 @@ if ($_SESSION['pi_modelnum'] >= 5) {
 // Performance
 $_select['worker_responsiveness'] .= "<option value=\"Default\" " . (($_SESSION['worker_responsiveness'] == 'Default') ? "selected" : "") . ">Default</option>\n";
 $_select['worker_responsiveness'] .= "<option value=\"Boosted\" " . (($_SESSION['worker_responsiveness'] == 'Boosted') ? "selected" : "") . ">Boosted</option>\n";
-$_select['cpugov'] .= "<option value=\"ondemand\" " . (($_SESSION['cpugov'] == 'ondemand') ? "selected" : "") . ">On-demand</option>\n";
-$_select['cpugov'] .= "<option value=\"performance\" " . (($_SESSION['cpugov'] == 'performance') ? "selected" : "") . ">Performance</option>\n";
+// Offer the governors the kernel actually exposes, not a hardcoded pair.
+$availGovs = trim(@file_get_contents('/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors'));
+$govList = $availGovs !== '' ? preg_split('/\s+/', $availGovs) : array('performance');
+$liveGov = trim(@file_get_contents('/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor'));
+$selGov = in_array($_SESSION['cpugov'], $govList) ? $_SESSION['cpugov'] : $liveGov;
+$govDescriptions = array(
+	'conservative' => 'Scale CPU frequency gradually based on load.',
+	'ondemand' => 'Scale CPU frequency from min to max based on load.',
+	'userspace' => 'Let a user-space program set the CPU frequency.',
+	'powersave' => 'Run the CPU at min frequency.',
+	'performance' => 'Run the CPU at max frequency.',
+	'schedutil' => 'Scale CPU frequency using the kernel scheduler load estimates.'
+);
+$govHelp = array();
+foreach ($govList as $gov) {
+	$label = $gov == 'ondemand' ? 'On-demand' : ucfirst($gov);
+	$_select['cpugov'] .= "<option value=\"" . $gov . "\" " . (($selGov == $gov) ? "selected" : "") . ">" . $label . "</option>\n";
+	$govHelp[] = "<b>" . $label . ":</b>" . (isset($govDescriptions[$gov]) ? ' ' . $govDescriptions[$gov] : '');
+}
+$_cpugov_help = implode("<br>\n", $govHelp);
 $_select['pci_express'] .= "<option value=\"auto\" " . (($_SESSION['pci_express'] == 'auto') ? "selected" : "") . ">Auto</option>\n";
 $_select['pci_express'] .= "<option value=\"gen2\" " . (($_SESSION['pci_express'] == 'gen2') ? "selected" : "") . ">Gen 2.0</option>\n";
 $_select['pci_express'] .= "<option value=\"gen3\" " . (($_SESSION['pci_express'] == 'gen3') ? "selected" : "") . ">Gen 3.0</option>\n";

--- a/www/templates/sys-config.html
+++ b/www/templates/sys-config.html
@@ -125,8 +125,7 @@
 				<button id="btn-set-cpugov" class="hide btn btn-primary btn-small config-btn-set btn-submit" type="submit" name="update_cpugov" value="novalue"><i class="fa fa-solid fa-sharp fa-arrow-turn-down-left"></i></button>
 				<a aria-label="Help" class="config-info-toggle" data-cmd="info-cpugov" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
 				<span id="info-cpugov" class="config-help-info">
-					<b>On-demand:</b> Scale CPU frequency from min to max based on load.<br>
-					<b>Performance:</b> Run the CPU at max frequency.
+					$_cpugov_help
 				</span>
 			</div>
 


### PR DESCRIPTION
### What

Build the CPU governor dropdown (and its help text) from the governors the
kernel actually exposes, instead of hardcoding `On-demand` / `Performance`.

The list and the help description are now generated from a single source:
`/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors`.

### Why

The two hardcoded values are only valid for the cpufreq driver used on the
Pi. Writing a governor that the active driver doesn't expose to
`scaling_governor` is rejected, so on any platform whose driver advertises a
different set the dropdown can offer an option that silently fails to apply.
Reading the available list keeps the control correct on whatever hardware/
driver moOde happens to run on.

The selected option falls back to the live governor
(`scaling_governor`) when the stored value isn't available on the current CPU,
so a config carried over from different hardware can't leave the control stuck
on an inapplicable value.

### Note on Pi behaviour

On a Pi the kernel typically advertises the full set
(`conservative ondemand userspace powersave performance schedutil`), so this
change makes all of them selectable instead of just the curated two. If you'd
rather keep the Pi list limited to On-demand/Performance, I can intersect the
kernel list with a curated allow-list instead — happy to adjust.

### Testing

- Raspberry Pi 3B (kernel exposes the 6 governors): dropdown and help list all
  six with the expected labels/descriptions; selection persists and applies.
- x86 (`intel_cpufreq`, exposes `performance schedutil`): only those two are
  offered; a stored `ondemand` correctly falls back to the live governor.

### Pictures on PI 3B

<img width="816" height="365" alt="govhelper" src="https://github.com/user-attachments/assets/6d514201-da81-49c5-b6a0-c3597bfba8bb" />

<img width="746" height="503" alt="govlist" src="https://github.com/user-attachments/assets/6e546b99-5704-4b2a-b759-03f910f8b14b" />
