### PR TITLE
radiobrowser: native radio-browser.info integration in the Radio view

### DIFF
--- a/www/command/radiobrowser.php
+++ b/www/command/radiobrowser.php
@@ -1,0 +1,223 @@
+<?php
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright 2014 The moOde audio player project / Tim Curtis
+ *
+ * radio-browser.info AJAX endpoint: dispatches ?cmd=… to the inc/radio-browser.php
+ * function library. Derived from RubaTron's Radio Browser extension (GPL-3.0-or-later).
+*/
+
+require_once __DIR__ . '/../inc/radio-browser.php';
+
+// Validate GET/POST scalars. Station payloads for write actions arrive as JSON on
+// php://input (see rbInputStation()) and are sanitised individually below.
+chkVariables($_GET);
+chkVariables($_POST);
+
+$cmd = $_GET['cmd'] ?? '';
+$response = array('success' => false, 'message' => 'Unknown command');
+
+switch ($cmd) {
+	case 'logo':
+		rbServeLogo($_REQUEST['u'] ?? '');
+		// rbServeLogo() streams the image (or 302s) and exit()s.
+		break;
+
+	case 'search':
+		$params = array(
+			'name' => $_REQUEST['name'] ?? '',
+			'countrycode' => $_REQUEST['countrycode'] ?? '',
+			'tag' => $_REQUEST['tag'] ?? '',
+			'offset' => (int)($_REQUEST['offset'] ?? 0),
+			'limit' => (int)($_REQUEST['limit'] ?? RADIOBROWSER_LIMIT),
+			'order' => 'clickcount',
+			'reverse' => 'true',
+			'hidebroken' => 'true'
+		);
+		$params = array_filter($params, function ($v) {
+			return $v !== '' && $v !== null;
+		});
+		$key = 'search_' . md5(json_encode($params));
+		$data = rbCacheGet($key, RADIOBROWSER_CACHE_TTL);
+		if ($data === false) {
+			$data = rbApi('/json/stations/search', $params);
+			if ($data !== false) {
+				rbCacheSet($key, $data);
+			} else {
+				$data = rbCacheGet($key, 0); // Stale fallback if API is down
+			}
+		}
+		if ($data !== false) {
+			$response = array('success' => true, 'stations' => rbShapeResults($data, sqlConnect()), 'batch' => count($data));
+		} else {
+			$response = array('success' => false, 'message' => 'No results or API error');
+		}
+		break;
+
+	case 'countries':
+		$data = rbCacheGet('countries', RADIOBROWSER_CACHE_TTL_STATIC);
+		if ($data === false) {
+			$data = rbApi('/json/countries', array('hidebroken' => 'true'));
+			if ($data !== false) {
+				rbCacheSet('countries', $data);
+			}
+		}
+		$response = $data !== false ?
+			array('success' => true, 'countries' => $data) :
+			array('success' => false, 'message' => 'API error');
+		break;
+
+	case 'genres':
+		$data = rbCacheGet('genres', RADIOBROWSER_CACHE_TTL_STATIC);
+		if ($data === false) {
+			$data = rbApi('/json/tags', array('hidebroken' => 'true', 'order' => 'stationcount', 'reverse' => 'true', 'limit' => 200));
+			if ($data !== false) {
+				rbCacheSet('genres', $data);
+			}
+		}
+		$response = $data !== false ?
+			array('success' => true, 'genres' => $data) :
+			array('success' => false, 'message' => 'API error');
+		break;
+
+	case 'recently_played':
+		$favUrls = rbFavoriteUrls(sqlConnect());
+		$stations = array();
+		foreach (rbGetRecent() as $s) {
+			$s['added'] = isset($favUrls[rbNormalizeUrl($s['url'])]);
+			$stations[] = $s;
+		}
+		$response = array('success' => true, 'stations' => $stations);
+		break;
+
+	case 'add':
+		$station = rbInputStation();
+		$url = trim($station['url'] ?? '');
+		if ($url === '' || !preg_match('#^https?://#i', $url) || str_contains($url, '"')) {
+			$response = array('success' => false, 'message' => 'Invalid station URL');
+			break;
+		}
+		$name = rbSafeName($station['name'] ?? DEFAULT_STATION_NAME);
+		$dbh = sqlConnect();
+
+		// Already in cfg_radio? Promote to favorite (idempotent), never duplicate the stream
+		$existing = sqlQuery("SELECT id, type, name FROM cfg_radio WHERE station='" . SQLite3::escapeString($url) . "' LIMIT 1", $dbh);
+		if (is_array($existing)) {
+			if ($existing[0]['type'] == 'f') {
+				$response = array('success' => true, 'message' => 'Station already in favorites');
+			} else {
+				sqlQuery("UPDATE cfg_radio SET type='f' WHERE id='" . $existing[0]['id'] . "'", $dbh);
+				$response = array('success' => true, 'message' => 'Station added to favorites');
+			}
+			break;
+		}
+
+		// New station: create the local logo files (favicon → convert, else default cover)
+		rbEnsureLogo($name, trim($station['favicon'] ?? ''));
+
+		rbWriteStation(array(
+			'url' => $url,
+			'name' => $name,
+			'genre' => trim($station['tags'] ?? ''),
+			'language' => trim($station['language'] ?? ''),
+			'country' => trim($station['country'] ?? ''),
+			'region' => trim($station['state'] ?? ''),
+			'bitrate' => (string)(int)($station['bitrate'] ?? 0),
+			'format' => trim($station['codec'] ?? ''),
+			'home_page' => trim($station['homepage'] ?? '')
+		));
+		$response = array('success' => true, 'message' => 'Station added to favorites');
+		break;
+
+	case 'remove':
+		$station = rbInputStation();
+		$url = trim($station['url'] ?? '');
+		if ($url === '') {
+			$response = array('success' => false, 'message' => 'No station URL');
+			break;
+		}
+		$dbh = sqlConnect();
+		$row = sqlQuery("SELECT id, name FROM cfg_radio WHERE station='" . SQLite3::escapeString($url) . "' AND type='f' LIMIT 1", $dbh);
+		if (!is_array($row)) {
+			$response = array('success' => false, 'message' => 'Station is not in favorites');
+			break;
+		}
+		// Core moOde stations (id < 499) are only un-favorited; user/imported stations are deleted
+		if ((int)$row[0]['id'] < 499) {
+			sqlQuery("UPDATE cfg_radio SET type='r' WHERE id='" . $row[0]['id'] . "'", $dbh);
+		} else {
+			rbDeleteStation($row[0]['name']);
+		}
+		$response = array('success' => true, 'message' => 'Station removed from favorites');
+		break;
+
+	case 'register':
+		// Called when a Radio Browser tile's context menu opens: make the native queue
+		// actions (Add/Play/Add next/…) resolve a not-yet-added station (logo + type='u').
+		$station = rbInputStation();
+		$url = trim($station['url'] ?? '');
+		if ($url === '' || !preg_match('#^https?://#i', $url) || str_contains($url, '"')) {
+			$response = array('success' => false, 'message' => 'Invalid station URL');
+			break;
+		}
+		rbRegisterStation($station);
+		$response = array('success' => true, 'message' => 'Registered');
+		break;
+
+	case 'play':
+		$station = rbInputStation();
+		$url = trim($station['url'] ?? '');
+		if ($url === '' || !preg_match('#^https?://#i', $url) || str_contains($url, '"')) {
+			$response = array('success' => false, 'message' => 'Invalid station URL');
+			break;
+		}
+		$favicon = trim($station['favicon'] ?? '');
+		// Ensure logo + cfg_radio type='u' + session var (so now-playing resolves the stream)
+		$reg = rbRegisterStation($station);
+		$name = $reg['name'];
+		$format = $reg['format'];
+		$bitrate = $reg['bitrate'];
+		$homepage = $reg['homepage'];
+
+		$sock = getMpdSock('command/radiobrowser.php');
+		sendMpdCmd($sock, 'addid "' . $url . '"');
+		$resp = readMpdResp($sock);
+		if (preg_match('/Id:\s*(\d+)/', $resp, $m)) {
+			sendMpdCmd($sock, 'playid ' . $m[1]);
+			readMpdResp($sock);
+			$response = array('success' => true, 'message' => 'Playing: ' . $name, 'name' => $name, 'url' => $url, 'format' => $format, 'bitrate' => $bitrate, 'home_page' => $homepage);
+		} else {
+			$response = array('success' => false, 'message' => 'MPD addid failed');
+		}
+		closeMpdSock($sock);
+
+		rbAddRecent(array(
+			'name' => $name,
+			'url' => $url,
+			'favicon' => rbCacheImage($favicon),
+			'country' => trim($station['country'] ?? ''),
+			'tags' => trim($station['tags'] ?? ''),
+			'bitrate' => (int)$bitrate,
+			'codec' => $format,
+			'stationuuid' => trim($station['stationuuid'] ?? ''),
+			'played_at' => time()
+		));
+
+		// Click tracking (fire-and-forget) — radio-browser.info best practice
+		$uuid = trim($station['stationuuid'] ?? '');
+		if ($uuid !== '' && preg_match('/^[0-9a-f\-]{36}$/i', $uuid)) {
+			$options = array('http' => array(
+				'method' => 'POST',
+				'timeout' => 3.0,
+				'header' => "User-Agent: " . RADIOBROWSER_UA . "\r\n"
+			));
+			@file_get_contents('https://' . RADIOBROWSER_API_PRIMARY . '/json/url/' . $uuid, false, stream_context_create($options));
+		}
+		break;
+
+	default:
+		$response = array('success' => false, 'message' => 'Unknown command');
+		break;
+}
+
+echo json_encode($response);

