### PR TITLE
Fix Bluetooth A2DP sink silent in Standard ALSA output mode

### DIFF
--- a/etc/bluealsaaplay.conf
+++ b/etc/bluealsaaplay.conf
@@ -1,5 +1,5 @@
 #########################################
 # This file is managed by moOde
 #########################################
-AUDIODEV=_audioout
+AUDIODEV=plug:_audioout
 BUFFERTIME=500000

--- a/www/audioinfo.php
+++ b/www/audioinfo.php
@@ -210,20 +210,7 @@ if ($_SESSION['invert_polarity'] == '1') {
 	$outputMode = $_SESSION['alsa_output_mode'];
 }
 
-// Bluetooth overrides
-if ($btActive === true) {
-	// Bluetooth inbound
-	if ($_SESSION['alsa_output_mode'] == 'iec958') {
-		$outputModeName = ALSA_OUTPUT_MODE_NAME[$_SESSION['alsa_output_mode']];
-	} else {
-		$outputModeName = ALSA_OUTPUT_MODE_BT_NAME[$_SESSION['alsa_output_mode_bt']];
-		$outputMode = $_SESSION['alsa_output_mode_bt'] == '_audioout' ?
-			$_SESSION['alsa_output_mode'] :
-			'plughw';
-	}
-} else {
-	$outputModeName = ALSA_OUTPUT_MODE_NAME[$_SESSION['alsa_output_mode']];
-}
+$outputModeName = ALSA_OUTPUT_MODE_NAME[$_SESSION['alsa_output_mode']];
 
 // Peppy ALSA
 $peppyAlsa = ($_SESSION['peppy_display'] == '1' || $_SESSION['enable_peppyalsa'] == '1') ? 'PeppyALSA &rarr; ' : '';

--- a/www/blu-config.php
+++ b/www/blu-config.php
@@ -117,19 +117,6 @@ if (isset($_POST['update_sbc_quality']) && $_POST['update_sbc_quality'] == '1') 
 	$_SESSION['notify']['title'] = NOTIFY_TITLE_INFO;
 	$_SESSION['notify']['msg'] = NOTIFY_MSG_BLUETOOTH_RECONNECT;
 }
-// ALSA output mode: Standard = _audioout, Compatibility = plughw
-// NOTE: conflicts with peppy
-if (isset($_POST['update_alsa_output_mode_bt']) && $_POST['update_alsa_output_mode_bt'] == '1') {
-	$_SESSION['alsa_output_mode_bt'] = $_POST['alsa_output_mode_bt'];
-	if ($_POST['alsa_output_mode_bt'] == 'plughw') {
-		$alsaDevice = $_SESSION['alsa_output_mode'] == 'iec958' ? getAlsaIEC958Device() : 'plughw' . ':' . $_SESSION['cardnum'] . ',0';
-	} else { // _audioout
-		$alsaDevice = $_POST['alsa_output_mode_bt'];
-	}
-	sysCmd("sed -i '/AUDIODEV/c\AUDIODEV=" . $alsaDevice . "' /etc/bluealsaaplay.conf");
-	$_SESSION['notify']['title'] = NOTIFY_TITLE_INFO;
-	$_SESSION['notify']['msg'] = NOTIFY_MSG_BLUETOOTH_RECONNECT;
-}
 // Controller mode
 if (isset($_POST['update_bluez_controller_mode']) && $_POST['update_bluez_controller_mode'] == '1') {
 	$_SESSION['bluez_controller_mode'] = $_POST['bluez_controller_mode'];
@@ -217,10 +204,6 @@ $_select['sbc_quality'] .= "<option value=\"medium\" " . (($_SESSION['bluez_sbc_
 $_select['sbc_quality'] .= "<option value=\"high\" " . (($_SESSION['bluez_sbc_quality'] == 'high') ? "selected" : "") . ">High (345 kbps)</option>\n";
 $_select['sbc_quality'] .= "<option value=\"xq\" " . (($_SESSION['bluez_sbc_quality'] == 'xq') ? "selected" : "") . ">XQ (452 kbps)</option>\n";
 $_select['sbc_quality'] .= "<option value=\"xq+\" " . (($_SESSION['bluez_sbc_quality'] == 'xq+') ? "selected" : "") . ">XQ+ (551 kbps)</option>\n";
-
-// ALSA output mode
-$_select['alsa_output_mode_bt'] .= "<option value=\"_audioout\" " . (($_SESSION['alsa_output_mode_bt'] == '_audioout') ? "selected" : "") . ">Standard</option>\n";
-$_select['alsa_output_mode_bt'] .= "<option value=\"plughw\" " . (($_SESSION['alsa_output_mode_bt'] == 'plughw') ? "selected" : "") . ">Compatibility</option>\n";
 
 // Controller mode
 $_select['bluez_controller_mode'] .= "<option value=\"dual\" " . (($_SESSION['bluez_controller_mode'] == 'dual') ? "selected" : "") . ">Dual (Default)</option>\n";

--- a/www/daemon/worker.php
+++ b/www/daemon/worker.php
@@ -1080,10 +1080,6 @@ if (!isset($_SESSION['cdspvolume_max_bt'])) {
 if (!isset($_SESSION['bluez_sbc_quality'])) {
 	$_SESSION['bluez_sbc_quality'] = 'xq+';
 }
-// ALSA output mode
-if (!isset($_SESSION['alsa_output_mode_bt'])) {
-	$_SESSION['alsa_output_mode_bt'] = '_audioout';
-}
 // Controller mode
 if (!isset($_SESSION['bluez_controller_mode'])) {
 	$_SESSION['bluez_controller_mode'] = 'dual';
@@ -1101,7 +1097,6 @@ if ($_SESSION['feat_bitmask'] & FEAT_BLUETOOTH) {
 }
 $status .= ', PIN: ' . (empty($_SESSION['bt_pin_code']) ? 'None' : 'Set');
 $status .= ', ALSA/CDSP max: ' . $_SESSION['alsavolume_max_bt'] . '%/' . $_SESSION['cdspvolume_max_bt'] . 'dB';
-$status .= ', ALSA out: ' . ALSA_OUTPUT_MODE_BT_NAME[$_SESSION['alsa_output_mode_bt']];
 $status .= ', Transport: ' . $_SESSION['bluez_controller_mode'];
 workerLog('worker: Bluetooth:       ' . $status);
 

--- a/www/inc/audio.php
+++ b/www/inc/audio.php
@@ -273,11 +273,9 @@ function updDspAndBtInConfs($cardNum, $outputMode) {
 		} else {
 			$alsaDevice = 'peppy';
 		}
-	// AUDIODEV=_audioout or plughw depending on Bluetooth Config, ALSA output mode
-	} else if ($_SESSION['alsa_output_mode_bt'] == 'plughw') {
-		$alsaDevice = $outputMode == 'iec958' ? getAlsaIEC958Device() : 'plughw' . ':' . $cardNum . ',0';
 	} else {
-		$alsaDevice = $_SESSION['alsa_output_mode_bt']; // _audioout
+		// A2DP sink: convert the fixed-format decoded PCM at the top of the chain
+		$alsaDevice = 'plug:_audioout';
 	}
 	sysCmd("sed -i 's/^AUDIODEV.*/AUDIODEV=" . $alsaDevice . "/' /etc/bluealsaaplay.conf");
 

--- a/www/inc/autocfg.php
+++ b/www/inc/autocfg.php
@@ -486,10 +486,6 @@ function autoConfigSettings() {
 			$_SESSION['bluez_sbc_quality'] = $values['bluez_sbc_quality'];
 			sysCmd("sed -i 's/--sbc-quality.*/--sbc-quality=" . $values['bluez_sbc_quality'] . "/' /etc/systemd/system/bluealsa.service");
 		}],
-		['requires' => ['alsa_output_mode_bt'], 'handler' => function($values) {
-			$_SESSION['alsa_output_mode_bt'] = '_audioout'; // Reset to Standard (_audioout)
-			sysCmd("sed -i '/AUDIODEV/c\AUDIODEV=_audioout" . "' /etc/bluealsaaplay.conf");
-		}],
 		['requires' => ['bluez_controller_mode'], 'handler' => function($values) {
 			$_SESSION['bluez_controller_mode'] = $values['bluez_controller_mode'];
 			sysCmd("sed -i 's/ControllerMode.*/ControllerMode = " . $_SESSION['bluez_controller_mode'] . "/' /etc/bluetooth/main.conf");

--- a/www/inc/constants.php
+++ b/www/inc/constants.php
@@ -271,7 +271,6 @@ const ALSA_DEFAULT_MIXER_NAME_I2S = 'Digital';
 const ALSA_DEFAULT_MIXER_NAME_INTEGRATED = 'PCM';
 // ALSA output mode names
 const ALSA_OUTPUT_MODE_NAME = array('plughw' => 'Default', 'hw' => 'Direct', 'iec958' => 'IEC958');
-const ALSA_OUTPUT_MODE_BT_NAME = array('_audioout' => 'Standard', 'plughw' => 'Compatibility');
 // ALSA HDMI IEC958
 const ALSA_IEC958_DEVICE = 'default:vc4hdmi';
 const ALSA_IEC958_FORMAT = 'IEC958_SUBFRAME_LE';

--- a/www/templates/blu-config.html
+++ b/www/templates/blu-config.html
@@ -99,19 +99,6 @@
 			</div>
 
 			<div>
-				<select id="alsa-output-mode-bt" class="config-select-large" name="alsa_output_mode_bt" onchange="autoClick('#btn-set-alsa-output-mode-bt');">
-					$_select[alsa_output_mode_bt]
-				</select>
-				<button id="btn-set-alsa-output-mode-bt" class="hide btn btn-primary btn-small config-btn-set btn-submit" type="submit" name="update_alsa_output_mode_bt" value="1"><i class="fa fa-solid fa-sharp fa-arrow-turn-down-left"></i></button>
-				<span class="config-btn-after">ALSA output mode</span>
-				<a aria-label="Help" class="config-info-toggle" data-cmd="info-alsa-output-mode-bt" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
-				<span id="info-alsa-output-mode-bt" class="config-help-info">
-					<b>Standard:</b> Use the Output mode setting from Audio Config. DSP and Peppy are supported.<br>
-					<b>Compatibility:</b> Does not support DSP or Peppy but may help if there is no sound output.
-				</span>
-			</div>
-
-			<div>
 				<select id="bluez-controller-mode" class="config-select-large" name="bluez_controller_mode" onchange="autoClick('#btn-set-bluez-controller-mode');">
 					$_select[bluez_controller_mode]
 				</select>

--- a/www/util/autocfg-gen.php
+++ b/www/util/autocfg-gen.php
@@ -64,7 +64,6 @@ $currentSettings['ashuffle_exclude'] = $_SESSION['ashuffle_exclude'];
 $currentSettings['invert_polarity'] = $_SESSION['invert_polarity'];
 // Audio: Bluetooth
 $currentSettings['bluez_sbc_quality'] = $_SESSION['bluez_sbc_quality'];
-$currentSettings['alsa_output_mode_bt'] = $_SESSION['alsa_output_mode_bt'];
 $currentSettings['bluez_controller_mode'] = $_SESSION['bluez_controller_mode'];
 $currentSettings['alsavolume_max_bt'] = $_SESSION['alsavolume_max_bt'];
 $currentSettings['cdspvolume_max_bt'] = $_SESSION['cdspvolume_max_bt'];

--- a/www/util/sysinfo.sh
+++ b/www/util/sysinfo.sh
@@ -307,7 +307,6 @@ RENDERER_SETTINGS() {
 		echo -e "\nCDSP max volume\t\t= $CDSPVOLUME_MAX_BT dB\c"
 		echo -e "\nResume MPD\t\t= $rsmafterbt\c"
 		echo -e "\nPCM buffer time\t\t= $bluez_pcm_buffer ($micro_symbol)\c"
-		echo -e "\nALSA output mode\t= $ALSA_OUTPUT_MODE_BT\c"
 		echo -e "\nController mode\t\t= $bluez_controller_mode\c"
 		echo -e "\nActivity timeout\t= $BT_AUTO_DISCONNECT\n"
 	fi
@@ -581,8 +580,6 @@ BLUETOOTH_VER=$(bluetoothd -v)
 BLUEALSA_VER=$(bluealsa -V 2> /dev/null)
 PARING_AGENT_VER=$(dpkg -l | grep bluez-tools | awk '{print $3}' | cut -d"~" -f1)
 PI_BLUETOOTH_VER=$(dpkg -l | grep pi-bluetooth | awk '{print $3}')
-output_mode=$(moodeutl -d -gv alsa_output_mode_bt)
-[[ $output_mode = "_audioout" ]] && ALSA_OUTPUT_MODE_BT="Default (_audioout)" || ALSA_OUTPUT_MODE_BT="Compatibility (plughw)"
 bluez_controller_mode=$(moodeutl -d -gv bluez_controller_mode)
 TMP=$(moodeutl -d -gv bt_pin_code)
 [[ "$TMP" = "None" ]] && BT_PIN_CODE="None" || BT_PIN_CODE="******"


### PR DESCRIPTION
Be aware, huge description for a small correction/improvement !

Tested  with success on my Pi and x86 port moOde 10.2.4 with my 2 DACs, but other testers are welcome.

## Summary

When a phone streams to moOde over Bluetooth (moOde acting as the A2DP sink /
"Bluetooth speaker"), with Bluetooth mode = **Standard**:

- **The defect occurs only when the main ALSA output mode is `Direct` (`hw`) or
  `IEC958`** (the "raw" modes that do not convert formats), **and** no DSP and
  no Peppy are active. In that case there is **no sound**.
- **Enabling any DSP (CamillaDSP, Graphic/Parametric EQ, Crossfeed) or Peppy
  already fixes it** — those plugins insert a `plug` into the chain, which
  performs the missing format conversion. **Compatibility** mode also produces
  sound, but it bypasses DSP and Peppy entirely.
- On output mode `Default` (`plughw`) the defect never appears, because
  `plughw` itself inserts a `plug`.

In other words, the only broken path is plain Standard (no DSP/Peppy) on a raw
output mode — exactly the path that has no `plug` to convert the fixed-format
Bluetooth stream.

This PR generalizes that same conversion to the plain Standard path by routing
the inbound stream through `plug:_audioout` instead of bare `_audioout`. Result:
Standard plays in **every** configuration (with or without DSP/Peppy), DSP and
Peppy still apply when active, the MPD playback path is **untouched**, and
**bit-perfect output is preserved**.

Adding a software `plug` layer to the Bluetooth path is acceptable by design:
A2DP is inherently non-audiophile, and the lossy Bluetooth codec
(SBC/AAC/aptX/LDAC) already alters the signal far more than an ALSA format/rate
conversion ever would. The `plug` is therefore negligible next to the codec it
sits behind — and it only ever touches the Bluetooth path, never the lossless
MPD playback chain.

## Root cause

`bluealsa-aplay` emits a **fixed-format** PCM (the decoded A2DP stream, e.g.
`S16_LE 44.1 kHz` from SBC/aptX-HD). In Standard mode it is sent to `_audioout`:

    pcm._audioout { type copy; slave.pcm "<device>" }

`type copy` performs **no format/rate conversion** — producer and slave must
agree. moOde's own ALSA output mode help already describes the mechanism:

> **Direct**: ALSA "hw" plugin which **does not perform format conversions**. The audio device must accept the given format.
> **Default**: ALSA "plughw" plugin which **performs format conversions if needed** to match audio device requirements.

So in Standard mode, when the slave resolves to a raw device (output mode
**Direct/`hw`** or **IEC958**) and nothing in the chain converts, the DAC
rejects the stream's fixed format and the device fails to open → **silence**.

Two sub-cases are affected:

1. **No DSP and no Peppy** → `copy → hw`
2. **Invert polarity only** → `copy → invpolarity (type route) → hw`
   (`type route` does not convert either)

**Default (`plughw`)** already worked because `plughw` == `plug` + `hw`, which
inserts a converter. This is why the defect went unnoticed — most users are on
Default; it bites bit-perfect (`Direct`/`hw`) and IEC958 setups.

Compatibility "works" only because it points `bluealsa-aplay` directly at
`plughw:<card>,0`, attacking the card and therefore **skipping the whole
`_audioout` chain (no DSP, no Peppy)**.

## Why DSP/Peppy already worked (and still do)

These targets already carry their own conversion, so they were never affected
and are not changed by this PR:

| Target        | ALSA type                        | Converts? |
|---------------|----------------------------------|-----------|
| `peppy`       | `type plug`                      | yes (built-in) |
| `alsaequal`   | `type plug`                      | yes (built-in) |
| `eqfa12p`     | `type plug`                      | yes (built-in) |
| `crossfeed`   | `type plug`                      | yes (built-in) |
| `camilladsp`  | `type cdsp` (rate list, `-f/-r`) | yes (self-adapting) |
| `invpolarity` | `type route`                     | no |
| `_audioout`   | `type copy`                      | no |

## The fix

Prefix the Standard (`_audioout`) target with `plug:` so the conversion happens
**at the top** of the chain — between `bluealsa-aplay` and `_audioout` —
instead of mutating the shared `_audioout` slave:

    bluealsa-aplay -> plug -> _audioout (copy) -> [DSP/Peppy/invpolarity] -> hw -> DAC
                      \ converts the fixed BT format, negotiated down to the device /

- The `plug` affects only the Bluetooth producer.
- The chain still flows through `_audioout`, so **DSP and Peppy keep applying**.
- For targets that already convert (DSP/Peppy), the extra top `plug` is a
  transparent **no-op** (it only converts when the formats differ).

Mutating `_audioout`'s slave to `plughw` instead was deliberately avoided:
`_audioout` is shared with MPD, and that would insert `plug` into MPD's path,
breaking bit-perfect playback. The top-level wrapper avoids this entirely.

## Why there are no expected regressions

- **MPD playback path is untouched** — it still uses `_audioout -> hw` directly;
  bit-perfect output is preserved.
- **Bluetooth audio is lossy** (SBC/AAC/aptX/LDAC), so adding `plug` to the BT
  path has no audible/bit-perfect cost.
- **`plug` only converts when needed** and **applies no gain** — it is a
  pass-through when the producer format already matches the slave. The inbound
  Bluetooth routing is therefore independent of the MPD volume type
  (Hardware / Software / Fixed).
- **Compatibility mode is unchanged** and remains available.
- The default seed (`etc/bluealsaaplay.conf`) is updated so a fresh install
  works out of the box.

## Behavior matrix

Legend: silent / sound / DSP-Peppy applied / DSP-Peppy bypassed.

**Main output mode = Direct (`hw`):**

| DSP/Peppy | Mode | AUDIODEV | Before | After | DSP/Peppy |
|---|---|---|---|---|---|
| none | Standard | `plug:_audioout` | silent | sound | - |
| none | Compatibility | `plughw:N,0` | sound | sound (same) | - |
| Peppy | Standard | `peppy` | sound | sound (same) | applied |
| CamillaDSP | Standard | `plug:_audioout` | sound | sound (no-op) | applied |
| EQ / Crossfeed | Standard | `plug:_audioout` | sound | sound (no-op) | applied |
| Invert polarity only | Standard | `plug:_audioout` | silent | sound | applied |
| any DSP/Peppy | Compatibility | `plughw:N,0` | sound | sound (same) | bypassed |

**Only the two raw-`_audioout` cases change** (silent -> sound). Everything else
is unchanged or a no-op.

**Output mode = Default (`plughw`):** never affected — `_audioout`'s slave is
`plughw` which already converts; the fix is a no-op there.

**Output mode = IEC958:** Standard goes silent -> sound (the `plug` converts to
the IEC958 subframe format). Note a pre-existing, separate gap not addressed
here: **Compatibility + IEC958** uses a raw IEC958 device with no `plug` and may
also be silent; this PR only touches Standard.

## Tested configurations

Reproduced and fixed on two independent setups, both with main output mode
**Direct (`hw`)** and a USB DAC (DIYINHK), phone over A2DP (aptX-HD -> decoded
`PCM 16 bit 44.1 kHz`):

- **Raspberry Pi 3B, moOde 10.2.4 (stock release image), RPiOS 13 Trixie 64-bit**
  - Standard, no DSP/Peppy -> was silent (stock), now plays
    (`bluealsa-aplay ... -D plug:_audioout`, `_audioout` slave `hw:1,0`)
  - Compatibility -> unchanged (plays before and after)
- **Debian 13 x86_64, USB DAC**
  - Standard, no DSP/Peppy -> was silent, now plays
  - Standard + Invert Polarity -> was silent, now plays with phase inversion
  - Peppy / CamillaDSP / Graphic EQ / Crossfeed -> unchanged, still play + DSP/Peppy applies
  - MPD local playback (Direct/`hw`, bit-perfect) -> unaffected

The defect and the fix are pure ALSA routing and identical across platforms;
the code path does not branch on hardware.

## Files changed

- `www/inc/audio.php` — `updDspAndBtInConfs()`: Standard branch -> `plug:_audioout`
- `www/blu-config.php` — Bluetooth UI toggle handler -> `plug:_audioout`
- `www/inc/autocfg.php` — autoconfig reset -> `plug:_audioout`
- `etc/bluealsaaplay.conf` — default seed -> `AUDIODEV=plug:_audioout`