--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -288,16 +288,17 @@ img.coverart {
 #coverart-url {position:relative;}
 #container-browse {width:100%;padding:0;top:2.75rem;top:calc(2.75rem + env(safe-area-inset-top));overflow:hidden;position:absolute;}
 #container-radio, #container-playlist {width:100%;padding:0;top:2.75rem;top:calc(2.75rem + env(safe-area-inset-top));overflow:hidden;position:absolute;}
-#database, #database-radio, #database-playlist {overflow:auto;position:relative;width:100%;top:.5em;bottom:0px;height:calc(100vh - 12.25rem);-webkit-overflow-scrolling:touch;}
+#database, #database-radio, #database-playlist, .rb-covers-container {overflow:auto;position:relative;width:100%;top:.5em;bottom:0px;height:calc(100vh - 12.25rem);-webkit-overflow-scrolling:touch;}
 .input-append input::placeholder {color:var(--textvariant);}
 #playqueue-filter::placeholder {color:var(--textvariant);}
 #lib-album-filter::placeholder {color:var(--textvariant);font-size:.9em;}
 
-#playqueue, #database, #database-radio, #database-playlist {padding:0;background:none;}
+#playqueue, #database, #database-radio, #database-playlist, .rb-covers-container {padding:0;background:none;}
 .playqueue, .cv-playqueue, .database, .database-radio, .database-playlist {display:block;margin:0;padding:0;list-style:none;counter-reset:item;word-break: break-word;}
 .database {padding:0 0 12rem 0;width:100%;overflow-x:hidden;margin:0;top:.5em;}
 .playqueue .cv-playqueue {padding:0 1em 4em 0;}
 #database-radio, #database-playlist {height:calc(100vh - 2.75em);}
+.rb-covers-container {height:calc(100vh - 5.25em);}
 .database-radio, .database-playlist {text-align:center;padding:0 0 14rem 0;}
 .playqueue li, .cv-playqueue li, .database li, .database-radio li, .database-playlist li {display:block;position:relative;margin:0;cursor:pointer;text-align:left;padding-left:.75em;}
 .database li:first-child .db-entry {border-top:1px solid var(--btnshade);}
@@ -386,7 +387,7 @@ img.coverart {
 .btnlist {position:fixed;left:0;right:0;display:block;width:auto;height:2.5em;padding:0;background:none;-webkit-border-radius:0px;-moz-border-radius:0px;border-radius:0px;z-index:999;}
 .btnlist:focus {outline:none;}
 .btnlist.playqueue-prevPage, .btnlist.db-prevPage, .btnlist.playqueue-firstPage, .btnlist.db-firstPage {padding:0 .3em;}
-.btnlist-top-db, .btnlist-top-ra, .btnlist-top-pl {
+.btnlist-top-db, .btnlist-top-ra, .btnlist-top-pl, .btnlist-top-rb {
 	position:relative;
 	background-color:var(--btnshade3);
 	top:.25em;
@@ -423,7 +424,7 @@ img.coverart {
 #radio-panel,
 #playlist-panel {animation: fadeIn var(--fadein-rate);width:100%;height:100vh;position:fixed;top:0;overflow:hidden;}
 #library-panel {animation: fadeIn var(--fadein-rate);height:100vh;}
-.btnlist-top-db button, .btnlist-top-ra button, .btnlist-top-pl button {margin:0;line-height:normal;height:2.5rem;width:2.5rem;font-size:1.1rem;border-radius:0;float:left;display:inline-block;padding:.25rem .5rem;border-right: 1px solid var(--btnshade);}
+.btnlist-top-db button, .btnlist-top-ra button, .btnlist-top-pl button, .btnlist-top-rb button {margin:0;line-height:normal;height:2.5rem;width:2.5rem;font-size:1.1rem;border-radius:0;float:left;display:inline-block;padding:.25rem .5rem;border-right: 1px solid var(--btnshade);}
 #db-back {font-size:1.5rem;}
 
 #reconnect,
@@ -623,7 +624,7 @@ img.lib-artistart {
 	border-style:none;
 	border-radius:var(--thm-border-radius);
 }
-#albumcovers .thumbHW, #radio-covers .thumbHW, #playlist-covers .thumbHW {height:var(--thumbimagesize);width:var(--thumbimagesize);position:relative;margin:.75em 0 .5em 0;}
+#albumcovers .thumbHW, #radio-covers .thumbHW, #playlist-covers .thumbHW, .rb-covers-container .thumbHW {height:var(--thumbimagesize);width:var(--thumbimagesize);position:relative;margin:.75em 0 .5em 0;}
 #albumcovers .artyear {color:var(--textvariant);font-weight:500;}
 #albumcovers .artist-name {
 	margin:0 .15em;
@@ -728,7 +729,8 @@ body.cvwide #playback-controls {display:none!important;}
 #splash div {position:absolute;top:50%;left:50%;transform:translate(-50%, -50%);font-size:10vw;font-weight:300;letter-spacing:-.06em;opacity:0;transition:1s;}
 .cover-menu {position:absolute;float:right;height:5rem;width:5rem;background-size:2rem 2rem;background-repeat:no-repeat;background-position:.75rem 2.4rem;transform:translate(.75rem, -5.5rem);background-image:url('../images/dots.png')}
 body.no-touch .cover-menu {opacity:0;}
-#radio-covers li:hover .cover-menu, #playlist-covers li:hover .cover-menu, #albumcovers li:hover .cover-menu {opacity:1;}
+#radio-covers li:hover .cover-menu, #playlist-covers li:hover .cover-menu, #albumcovers li:hover .cover-menu,
+#rb-covers-search li:hover .cover-menu, #rb-covers-recent li:hover .cover-menu, #rb-covers-fav li:hover .cover-menu {opacity:1;}
 #playback-toolbar {display:none;z-index:1003;transform:translate(-50%, -50%);top:2%;top:calc(env(safe-area-inset-top) + 2%);left:50%;position:fixed;color:var(--adapttext);border-radius:0 0 .5em .5em;background-color:inherit;backdrop-filter:blur(5px);-webkit-backdrop-filter:blur(5px);box-shadow:0px 0px 10px rgba(0, 0, 0, 0.40);}
 
 /* Equalizers */
@@ -1133,3 +1135,26 @@ body.cv .timeline-thm input[type='range']::-webkit-slider-thumb {
 #multiroom-sender {position:relative;display:none;top:env(safe-area-inset-top);transform:translate(-55%);left:50%;}
 #multiroom-sender a {font-size:1.25rem;color:var(--textvariant);/*color:var(--adapttext);*/}
 #menu-cdsp {color:var(--adapttext);}
+
+/* Radio Browser view (radio-browser.info) */
+.btnlist-top-rb button.rb-tab {width:auto;padding:.25rem .75rem;font-size:.95rem;}
+.btnlist-top-rb button.active {background-color:var(--accentxta);color:var(--adapttext);}
+.btnlist-top-rb button:first-child.active {border-top-left-radius:var(--btn-border-radius);border-bottom-left-radius:var(--btn-border-radius);}
+.btnlist-top-rb .ra-explore-btn.active {border-top-right-radius:var(--btn-border-radius);border-bottom-right-radius:var(--btn-border-radius);}
+#rb-search {display:block;float:left;margin:0;z-index:1001;position:relative;}
+#rb-search input {margin-left:.5em;padding:0;height:2.5rem;border:none;font-size:inherit;width:26vw;}
+#rb-filters {float:left;}
+.btnlist-top-ra .ra-explore-btn, .btnlist-top-rb .ra-explore-btn {float:right;}
+/* Filter selects: solid dropdown (moOde's bootstrap-select menu is transparent) */
+#container-radio-browser .bootstrap-select .dropdown-menu {background-color:var(--adaptmbg);}
+.rb-tab-pane {position:relative;}
+.rb-empty {text-align:center!important;color:var(--textvariant);padding:2rem 0!important;width:100%;display:block!important;cursor:default!important;}
+.rb-fav-toggle {position:absolute;top:.4rem;right:0;width:2rem;height:2rem;display:flex;align-items:center;justify-content:center;border-radius:50%;background-color:rgba(0,0,0,.45);color:#fff;font-size:1.2rem;z-index:2;cursor:pointer;}
+.rb-fav-toggle.added {color:#d35400;}
+.rb-fav-toggle .fa-heart {margin-top:4px;}
+.rb-hls-badge {position:absolute;top:.4rem;left:.4rem;padding:.1rem .4rem;border-radius:.6rem;background-color:rgba(192,57,43,.9);color:#fff;font-size:.7rem;font-weight:bold;letter-spacing:.5px;z-index:2;}
+.rb-hls .thumbHW img {opacity:.5;cursor:default;}
+#rb-covers-search #rb-showmore {display:block;width:100%;text-align:center;padding:.5rem 0 0 0;margin:0;cursor:default;}
+#rb-covers-search #rb-showmore button {font-size:.9em;background:var(--btnshade2);border-radius:3em;margin:1em auto;padding:.5em 1.25em .6em 1.25em;line-height:normal;height:auto;width:auto;}
+#rb-covers-search #rb-showmore button:hover {background:var(--btnshade2);} /* Mask hover effect */
+.rb-attribution {position:fixed;bottom:0;width:100%;text-align:center;font-size:.75rem;color:var(--textvariant);padding:.25rem 0;background:var(--bg);}

--- a/www/header.php
+++ b/www/header.php
@@ -87,6 +87,7 @@
 		<script src="js/bootstrap-contextmenu.js" defer></script>
 		<script src="js/scripts-library.js" defer></script>
 		<script src="js/scripts-panels.js" defer></script>
+		<script src="js/radio-browser.js" defer></script>
 		<!-- endbuild -->
 	<!-- Configs -->
 	<!--removeIf(GENINDEXDEV)-->

--- a/www/inc/constants.php
+++ b/www/inc/constants.php
@@ -37,6 +37,17 @@ const CURRENTSONG_TXT_TMP = '/tmp/currentsong.txt';
 // Radiocover plus
 const RADIOCOVER_PLUS_CFG = '/etc/radiocover-plus/config.txt';
 const RADIOCOVER_PLUS_LOG = '/var/log/moode_radiocover_plus.log';
+// Radio Browser (radio-browser.info)
+const RADIOBROWSER_API_PRIMARY = 'all.api.radio-browser.info'; // round-robin alias: bootstrap + last resort
+const RADIOBROWSER_API_SRV = '_api._tcp.radio-browser.info';   // DNS SRV record for server discovery
+const RADIOBROWSER_UA = 'moode-radio-browser/1.0';
+const RADIOBROWSER_CACHE = '/var/local/www/rbcache';
+const RADIOBROWSER_RECENT_FILE = '/var/local/www/rbcache/recently_played.json';
+const RADIOBROWSER_IMAGE_CACHE = '/var/local/www/imagesw/radio-logos/cache';
+const RADIOBROWSER_CACHE_TTL = 1800; // Search results (30 min)
+const RADIOBROWSER_CACHE_TTL_STATIC = 43200; // Countries/genres/topclick (12 hr)
+const RADIOBROWSER_RECENT_MAX = 50;
+const RADIOBROWSER_LIMIT = 28; // Fixed search/page size
 // AirPlay, Deezer Connect and Spotify Connect
 const APLMETA_CACHE_FILE = '/var/local/www/aplmeta.json';
 const DEEZMETA_CACHE_FILE = '/var/local/www/deezmeta.json';

--- a/www/inc/radio-browser.php
+++ b/www/inc/radio-browser.php
@@ -1,0 +1,492 @@
+<?php
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright 2014 The moOde audio player project / Tim Curtis
+ *
+ * radio-browser.info integration — function library (radio-browser.info client,
+ * cache, cfg_radio station read/write, logo proxy). Derived from RubaTron's Radio
+ * Browser extension for moOde (GPL-3.0-or-later), re-implemented in moOde's native
+ * conventions (cfg_radio, submitJob, mpd.php). Included by command/radiobrowser.php.
+*/
+
+require_once __DIR__ . '/common.php';
+require_once __DIR__ . '/mpd.php';
+require_once __DIR__ . '/session.php';
+require_once __DIR__ . '/sql.php';
+
+// HTTP GET with moOde's stream-context convention (no curl in core)
+function rbHttpGet($url, $timeout = 10, $acceptJson = false) {
+	$header = "User-Agent: " . RADIOBROWSER_UA . "\r\n";
+	if ($acceptJson) {
+		$header .= "Accept: application/json\r\n";
+	}
+	$options = array('http' => array(
+		'method' => 'GET',
+		'protocol_version' => (float)'1.1',
+		'timeout' => (float)$timeout,
+		'header' => $header,
+		'follow_location' => 1,
+		'max_redirects' => 3
+	));
+	// The context 'timeout' only bounds the READ; the http:// wrapper uses
+	// default_socket_timeout for the CONNECT. Without bounding it, a favicon on a
+	// dead/silent host hangs up to 60s and search (30 fetches) stalls for minutes.
+	// Cap both so each fetch is capped at ~$timeout, like the plugin's cURL TIMEOUT.
+	$prevSocketTimeout = ini_set('default_socket_timeout', (string)(int)ceil($timeout));
+	$data = @file_get_contents($url, false, stream_context_create($options));
+	if ($prevSocketTimeout !== false) {
+		ini_set('default_socket_timeout', $prevSocketTimeout);
+	}
+	return $data;
+}
+
+// Discover the current API server list, per radio-browser.info guidance ("get a list
+// of the servers", "names may change"): DNS SRV, then HTTP /json/servers, then the
+// round-robin alias as last resort. Cached 12h; shuffled each call to spread load.
+function rbGetServers() {
+	$servers = rbCacheGet('servers', RADIOBROWSER_CACHE_TTL_STATIC);
+	if (!is_array($servers) || !count($servers)) {
+		$servers = array();
+		$records = @dns_get_record(RADIOBROWSER_API_SRV, DNS_SRV);
+		if (is_array($records)) {
+			foreach ($records as $r) {
+				if (!empty($r['target'])) { $servers[] = $r['target']; }
+			}
+		}
+		if (!count($servers)) {
+			$resp = rbHttpGet('https://' . RADIOBROWSER_API_PRIMARY . '/json/servers', 10, true);
+			$list = ($resp !== false && $resp !== '') ? json_decode($resp, true) : null;
+			if (is_array($list)) {
+				foreach ($list as $s) {
+					if (!empty($s['name'])) { $servers[] = $s['name']; }
+				}
+			}
+		}
+		$servers = array_values(array_unique($servers));
+		if (!count($servers)) {
+			return array(RADIOBROWSER_API_PRIMARY); // last resort, not cached
+		}
+		rbCacheSet('servers', $servers);
+	}
+	shuffle($servers);
+	return $servers;
+}
+
+// Call the radio-browser.info JSON API with automatic mirror failover
+function rbApi($endpoint, $params = array(), $timeout = 10) {
+	$query = http_build_query($params);
+	// Always try the round-robin alias first (fast, health-balanced), then the
+	// dynamically discovered individual servers as failover.
+	$servers = array_values(array_unique(array_merge(array(RADIOBROWSER_API_PRIMARY), rbGetServers())));
+	foreach ($servers as $srv) {
+		$url = 'https://' . $srv . $endpoint . ($query ? '?' . $query : '');
+		$resp = rbHttpGet($url, $timeout, true);
+		if ($resp !== false && $resp !== '') {
+			$data = json_decode($resp, true);
+			if ($data !== null) {
+				return $data;
+			}
+		}
+	}
+	return false;
+}
+
+// Normalise a stream URL for identity comparison (scheme/trailing slash/case insensitive)
+function rbNormalizeUrl($url) {
+	$u = trim(strtolower($url));
+	$u = preg_replace('#^https?://#', '', $u);
+	$u = rtrim($u, '/');
+	return $u;
+}
+
+// Make a station name safe for use as a filesystem/shell path component.
+// moOde keeps station names verbatim as the logo/.pls filename (validateInput only
+// SQL-escapes; putStationCover uses the raw name), and the now-playing renderer looks
+// the logo up by that exact name — so we must NOT strip characters moOde keeps (notably
+// '&', which is literal inside the double-quoted sysCmd paths). Only remove path
+// separators and the few chars that break a double-quoted shell arg or a file write.
+function rbSafeName($name) {
+	$safe = preg_replace('#[/\\\\"`$\x00-\x1f]#', '', (string)$name);
+	$safe = trim(preg_replace('/\s+/', ' ', $safe));
+	$safe = substr($safe, 0, 128);
+	return $safe !== '' ? $safe : DEFAULT_STATION_NAME;
+}
+
+// Read a station object from the JSON request body (fallback to POST fields)
+function rbInputStation() {
+	$st = json_decode(file_get_contents('php://input'), true);
+	if (!is_array($st)) {
+		$st = $_POST;
+	}
+	return is_array($st) ? $st : array();
+}
+
+// Simple file-based JSON response cache
+function rbCacheGet($key, $ttl) {
+	$file = RADIOBROWSER_CACHE . '/' . $key . '.json';
+	if (file_exists($file) && ($ttl === 0 || (time() - filemtime($file) < $ttl))) {
+		$data = json_decode(file_get_contents($file), true);
+		return $data === null ? false : $data;
+	}
+	return false;
+}
+function rbCacheSet($key, $data) {
+	if (!is_dir(RADIOBROWSER_CACHE)) {
+		@mkdir(RADIOBROWSER_CACHE, 0775, true);
+	}
+	@file_put_contents(RADIOBROWSER_CACHE . '/' . $key . '.json', json_encode($data));
+}
+
+// Download a station favicon into the local image cache; return a same-origin web path
+function rbCacheImage($url) {
+	if (empty($url) || str_contains($url, 'encrypted-tbn0.gstatic.com')) {
+		return '';
+	}
+	$hash = md5($url);
+	$file = RADIOBROWSER_IMAGE_CACHE . '/' . $hash . '.png';
+	$webPath = 'imagesw/radio-logos/cache/' . $hash . '.png';
+	if (file_exists($file) && (time() - filemtime($file) < RADIOBROWSER_CACHE_TTL_STATIC)) {
+		return $webPath;
+	}
+	$data = rbHttpGet($url, 3);
+	if ($data !== false && strlen($data) > 100 && strlen($data) < 51200) {
+		if (!is_dir(RADIOBROWSER_IMAGE_CACHE)) {
+			@mkdir(RADIOBROWSER_IMAGE_CACHE, 0775, true);
+		}
+		if (@file_put_contents($file, $data)) {
+			return $webPath;
+		}
+	}
+	return '';
+}
+
+// --- Station logo handling (ported from RubaTron's Radio Browser api.php) --------------
+// Creates the three JPGs moOde expects for a radio station logo, synchronously (so they
+// exist before the stream plays / the tile renders): <name>.jpg (400), thumbs/<name>.jpg
+// (200), thumbs/<name>_sm.jpg (80). This is the plugin's rb_save_permanent_logo mechanism.
+
+// Fetch raw image bytes from an http(s) URL or a local /var/local/www cache path
+function rbFetchImageData($favicon) {
+	if ($favicon === '') {
+		return false;
+	}
+	if (preg_match('#^https?://#i', $favicon)) {
+		$data = rbHttpGet($favicon, 8);
+		return ($data !== false && strlen($data) > 100) ? $data : false;
+	}
+	// Local same-origin path (e.g. a cached favicon under imagesw/radio-logos/cache/)
+	$local = '/var/local/www/' . ltrim($favicon, '/');
+	$real = realpath($local);
+	if ($real !== false && str_starts_with($real, '/var/local/www/imagesw/') && is_file($real)) {
+		$data = file_get_contents($real);
+		return ($data !== false && strlen($data) > 100) ? $data : false;
+	}
+	return false;
+}
+
+// Resize a GD image to a square (white background), save as JPG
+function rbResizeAndSave($src, $srcW, $srcH, $size, $outPath, $quality = 85) {
+	$canvas = imagecreatetruecolor($size, $size);
+	$white = imagecolorallocate($canvas, 255, 255, 255);
+	imagefill($canvas, 0, 0, $white);
+	$scale = min($size / $srcW, $size / $srcH);
+	$newW = (int)($srcW * $scale);
+	$newH = (int)($srcH * $scale);
+	$x = (int)(($size - $newW) / 2);
+	$y = (int)(($size - $newH) / 2);
+	imagecopyresampled($canvas, $src, $x, $y, 0, 0, $newW, $newH, $srcW, $srcH);
+	$saved = @imagejpeg($canvas, $outPath, $quality);
+	imagedestroy($canvas);
+	return $saved;
+}
+
+// Save station logo (400/200/80) to moOde's radio-logos folder. Returns true if all saved.
+function rbSaveLogo($name, $imageData) {
+	$src = @imagecreatefromstring($imageData);
+	if (!$src) {
+		return false;
+	}
+	$w = imagesx($src);
+	$h = imagesy($src);
+	if (!is_dir(RADIO_LOGOS_ROOT)) {
+		@mkdir(RADIO_LOGOS_ROOT, 0755, true);
+	}
+	if (!is_dir(RADIO_LOGOS_ROOT . 'thumbs/')) {
+		@mkdir(RADIO_LOGOS_ROOT . 'thumbs/', 0755, true);
+	}
+	$ok1 = rbResizeAndSave($src, $w, $h, 400, RADIO_LOGOS_ROOT . $name . '.jpg');
+	$ok2 = rbResizeAndSave($src, $w, $h, 200, RADIO_LOGOS_ROOT . 'thumbs/' . $name . '.jpg');
+	$ok3 = rbResizeAndSave($src, $w, $h, 80, RADIO_LOGOS_ROOT . 'thumbs/' . $name . '_sm.jpg');
+	imagedestroy($src);
+	return $ok1 && $ok2 && $ok3;
+}
+
+// Ensure the station has local logo files: download+convert the favicon, else copy the
+// moOde default cover. No-op if the small thumb already exists. Runs before play/add so
+// moOde's native now-playing/playqueue renderer never requests a missing logo (no 404).
+function rbEnsureLogo($name, $favicon) {
+	if (file_exists(RADIO_LOGOS_ROOT . 'thumbs/' . $name . '_sm.jpg')) {
+		return;
+	}
+	$saved = false;
+	if ($favicon !== '' && !str_contains($favicon, 'encrypted-tbn0.gstatic.com')) {
+		$data = rbFetchImageData($favicon);
+		if ($data !== false) {
+			$saved = rbSaveLogo($name, $data);
+		}
+	}
+	if (!$saved) {
+		@copy(DEFAULT_NOTFOUND_COVER, RADIO_LOGOS_ROOT . $name . '.jpg');
+		@copy(DEFAULT_NOTFOUND_COVER, RADIO_LOGOS_ROOT . 'thumbs/' . $name . '.jpg');
+		@copy(DEFAULT_NOTFOUND_COVER, RADIO_LOGOS_ROOT . 'thumbs/' . $name . '_sm.jpg');
+	}
+}
+
+// Recently played history (file-based, most-recent-first)
+function rbGetRecent() {
+	if (!file_exists(RADIOBROWSER_RECENT_FILE)) {
+		return array();
+	}
+	$data = json_decode(@file_get_contents(RADIOBROWSER_RECENT_FILE), true);
+	return is_array($data) ? $data : array();
+}
+function rbAddRecent($station) {
+	if (!is_dir(RADIOBROWSER_CACHE)) {
+		@mkdir(RADIOBROWSER_CACHE, 0775, true);
+	}
+	$fp = @fopen(RADIOBROWSER_RECENT_FILE, 'c+');
+	if (!$fp) {
+		return;
+	}
+	if (!flock($fp, LOCK_EX)) {
+		fclose($fp);
+		return;
+	}
+	$content = stream_get_contents($fp);
+	$list = ($content !== '' && ($d = json_decode($content, true)) && is_array($d)) ? $d : array();
+	$url = trim($station['url']);
+	$list = array_values(array_filter($list, function ($item) use ($url) {
+		return $item['url'] !== $url;
+	}));
+	array_unshift($list, $station);
+	$list = array_slice($list, 0, RADIOBROWSER_RECENT_MAX);
+	ftruncate($fp, 0);
+	rewind($fp);
+	fwrite($fp, json_encode($list, JSON_PRETTY_PRINT));
+	fflush($fp);
+	flock($fp, LOCK_UN);
+	fclose($fp);
+}
+
+// Normalised URL set of the user's favorites (cfg_radio type='f')
+function rbFavoriteUrls($dbh) {
+	$urls = array();
+	$rows = sqlQuery("SELECT station FROM cfg_radio WHERE type='f'", $dbh);
+	if (is_array($rows)) {
+		foreach ($rows as $r) {
+			$urls[rbNormalizeUrl($r['station'])] = true;
+		}
+	}
+	return $urls;
+}
+
+// Map a radio-browser.info result to the fields the UI needs, dedup and mark favorites
+function rbShapeResults($data, $dbh) {
+	$favUrls = rbFavoriteUrls($dbh);
+	$deduped = array();
+	$index = array();
+	foreach ($data as $s) {
+		$url = trim($s['url_resolved'] ?? $s['url'] ?? '');
+		if ($url === '') {
+			continue;
+		}
+		$key = rbNormalizeUrl($url);
+		// Return the raw favicon URL — do NOT cache inline here. Caching 30 external
+		// images synchronously in one request stalls search for tens of seconds (a
+		// slow/dead host blocks the whole loop). The tile <img> instead points at the
+		// same-origin 'logo' proxy below, so images are fetched+cached per-image and in
+		// parallel by the browser (rbCacheImage mechanism preserved, just on demand).
+		$favicon = trim($s['favicon'] ?? '');
+		$station = array(
+			'name' => trim($s['name'] ?? ''),
+			'url' => $url,
+			'favicon' => $favicon,
+			'homepage' => trim($s['homepage'] ?? ''),
+			'country' => trim($s['country'] ?? ''),
+			'countrycode' => trim($s['countrycode'] ?? ''),
+			'state' => trim($s['state'] ?? ''),
+			'language' => trim($s['language'] ?? ''),
+			'tags' => trim($s['tags'] ?? ''),
+			'codec' => trim($s['codec'] ?? ''),
+			'bitrate' => (int)($s['bitrate'] ?? 0),
+			'stationuuid' => trim($s['stationuuid'] ?? ''),
+			// HLS (.m3u8) streams hard-lock MPD's ffmpeg decoder (confirmed on nopi AND
+			// stock moOde Pi — upstream limitation); the UI marks these non-playable.
+			'hls' => (int)($s['hls'] ?? 0),
+			'added' => isset($favUrls[$key])
+		);
+		if (!isset($index[$key])) {
+			$index[$key] = count($deduped);
+			$deduped[] = $station;
+		} else if ($deduped[$index[$key]]['favicon'] === '' && $favicon !== '') {
+			$deduped[$index[$key]] = $station;
+		}
+	}
+	return $deduped;
+}
+
+// Insert a favorite station into cfg_radio + session var + .pls, then update MPD.
+// NOTE: mirrors the native new_station path in command/radio.php (kept self-contained
+// so this feature stays purely additive and does not modify radio.php).
+function rbWriteStation($s) {
+	$dbh = sqlConnect();
+	$values =
+		'NULL,' .
+		"'" . SQLite3::escapeString($s['url']) . "'," .
+		"'" . SQLite3::escapeString($s['name']) . "'," .
+		"'f'," .
+		"'local'," .
+		"\"" . SQLite3::escapeString($s['genre']) . "\"," .
+		"''," .
+		"'" . SQLite3::escapeString($s['language']) . "'," .
+		"'" . SQLite3::escapeString($s['country']) . "'," .
+		"'" . SQLite3::escapeString($s['region']) . "'," .
+		"'" . SQLite3::escapeString($s['bitrate']) . "'," .
+		"'" . SQLite3::escapeString($s['format']) . "'," .
+		"'No'," .
+		"'" . SQLite3::escapeString($s['home_page']) . "'," .
+		"'No'";
+	sqlQuery('INSERT INTO cfg_radio VALUES (' . $values . ')', $dbh);
+
+	phpSession('open');
+	$_SESSION[$s['url']] = array(
+		'name' => $s['name'],
+		'type' => 'f',
+		'logo' => 'local',
+		'bitrate' => $s['bitrate'],
+		'format' => $s['format'],
+		'home_page' => $s['home_page'],
+		'monitor' => 'No'
+	);
+	phpSession('close');
+
+	$plsFile = MPD_MUSICROOT . 'RADIO/' . $s['name'] . '.pls';
+	$contents = "[playlist]\nFile1=" . $s['url'] . "\nTitle1=" . $s['name'] . "\nLength1=-1\nNumberOfEntries=1\nVersion=2\n";
+	file_put_contents($plsFile, $contents);
+	sysCmd('chmod 0777 "' . $plsFile . '"');
+	sysCmd('chown root:root "' . $plsFile . '"');
+	sysCmd('find ' . MPD_MUSICROOT . 'RADIO -name *.pls -exec touch {} \+');
+	rbMpdUpdateRadio();
+}
+
+// Delete a station row + its .pls + logo files, then update MPD
+function rbDeleteStation($name) {
+	$dbh = sqlConnect();
+	$row = sqlQuery("SELECT station FROM cfg_radio WHERE name='" . SQLite3::escapeString($name) . "'", $dbh);
+	if (is_array($row)) {
+		phpSession('open');
+		unset($_SESSION[$row[0]['station']]);
+		phpSession('close');
+	}
+	sqlQuery("DELETE FROM cfg_radio WHERE name='" . SQLite3::escapeString($name) . "'", $dbh);
+	sysCmd('rm -f "' . MPD_MUSICROOT . 'RADIO/' . $name . '.pls"');
+	sysCmd('rm -f "' . RADIO_LOGOS_ROOT . $name . '.jpg"');
+	sysCmd('rm -f "' . RADIO_LOGOS_ROOT . 'thumbs/' . $name . '.jpg"');
+	sysCmd('rm -f "' . RADIO_LOGOS_ROOT . 'thumbs/' . $name . '_sm.jpg"');
+	sysCmd('find ' . MPD_MUSICROOT . 'RADIO -name *.pls -exec touch {} \+');
+	rbMpdUpdateRadio();
+}
+
+function rbMpdUpdateRadio() {
+	$sock = getMpdSock('command/radiobrowser.php');
+	sendMpdCmd($sock, 'update RADIO');
+	readMpdResp($sock);
+	closeMpdSock($sock);
+}
+
+// Same-origin logo proxy: fetch+cache ONE favicon on demand (rbCacheImage mechanism)
+// and stream it. Search returns raw favicon URLs; each tile's <img> points here, so
+// the browser loads logos in parallel and a slow/dead host only delays its own tile,
+// never the search response. Streams the cached PNG; 302s to the default cover on miss.
+function rbServeLogo($url) {
+	if (session_status() === PHP_SESSION_ACTIVE) {
+		session_write_close(); // release the session lock so parallel image requests don't serialise
+	}
+	$url = trim($url);
+	$file = '';
+	if ($url !== '' && preg_match('#^https?://#i', $url) && !str_contains($url, 'encrypted-tbn0.gstatic.com')) {
+		$hash = md5($url);
+		$path = RADIOBROWSER_IMAGE_CACHE . '/' . $hash . '.png';
+		if (file_exists($path) && (time() - filemtime($path) < RADIOBROWSER_CACHE_TTL_STATIC)) {
+			$file = $path;
+		} else {
+			$data = rbHttpGet($url, 4);
+			if ($data !== false && strlen($data) > 100 && strlen($data) < 51200) {
+				if (!is_dir(RADIOBROWSER_IMAGE_CACHE)) {
+					@mkdir(RADIOBROWSER_IMAGE_CACHE, 0775, true);
+				}
+				if (@file_put_contents($path, $data)) {
+					$file = $path;
+				}
+			}
+		}
+	}
+	if ($file === '') {
+		header('Location: /' . DEFAULT_RADIO_COVER);
+		exit;
+	}
+	$info = @getimagesize($file);
+	$type = ($info && !empty($info['mime'])) ? $info['mime'] : 'image/png';
+	header('Content-Type: ' . $type);
+	header('Cache-Control: public, max-age=86400');
+	header('Content-Length: ' . filesize($file));
+	readfile($file);
+	exit;
+}
+
+// Register a radio-browser station locally WITHOUT playing it: ensure the 3 logo files
+// exist, persist it as cfg_radio type='u' (played/history — not shown in the Radio view)
+// if new, and set the session var so moOde's native now-playing/playqueue renderer
+// resolves name/format/logo. Shared by 'play' and by 'register' (the latter is fired
+// when a Radio Browser tile's context menu opens, so the native queue actions resolve a
+// not-yet-added station instead of crashing on an unknown stream). Returns normalised fields.
+function rbRegisterStation($station) {
+	$url = trim($station['url'] ?? '');
+	$name = rbSafeName($station['name'] ?? DEFAULT_STATION_NAME);
+	$favicon = trim($station['favicon'] ?? '');
+	$bitrate = (string)(int)($station['bitrate'] ?? 0);
+	$format = trim($station['codec'] ?? '');
+	$homepage = trim($station['homepage'] ?? '');
+
+	rbEnsureLogo($name, $favicon);
+
+	$dbh = sqlConnect();
+	$exists = sqlQuery("SELECT id FROM cfg_radio WHERE station='" . SQLite3::escapeString($url) . "' LIMIT 1", $dbh);
+	if (!is_array($exists)) {
+		$vals = 'NULL,' .
+			"'" . SQLite3::escapeString($url) . "'," .
+			"'" . SQLite3::escapeString($name) . "'," .
+			"'u','local'," .
+			"\"" . SQLite3::escapeString(trim($station['tags'] ?? '')) . "\"," .
+			"''," .
+			"'" . SQLite3::escapeString(trim($station['language'] ?? '')) . "'," .
+			"'" . SQLite3::escapeString(trim($station['country'] ?? '')) . "'," .
+			"'" . SQLite3::escapeString(trim($station['state'] ?? '')) . "'," .
+			"'" . SQLite3::escapeString($bitrate) . "'," .
+			"'" . SQLite3::escapeString($format) . "'," .
+			"'No'," .
+			"'" . SQLite3::escapeString($homepage) . "'," .
+			"'No'";
+		sqlQuery('INSERT INTO cfg_radio VALUES (' . $vals . ')', $dbh);
+	}
+
+	phpSession('open');
+	$_SESSION[$url] = array(
+		'name' => $name, 'type' => 'u', 'logo' => 'local',
+		'bitrate' => $bitrate, 'format' => $format,
+		'home_page' => $homepage, 'monitor' => 'No'
+	);
+	phpSession('close');
+
+	return array('name' => $name, 'format' => $format, 'bitrate' => $bitrate, 'homepage' => $homepage);
+}

--- a/www/js/radio-browser.js
+++ b/www/js/radio-browser.js
@@ -1,0 +1,343 @@
+/*!
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright 2014 The moOde audio player project / Tim Curtis
+ *
+ * Radio Browser view (radio-browser.info). Derived from RubaTron's Radio Browser
+ * extension for moOde (GPL-3.0-or-later), re-implemented in moOde's native style and
+ * reusing the Radio view tile markup/CSS.
+ */
+
+var RB = {
+    tab: 'search',      // search | recent
+    offset: 0,          // Search pagination offset
+    limit: 28,          // Page size (fixed)
+    listsLoaded: {recent: false},
+    countriesLoaded: false
+};
+
+var RB_API = 'command/radiobrowser.php';
+
+// Build a station object from a tile's data-* attributes
+function rbStationFromTile(li) {
+    var $li = $(li);
+    return {
+        name: $li.data('name') || '',
+        url: $li.data('url') || '',
+        favicon: $li.data('favicon') || '',
+        homepage: $li.data('homepage') || '',
+        country: $li.data('country') || '',
+        tags: $li.data('tags') || '',
+        bitrate: parseInt($li.data('bitrate')) || 0,
+        codec: $li.data('codec') || '',
+        stationuuid: $li.data('uuid') || ''
+    };
+}
+
+// Logo URL from the favicon (external ones proxied same-origin, cached on demand)
+function rbLogoUrl(s) {
+    if (s.favicon) {
+        if (/^https?:\/\//i.test(s.favicon)) {
+            return RB_API + '?cmd=logo&u=' + encodeURIComponent(s.favicon);
+        }
+        return s.favicon;
+    }
+    return DEFAULT_RADIO_COVER;
+}
+
+// Build a single station tile (mirrors renderRadioView() markup so Radio CSS applies)
+function rbBuildTile(s, i) {
+    var logo = rbLogoUrl(s);
+    var meta = [];
+    if (s.country) meta.push(rbEscapeHtml(s.country));
+    if (s.codec) meta.push(rbEscapeHtml(s.codec));
+    if (s.bitrate) meta.push(s.bitrate + ' kbps');
+    var favClass = s.added ? 'rb-fav-toggle added' : 'rb-fav-toggle';
+    var favIcon = s.added ? 'fa-solid' : 'fa-regular';
+    var hires = (s.bitrate && s.bitrate >= 320) ? '<div class="lib-encoded-at-hires-badge">' + RADIO_HIRES_BADGE_TEXT + '</div>' : '';
+    // HLS (.m3u8) hard-locks MPD's decoder — mark non-playable (badge, no play/fav/menu)
+    var hls = s.hls == 1;
+    var favToggle = hls ? '' :
+        '<div class="' + favClass + '"><i class="' + favIcon + ' fa-sharp fa-heart"></i></div>';
+    var coverMenu = hls ? '' :
+        '<div class="cover-menu" data-toggle="context" data-target="#context-menu-radio-browser-item"></div>';
+    var hlsBadge = hls ? '<div class="rb-hls-badge"><i class="fa-solid fa-sharp fa-triangle-exclamation"></i> HLS</div>' : '';
+
+    return '<li id="rb-' + i + '"' +
+            (hls ? ' class="rb-hls"' : '') +
+            ' data-hls="' + (hls ? 1 : 0) + '"' +
+            ' data-path="' + rbEscapeHtml(s.url) + '"' +
+            ' data-url="' + rbEscapeHtml(s.url) + '"' +
+            ' data-name="' + rbEscapeHtml(s.name) + '"' +
+            ' data-favicon="' + rbEscapeHtml(s.favicon || '') + '"' +
+            ' data-homepage="' + rbEscapeHtml(s.homepage || '') + '"' +
+            ' data-country="' + rbEscapeHtml(s.country || '') + '"' +
+            ' data-tags="' + rbEscapeHtml(s.tags || '') + '"' +
+            ' data-bitrate="' + (s.bitrate || 0) + '"' +
+            ' data-codec="' + rbEscapeHtml(s.codec || '') + '"' +
+            ' data-uuid="' + rbEscapeHtml(s.stationuuid || '') + '">' +
+        '<div class="db-icon db-song db-browse db-action">' +
+            '<div class="thumbHW">' +
+                '<img loading="lazy" src="' + logo.replace(/&/g, '&amp;') + '" onerror="this.src=\'' + DEFAULT_RADIO_COVER + '\'">' +
+                favToggle + hlsBadge +
+            '</div>' +
+        '</div>' +
+        coverMenu +
+        hires +
+        '<span class="station-name">' + rbEscapeHtml(s.name) + '</span>' +
+        (meta.length ? '<div class="radioview-metadata-text">' + meta.join(' &middot; ') + '</div>' : '') +
+    '</li>';
+}
+
+function rbRenderTiles(stations, ulId) {
+    RB.seen = {};          // normalized url set (dedup across appended pages)
+    RB.tileIndex = 0;      // running <li> id counter
+    if (!stations || stations.length === 0) {
+        $('#' + ulId).html('<li class="rb-empty">No stations</li>');
+        return;
+    }
+    document.getElementById(ulId).innerHTML = '';
+    rbAppendTiles(stations, ulId);
+}
+
+// Append a batch, skipping stations already shown (client-side cross-page dedup)
+function rbAppendTiles(stations, ulId) {
+    var sm = document.getElementById('rb-showmore');
+    if (sm) { sm.remove(); }           // keep "Show more" as the last <li>
+    var html = '';
+    for (var i = 0; i < stations.length; i++) {
+        var key = (stations[i].url || '').trim().toLowerCase();
+        if (key && RB.seen[key]) { continue; }
+        if (key) { RB.seen[key] = true; }
+        html += rbBuildTile(stations[i], RB.tileIndex++);
+    }
+    document.getElementById(ulId).insertAdjacentHTML('beforeend', html);
+}
+
+// Inject/remove the "Show more" button as the last <li> of the search grid
+function rbSetShowMore(show) {
+    var old = document.getElementById('rb-showmore');
+    if (old) { old.remove(); }
+    if (show) {
+        document.getElementById('rb-covers-search').insertAdjacentHTML('beforeend',
+            '<li id="rb-showmore"><button id="btn-rb-showmore" class="btn">Show more</button></li>');
+    }
+}
+
+function rbEscapeHtml(text) {
+    return $('<div>').text(text == null ? '' : text).html().replace(/"/g, '&quot;');
+}
+
+function rbLoading(ulId) {
+    $('#' + ulId).html('<li class="rb-empty"><i class="fa-solid fa-sharp fa-spinner fa-spin"></i> Loading&hellip;</li>');
+}
+
+// --- Search ---------------------------------------------------------------
+
+function rbSearch(offset, append) {
+    RB.offset = offset || 0;
+    var params = {
+        name: $('#rb-filter').val().trim(),
+        countrycode: $('#rb-country').val(),
+        tag: $('#rb-genre').val(),
+        offset: RB.offset,
+        limit: RB.limit
+    };
+    if (!append) { rbLoading('rb-covers-search'); }
+    // No filters = top stations by clickcount (search paginates via offset)
+    $.getJSON(RB_API + '?cmd=search', params, function(data) {
+        if (data && data.success) {
+            if (append) { rbAppendTiles(data.stations, 'rb-covers-search'); }
+            else { rbRenderTiles(data.stations, 'rb-covers-search'); }
+            // API returns no total: show "more" while the raw batch was full
+            var batch = (typeof data.batch === 'number') ? data.batch : data.stations.length;
+            rbSetShowMore(batch >= RB.limit);
+        } else {
+            if (!append) { $('#rb-covers-search').html('<li class="rb-empty">No results</li>'); }
+            rbSetShowMore(false);
+        }
+    }).fail(function() {
+        if (!append) { $('#rb-covers-search').html('<li class="rb-empty">radio-browser.info unavailable</li>'); }
+        rbSetShowMore(false);
+    });
+}
+
+// --- Recently played ------------------------------------------------------
+
+function rbLoadRecent() {
+    rbLoading('rb-covers-recent');
+    $.getJSON(RB_API + '?cmd=recently_played', function(data) {
+        rbRenderTiles(data.success ? data.stations : [], 'rb-covers-recent');
+        RB.listsLoaded.recent = true;
+    });
+}
+
+// --- Actions --------------------------------------------------------------
+
+// Pre-register the stream in RADIO.json so the native now-playing renderer resolves it
+function rbRegisterInRadioJson(station) {
+    if (typeof RADIO === 'object' && RADIO.json && station.url && !RADIO.json[station.url]) {
+        RADIO.json[station.url] = {
+            name: station.name, type: 'u', logo: 'local',
+            bitrate: String(station.bitrate || ''), format: station.codec || '',
+            home_page: station.homepage || '', monitor: 'No'
+        };
+    }
+}
+
+function rbPlay(li) {
+    var station = rbStationFromTile(li);
+    if (!station.url) return;
+    $('#container-radio-browser .database-radio li').removeClass('active');
+    $(li).addClass('active');
+    rbRegisterInRadioJson(station);
+
+    $.ajax({
+        url: RB_API + '?cmd=play',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify(station),
+        dataType: 'json',
+        success: function(data) {
+            notify(data && data.success ? NOTIFY_TITLE_INFO : NOTIFY_TITLE_ALERT,
+                'mpd_error', data ? data.message : 'Play failed', NOTIFY_DURATION_SHORT);
+        }
+    });
+}
+
+function rbToggleFavorite(li) {
+    var $li = $(li);
+    var station = rbStationFromTile(li);
+    if (!station.url) return;
+    var isAdded = $li.find('.rb-fav-toggle').hasClass('added');
+    var cmd = isAdded ? 'remove' : 'add';
+    $.ajax({
+        url: RB_API + '?cmd=' + cmd,
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify(station),
+        dataType: 'json',
+        success: function(data) {
+            if (data && data.success) {
+                rbSetFavoriteState(station.url, !isAdded);
+                RB.favoritesDirty = true; // refresh the native Radio grid when we return to it
+            }
+            notify(data && data.success ? NOTIFY_TITLE_INFO : NOTIFY_TITLE_ALERT,
+                'mpd_error', data ? data.message : 'Action failed', NOTIFY_DURATION_SHORT);
+            // 'update RADIO' lights the busy-spinner; clear it after it settles (native pattern)
+            setTimeout(function() { $('.busy-spinner').hide(); }, ONE_SEC_TIMEOUT);
+        }
+    });
+}
+
+// Sync the heart state of every tile that shares this stream URL
+function rbSetFavoriteState(url, added) {
+    $('#container-radio-browser .database-radio li').each(function() {
+        if ($(this).data('url') === url) {
+            var $t = $(this).find('.rb-fav-toggle');
+            $t.toggleClass('added', added);
+            $t.find('i').toggleClass('fa-solid', added).toggleClass('fa-regular', !added);
+        }
+    });
+}
+
+// --- Tabs / view activation ----------------------------------------------
+
+function rbShowTab(tab) {
+    RB.tab = tab;
+    $('.rb-tab').removeClass('active');
+    $('#btn-rb-tab-' + tab).addClass('active');
+    $('.rb-tab-pane').addClass('hide');
+    $('#rb-tab-' + tab).removeClass('hide');
+
+    if (tab === 'search' && $('#rb-covers-search li').length === 0) {
+        rbSearch(0);
+    } else if (tab === 'recent' && !RB.listsLoaded.recent) {
+        rbLoadRecent();
+    }
+}
+
+// Called from makeActive() when the Radio Browser view becomes active
+function rbOnViewActive() {
+    if (!RB.countriesLoaded) {
+        rbLoadCountriesAndGenres();
+    }
+    // Refresh the dropdowns now the panel is visible (selectpicker init'd while hidden)
+    $('#rb-country, #rb-genre').selectpicker('refresh');
+    rbShowTab(RB.tab);
+}
+
+function rbLoadCountriesAndGenres() {
+    RB.countriesLoaded = true;
+    $.getJSON(RB_API + '?cmd=countries', function(data) {
+        if (data && data.success) {
+            var opts = '<option value="">All countries</option>';
+            data.countries.forEach(function(c) {
+                if (c.iso_3166_1 && c.name) {
+                    opts += '<option value="' + rbEscapeHtml(c.iso_3166_1) + '">' + rbEscapeHtml(c.name) + '</option>';
+                }
+            });
+            $('#rb-country').html(opts).selectpicker('refresh');
+        }
+    });
+    $.getJSON(RB_API + '?cmd=genres', function(data) {
+        if (data && data.success) {
+            var opts = '<option value="">All genres</option>';
+            data.genres.forEach(function(g) {
+                if (g.name) {
+                    var label = g.name.charAt(0).toUpperCase() + g.name.slice(1);
+                    opts += '<option value="' + rbEscapeHtml(g.name) + '">' + rbEscapeHtml(label) + '</option>';
+                }
+            });
+            $('#rb-genre').html(opts).selectpicker('refresh');
+        }
+    });
+}
+
+// --- Event bindings -------------------------------------------------------
+
+$(document).ready(function() {
+    $('#btn-rb-tab-search').click(function() { rbShowTab('search'); });
+    $('#btn-rb-tab-recent').click(function() { rbShowTab('recent'); });
+
+    $('#btn-rb-refresh').click(function() {
+        if (RB.tab === 'search') { rbSearch(0); }
+        else { rbLoadRecent(); }
+    });
+
+    $('#rb-filter').on('keyup', function(e) {
+        $('#btn-rb-search-reset').toggleClass('hide', $(this).val() === '');
+        if (e.which === 13) { rbSearch(0); }
+    });
+    $('#btn-rb-search-reset').click(function() {
+        $('#rb-filter').val('');
+        $(this).addClass('hide');
+        rbSearch(0);
+    });
+    $('#rb-country, #rb-genre').change(function() { rbSearch(0); });
+    // Tag 'external' so the global links.js skips navigation but the dropdown still closes
+    $('#rb-filters').on('click', '.dropdown-menu li a', function() { $(this).addClass('external'); });
+
+    $('#rb-covers-search').on('click', '#btn-rb-showmore', function() { rbSearch(RB.offset + RB.limit, true); });
+
+    // Tile interactions (event delegation across the search/recent tabs)
+    $('#container-radio-browser').on('click', '.database-radio img', function() {
+        var $li = $(this).closest('li');
+        if ($li.data('hls') == 1) {
+            notify(NOTIFY_TITLE_ALERT, 'mpd_error', 'HLS stream (.m3u8) — not supported by MPD', NOTIFY_DURATION_SHORT);
+            return;
+        }
+        rbPlay($li);
+    });
+    $('#container-radio-browser').on('click', '.rb-fav-toggle', function(e) {
+        e.stopPropagation();
+        rbToggleFavorite($(this).closest('li'));
+    });
+    // Register the station for now-playing; the native .cover-menu handler queues data-path
+    $('#container-radio-browser').on('click', '.cover-menu', function() {
+        var station = rbStationFromTile($(this).closest('li'));
+        if (!station.url) return;
+        rbRegisterInRadioJson(station);
+        $.ajax({ url: RB_API + '?cmd=register', type: 'POST',
+                 contentType: 'application/json', data: JSON.stringify(station) });
+    });
+});

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -423,10 +423,32 @@ jQuery(document).ready(function($) { 'use strict';
 	// EVENT HANDLERS
 	//
 
+    // Swap the native Radio grid and the radio-browser explorer (each wrapper has its own bar)
+    function setRadioExplore(active) {
+        if (active) {
+            $('.container-radio-native').addClass('hide');
+            $('#container-radio-browser').removeClass('hide');
+            rbOnViewActive();
+        }
+        else {
+            $('#container-radio-browser').addClass('hide');
+            $('.container-radio-native').removeClass('hide');
+            // Refresh the now-visible native grid if a favorite changed while explore was on
+            if (typeof RB === 'object' && RB.favoritesDirty && typeof renderRadioView === 'function') {
+                RB.favoritesDirty = false;
+                renderRadioView();
+            }
+        }
+    }
+
     // Radio view
 	$('.radio-view-btn').click(function(e){
         makeActive('.radio-view-btn','#radio-panel','radio');
 	});
+    // Radio Browser explore toggle (inside Radio view) — one copy per wrapper
+    $('.ra-explore-btn').click(function(e){
+        setRadioExplore($('#container-radio-browser').hasClass('hide'));
+    });
     // Playlist view
 	$('.playlist-view-btn').click(function(e){
         makeActive('.playlist-view-btn','#playlist-panel','playlist');

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -254,23 +254,63 @@
 	<!-- RADIO VIEW -->
 	<div id="radio-panel" class="tab-pane">
 		<div id="container-radio">
-			<div class="btnlist btnlist-top btnlist-top-ra">
-				<button aria-label="Radio Manager" id="btn-ra-manager" class="btn"><i class="fa-solid fa-sharp fa-gear-complex"></i></button>
-				<button aria-label="Refresh" id="btn-ra-refresh" class="btn"><i class="fa-regular fa-sharp fa-redo"></i></button>
-				<button aria-label="New Station" id="btn-ra-new" class="btn"><i class="fa-regular fa-sharp fa-plus"></i></button>
-				<form id="ra-search" class="" method="post" onSubmit="return false;">
-					<div class="input-append">
-						<input id="ra-filter" type="text" value="" placeholder="search">
+			<!-- Radio native view (explore toggle off) -->
+			<div class="container-radio-native">
+					<div class="btnlist btnlist-top btnlist-top-ra">
+						<button aria-label="Radio Manager" id="btn-ra-manager" class="btn"><i class="fa-solid fa-sharp fa-gear-complex"></i></button>
+						<button aria-label="Refresh" id="btn-ra-refresh" class="btn"><i class="fa-regular fa-sharp fa-redo"></i></button>
+						<button aria-label="New Station" id="btn-ra-new" class="btn"><i class="fa-regular fa-sharp fa-plus"></i></button>
+					<form id="ra-search" class="" method="post" onSubmit="return false;">
+						<div class="input-append">
+							<input id="ra-filter" type="text" value="" placeholder="search">
+						</div>
+						<button aria-label="Reset" id="btn-ra-search-reset" class="btn hide" type="reset" value="reset"><i class="fa-regular fa-sharp fa-times-circle"></i></button>
+					</form>
+					<button aria-label="Explore radio-browser" class="btn btn-toggle ra-explore-btn"><i class="fa-solid fa-sharp fa-globe"></i></button>
+				</div>
+
+				<div id="database-radio">
+					<ul id="radio-covers" class="database-radio"></ul>
+				</div>
+				<div id ="index-radio" class="alphabits">
+					<ul><li>#</li><li>a</li><li>b</li><li>c</li><li>d</li><li>e</li><li>f</li><li>g</li><li>h</li><li>i</li><li>j</li><li>k</li><li>l</li><li>m</li><li>n</li><li>o</li><li>p</li><li>q</li><li>r</li><li>s</li><li>t</li><li>u</li><li>v</li><li>w</li><li>x</li><li>y</li><li>z</li></ul>
+				</div>
+			</div>
+			<!-- end Radio native view -->
+
+			<!-- Radio Browser explorer (explore toggle on) -->
+			<div id="container-radio-browser" class="hide">
+				<div class="btnlist btnlist-top btnlist-top-rb">
+					<button aria-label="Search" id="btn-rb-tab-search" class="btn rb-tab active">Search</button>
+					<button aria-label="Recently played" id="btn-rb-tab-recent" class="btn rb-tab">Recent</button>
+					<button aria-label="Refresh" id="btn-rb-refresh" class="btn"><i class="fa-regular fa-sharp fa-redo"></i></button>
+					<form id="rb-search" class="" method="post" onSubmit="return false;">
+						<div class="input-append">
+							<input id="rb-filter" type="text" value="" placeholder="search radio-browser.info">
+						</div>
+						<button aria-label="Reset" id="btn-rb-search-reset" class="btn hide" type="reset" value="reset"><i class="fa-regular fa-sharp fa-times-circle"></i></button>
+					</form>
+					<div class="controls" id="rb-filters">
+						<select id="rb-country" class="config-select-large" data-size="10"><option value="">All countries</option></select>
+						<select id="rb-genre" class="config-select-large" data-size="10"><option value="">All genres</option></select>
 					</div>
-					<button aria-label="Reset" id="btn-ra-search-reset" class="btn hide" type="reset" value="reset"><i class="fa-regular fa-sharp fa-times-circle"></i></button>
-				</form>
+					<button aria-label="Explore radio-browser" class="btn btn-toggle ra-explore-btn active"><i class="fa-solid fa-sharp fa-globe"></i></button>
+				</div>
+				<!-- Search tab -->
+				<div id="rb-tab-search" class="rb-tab-pane">
+					<div id="rb-covers-search-container" class="rb-covers-container">
+						<ul id="rb-covers-search" class="database-radio"></ul>
+					</div>
+				</div>
+				<!-- Recently played tab -->
+				<div id="rb-tab-recent" class="rb-tab-pane hide">
+					<div id="rb-covers-recent-container" class="rb-covers-container">
+						<ul id="rb-covers-recent" class="database-radio"></ul>
+					</div>
+				</div>
+				<div class="rb-attribution">Powered by <a class="target-blank-link" href="https://www.radio-browser.info" target="_blank">radio-browser.info</a> &middot; integration derived from RubaTron's Radio Browser extension</div>
 			</div>
-			<div id="database-radio">
-				<ul id="radio-covers" class="database-radio"></ul>
-			</div>
-			<div id ="index-radio" class="alphabits">
-				<ul><li>#</li><li>a</li><li>b</li><li>c</li><li>d</li><li>e</li><li>f</li><li>g</li><li>h</li><li>i</li><li>j</li><li>k</li><li>l</li><li>m</li><li>n</li><li>o</li><li>p</li><li>q</li><li>r</li><li>s</li><li>t</li><li>u</li><li>v</li><li>w</li><li>x</li><li>y</li><li>z</li></ul>
-			</div>
+			<!-- end Radio Browser explorer -->
 		</div>
 	</div>
 
@@ -297,7 +337,9 @@
 			</div>
 		</div>
 	</div>
+
 </div>
+
 
 <!-- ADVANCED SEARCH -->
 <div id="dbsearch-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="dbsearch-modal-label" aria-hidden="true">
@@ -2958,6 +3000,17 @@
 			<li class="menu-separator"><a href="#notarget" data-cmd="get_playlist_names"><i class="fa-regular fa-sharp fa-list-music sx"></i> Add to playlist</a></li>
 			<li><a href="#notarget" data-cmd="edit_station"><i class="fa-regular fa-sharp fa-edit sx"></i> Edit station</a></li>
 			<li><a href="#notarget" data-cmd="delete_station"><i class="fa-regular fa-sharp fa-trash sx"></i> Delete station</a></li>
+		</ul>
+	</div>
+
+	<div id="context-menu-radio-browser-item" class="context-menu">
+		<ul class="dropdown-menu" role="menu">
+			<li><a href="#notarget" data-cmd="add_item"><i class="fa-regular fa-sharp fa-plus sx"></i> Add</a></li>
+			<li><a href="#notarget" data-cmd="play_item"><i class="fa-regular fa-sharp fa-play sx"></i> Play</a></li>
+			<li><a href="#notarget" data-cmd="clear_play_item"><i class="fa-regular fa-sharp fa-chevron-square-right sx"></i> Clear/Play</a></li>
+			<li><a href="#notarget" data-cmd="add_item_next"><i class="fa-regular fa-sharp fa-plus-circle sx"></i> Add next</a></li>
+			<li><a href="#notarget" data-cmd="play_item_next"><i class="fa-regular fa-sharp fa-play-circle sx"></i> Play next</a></li>
+			<li class="menu-separator"><a href="#notarget" data-cmd="get_playlist_names"><i class="fa-regular fa-sharp fa-list-music sx"></i> Add to playlist</a></li>
 		</ul>
 	</div>
 

--- a/www/util/radio-browser.sh
+++ b/www/util/radio-browser.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright 2014 The moOde audio player project / Tim Curtis
+#
+# Radio Browser maintenance helper.
+# Usage: radio-browser.sh [--clear-recents|--fix-permissions|--flush-cache|--test-api]
+
+RBCACHE="/var/local/www/rbcache"
+RECENT="$RBCACHE/recently_played.json"
+IMGCACHE="/var/local/www/imagesw/radio-logos/cache"
+API="all.api.radio-browser.info"
+UA="moode-radio-browser/1.0"
+
+usage() {
+	echo "Usage: $(basename "$0") [--clear-recents|--fix-permissions|--flush-cache|--test-api]"
+	exit 1
+}
+
+need_root() {
+	[[ $EUID -ne 0 ]] && { echo "Use sudo to run $1" ; exit 1 ; }
+}
+
+case "$1" in
+	--clear-recents)
+		need_root "$1"
+		rm -f "$RECENT" && echo "Recently played cleared."
+		;;
+	--fix-permissions)
+		need_root "$1"
+		mkdir -p "$RBCACHE" "$IMGCACHE"
+		chown -R www-data:www-data "$RBCACHE" "$IMGCACHE"
+		chmod -R 0775 "$RBCACHE" "$IMGCACHE"
+		echo "Permissions fixed on $RBCACHE and $IMGCACHE."
+		;;
+	--flush-cache)
+		need_root "$1"
+		# API/response + logo caches (keeps recently_played.json; use --clear-recents for that)
+		find "$RBCACHE" -maxdepth 1 -type f -name '*.json' ! -name 'recently_played.json' -delete 2>/dev/null
+		rm -f "$IMGCACHE"/* 2>/dev/null
+		echo "Cache flushed (API responses + logos)."
+		;;
+	--test-api)
+		start=$(date +%s%3N)
+		count=$(curl -fsS --max-time 10 -A "$UA" "https://$API/json/servers" | grep -o '"name"' | wc -l)
+		rc=$?
+		end=$(date +%s%3N)
+		if [[ $rc -eq 0 && $count -gt 0 ]]; then
+			echo "API OK: $count servers via $API ($((end - start)) ms)."
+		else
+			echo "API FAILED via $API."
+			exit 1
+		fi
+		;;
+	*)
+		usage
+		;;
+esac


### PR DESCRIPTION
Search / browse / add / remove / play radio-browser.info stations, folded into the Radio tab behind an "Explore radio-browser" toggle (no separate view).

- inc/radio-browser.php: function library holding all radio-browser.info logic — file_get_contents + stream-context client with dynamic server discovery (DNS SRV -> /json/servers -> all.api alias) and mirror failover, response/logo caching, station add/remove (cfg_radio type='f'), recently played, logo proxy. Runtime cache dirs (rbcache, radio-logos/cache) are created on demand.
- command/radiobrowser.php: thin AJAX dispatcher (require inc/radio-browser.php + chkVariables + switch) exposing search, countries, genres, add/remove favorite, play, recently played, logo proxy, register.
- js/radio-browser.js: jQuery view reusing the native radio tile markup/CSS; "Show more" incremental loading (API returns no total), client-side URL dedup, country/genre filters (bootstrap-select), HLS (.m3u8) stations flagged non-playable.
- indextpl.html/scripts-panels.js/panels.css: the toggle swaps the native grid and the radio-browser explorer inside #container-radio; state kept per session; add/remove favorites reflect into the native grid.
- util/radio-browser.sh: maintenance helper (--clear-recents / --fix-permissions / --flush-cache / --test-api) operating on the cache dirs.
- constants.php/header.php: RADIOBROWSER_* constants, script bundle.

HLS (.m3u8) stations are flagged non-playable for now: session-tokenised live HLS hard-locks MPD's ffmpeg integration (upstream limitation, reproduces on stock moOde/Pi). Root cause still to elucidate; an ffmpeg input relay is the planned fix.

Derived from rubatron's Radio Browser extension (GPL-3.0), re-implemented in moOde's native conventions. The command/inc split and util/ helper follow the maintainer's review (function library + thin dispatcher, plus a util maintenance script). WIP branch for testing/reference, not final.
