### PR TITLE
radiobrowser: garbage-collect transient 'u' stations + fix favorite add/remove lifecycle

### DIFF
--- a/www/command/queue.php
+++ b/www/command/queue.php
@@ -46,6 +46,11 @@ switch ($_GET['cmd']) {
 	case 'delete_playqueue_item':
 		sendMpdCmd($sock, 'delete ' . $_GET['range']);
 		$resp = readMpdResp($sock);
+		// A transient radio-browser station (cfg_radio type='u') exists only while its
+		// stream is queued; once removed from the queue, prune its row from the DB.
+		// Favorites (type='f') and native stations (type='r') are kept untouched.
+		require_once __DIR__ . '/../inc/radio-browser.php';
+		rbPruneOrphanStations();
 		break;
 	case 'move_playqueue_item':
 		sendMpdCmd($sock, 'move ' . $_GET['range'] . ' ' . $_GET['newpos']);

--- a/www/command/radiobrowser.php
+++ b/www/command/radiobrowser.php
@@ -107,6 +107,13 @@ switch ($cmd) {
 				$response = array('success' => true, 'message' => 'Station already in favorites');
 			} else {
 				sqlQuery("UPDATE cfg_radio SET type='f' WHERE id='" . $existing[0]['id'] . "'", $dbh);
+				// The native Radio grid plays RADIO/<name>.pls; a promoted 'u' has none, so
+				// create it (+ ensure the logo). Stock 'r' stations already ship theirs — don't overwrite.
+				$exName = $existing[0]['name'];
+				if (!file_exists(MPD_MUSICROOT . 'RADIO/' . $exName . '.pls')) {
+					rbEnsureLogo($exName, trim($station['favicon'] ?? ''));
+					rbWritePls($exName, $url);
+				}
 				$response = array('success' => true, 'message' => 'Station added to favorites');
 			}
 			break;
@@ -142,11 +149,19 @@ switch ($cmd) {
 			$response = array('success' => false, 'message' => 'Station is not in favorites');
 			break;
 		}
-		// Core moOde stations (id < 499) are only un-favorited; user/imported stations are deleted
+		// Core moOde stations (id < 499): just un-favorite (f -> r), keep them in the list.
+		// User/imported RB stations (id >= 499): if the stream is STILL in the play queue,
+		// demote to transient 'u' so now-playing/thumb keep resolving (the queue-prune deletes
+		// it once it leaves the queue); only fully delete it when it's not queued anymore.
 		if ((int)$row[0]['id'] < 499) {
 			sqlQuery("UPDATE cfg_radio SET type='r' WHERE id='" . $row[0]['id'] . "'", $dbh);
 		} else {
-			rbDeleteStation($row[0]['name']);
+			$queued = rbQueuedUrls();
+			if (isset($queued[rbNormalizeUrl($url)])) {
+				sqlQuery("UPDATE cfg_radio SET type='u' WHERE id='" . $row[0]['id'] . "'", $dbh);
+			} else {
+				rbDeleteStation($row[0]['name']);
+			}
 		}
 		$response = array('success' => true, 'message' => 'Station removed from favorites');
 		break;
@@ -161,6 +176,7 @@ switch ($cmd) {
 			break;
 		}
 		rbRegisterStation($station);
+		rbPruneOrphanStations($url); // drop transient 'u' rows that have left the queue
 		$response = array('success' => true, 'message' => 'Registered');
 		break;
 
@@ -202,6 +218,8 @@ switch ($cmd) {
 			'stationuuid' => trim($station['stationuuid'] ?? ''),
 			'played_at' => time()
 		));
+
+		rbPruneOrphanStations($url); // drop transient 'u' rows that have left the queue
 
 		// Click tracking (fire-and-forget) — radio-browser.info best practice
 		$uuid = trim($station['stationuuid'] ?? '');

--- a/www/daemon/worker.php
+++ b/www/daemon/worker.php
@@ -191,6 +191,8 @@ sysCmd('touch ' . SPSEVENT_LOG);
 sysCmd('touch ' . SLPOWER_LOG);
 sysCmd('truncate ' . MOUNTMON_LOG . ' --size 0');
 sysCmd('mkdir ' . THMCACHE_DIR . ' > /dev/null 2>&1');
+// Radio Browser caches are written synchronously by www-data (php-fpm), so unlike moOde's
+sysCmd('/var/www/util/radio-browser.sh --fix-permissions > /dev/null 2>&1');
 // Delete any tmp files left over from New/Edit station or playlist
 sysCmd('rm /var/local/www/imagesw/radio-logos/' . TMP_IMAGE_PREFIX . '* > /dev/null 2>&1');
 sysCmd('rm /var/local/www/imagesw/radio-logos/thumbs/' . TMP_IMAGE_PREFIX . '* > /dev/null 2>&1');

--- a/www/inc/radio-browser.php
+++ b/www/inc/radio-browser.php
@@ -370,8 +370,15 @@ function rbWriteStation($s) {
 	);
 	phpSession('close');
 
-	$plsFile = MPD_MUSICROOT . 'RADIO/' . $s['name'] . '.pls';
-	$contents = "[playlist]\nFile1=" . $s['url'] . "\nTitle1=" . $s['name'] . "\nLength1=-1\nNumberOfEntries=1\nVersion=2\n";
+	rbWritePls($s['name'], $s['url']);
+}
+
+// Create the RADIO/<name>.pls that the native Radio grid plays (data-path="RADIO/<name>.pls").
+// Factored out of rbWriteStation so promoting a played 'u' station to favorite can also
+// create it (a 'u' has a logo but no .pls, so without this the promoted favorite won't play).
+function rbWritePls($name, $url) {
+	$plsFile = MPD_MUSICROOT . 'RADIO/' . $name . '.pls';
+	$contents = "[playlist]\nFile1=" . $url . "\nTitle1=" . $name . "\nLength1=-1\nNumberOfEntries=1\nVersion=2\n";
 	file_put_contents($plsFile, $contents);
 	sysCmd('chmod 0777 "' . $plsFile . '"');
 	sysCmd('chown root:root "' . $plsFile . '"');
@@ -402,6 +409,60 @@ function rbMpdUpdateRadio() {
 	sendMpdCmd($sock, 'update RADIO');
 	readMpdResp($sock);
 	closeMpdSock($sock);
+}
+
+// Normalised set of the stream URLs currently in the MPD play queue (for orphan pruning).
+// Uses playlistinfo and reads the canonical `file: <uri>` lines (moOde's own convention,
+// cf. getPlayqueue()/findInQueue) — the legacy `playlist` command's `pos:uri` format did
+// NOT match cfg_radio.station here, so prune wrongly deleted still-queued 'u' rows.
+function rbQueuedUrls() {
+	$urls = array();
+	$sock = getMpdSock('command/radiobrowser.php');
+	sendMpdCmd($sock, 'playlistinfo');
+	$resp = readMpdResp($sock);
+	closeMpdSock($sock);
+	if (is_string($resp)) {
+		foreach (explode("\n", $resp) as $line) {
+			if (strncmp($line, 'file: ', 6) === 0) {
+				$urls[rbNormalizeUrl(trim(substr($line, 6)))] = true;
+			}
+		}
+	}
+	return $urls;
+}
+
+// Prune transient (type='u') radio-browser stations that are no longer in the play queue.
+// A 'u' row exists ONLY so moOde's native now-playing/playqueue renderer can resolve a
+// played-but-unsaved stream's name/logo (via cfg_radio → session/RADIO.json); once the
+// stream leaves the queue the row is dead weight, so we delete it (row + local logo files
+// + session var). Keeps cfg_radio authoritative and self-cleaning without any temporary
+// JSON. $keepUrl protects the station currently being registered/played (it may not be in
+// the queue yet). Favorites (type='f') and core/native stations are never touched.
+function rbPruneOrphanStations($keepUrl = '') {
+	$dbh = sqlConnect();
+	$rows = sqlQuery("SELECT station, name FROM cfg_radio WHERE type='u'", $dbh);
+	if (!is_array($rows)) {
+		return;
+	}
+	$queued = rbQueuedUrls();
+	$keep = rbNormalizeUrl($keepUrl);
+	phpSession('open');
+	foreach ($rows as $r) {
+		$norm = rbNormalizeUrl($r['station']);
+		if ($norm === $keep || isset($queued[$norm])) {
+			continue;
+		}
+		unset($_SESSION[$r['station']]);
+		sqlQuery("DELETE FROM cfg_radio WHERE station='" . SQLite3::escapeString($r['station']) . "' AND type='u'", $dbh);
+		$name = $r['name'];
+		sysCmd('rm -f "' . RADIO_LOGOS_ROOT . $name . '.jpg"');
+		sysCmd('rm -f "' . RADIO_LOGOS_ROOT . 'thumbs/' . $name . '.jpg"');
+		sysCmd('rm -f "' . RADIO_LOGOS_ROOT . 'thumbs/' . $name . '_sm.jpg"');
+		// A demoted favorite (f -> u) keeps its RADIO/<name>.pls; remove it too so it doesn't
+		// orphan in the RADIO folder. A play-only 'u' has none (rm -f is then a harmless no-op).
+		sysCmd('rm -f "' . MPD_MUSICROOT . 'RADIO/' . $name . '.pls"');
+	}
+	phpSession('close');
 }
 
 // Same-origin logo proxy: fetch+cache ONE favicon on demand (rbCacheImage mechanism)

--- a/www/inc/radio-browser.php
+++ b/www/inc/radio-browser.php
@@ -131,9 +131,6 @@ function rbCacheGet($key, $ttl) {
 	return false;
 }
 function rbCacheSet($key, $data) {
-	if (!is_dir(RADIOBROWSER_CACHE)) {
-		@mkdir(RADIOBROWSER_CACHE, 0775, true);
-	}
 	@file_put_contents(RADIOBROWSER_CACHE . '/' . $key . '.json', json_encode($data));
 }
 
@@ -150,9 +147,6 @@ function rbCacheImage($url) {
 	}
 	$data = rbHttpGet($url, 3);
 	if ($data !== false && strlen($data) > 100 && strlen($data) < 51200) {
-		if (!is_dir(RADIOBROWSER_IMAGE_CACHE)) {
-			@mkdir(RADIOBROWSER_IMAGE_CACHE, 0775, true);
-		}
 		if (@file_put_contents($file, $data)) {
 			return $webPath;
 		}
@@ -251,9 +245,6 @@ function rbGetRecent() {
 	return is_array($data) ? $data : array();
 }
 function rbAddRecent($station) {
-	if (!is_dir(RADIOBROWSER_CACHE)) {
-		@mkdir(RADIOBROWSER_CACHE, 0775, true);
-	}
 	$fp = @fopen(RADIOBROWSER_RECENT_FILE, 'c+');
 	if (!$fp) {
 		return;
@@ -483,9 +474,6 @@ function rbServeLogo($url) {
 		} else {
 			$data = rbHttpGet($url, 4);
 			if ($data !== false && strlen($data) > 100 && strlen($data) < 51200) {
-				if (!is_dir(RADIOBROWSER_IMAGE_CACHE)) {
-					@mkdir(RADIOBROWSER_IMAGE_CACHE, 0775, true);
-				}
 				if (@file_put_contents($path, $data)) {
 					$file = $path;
 				}


### PR DESCRIPTION
Follow-up to #760.

## Problem

`radiobrowser.php` writes a `cfg_radio` row with `type='u'` whenever a station is **played** or **registered** (a tile's context menu opening) via `rbRegisterStation()`. Its only purpose is to let moOde's native now-playing / playqueue renderer resolve a played-but-unsaved stream's name & logo (`cfg_radio → $_SESSION[url] → RADIO.json`). Nothing ever removed these rows, so they **accumulate** in `cfg_radio`.

Two related lifecycle bugs surfaced while testing:

- Un-favoriting a station that is **still in the play queue** deleted it outright, so now-playing / the queue tile lost its name & logo.
- Favoriting an already-played (`u`) station did **not** create its `RADIO/<name>.pls`, so the favorite appeared in the Radio grid but would not play (tiles are `data-path="RADIO/<name>.pls"`).

## Changes

**`inc/radio-browser.php`**
- `rbPruneOrphanStations($keepUrl='')` — deletes a `type='u'` row (row + logo + `.pls`) once its stream is no longer in the MPD queue. Matches on the normalized stream URL as a set-difference, so multi-item removes and duplicate queue entries are handled correctly. Cheap when there are no `u` rows (the empty `SELECT` returns before touching MPD). Never touches `r`/`f`/`h`.
- `rbQueuedUrls()` — the queue's URL set, read from `playlistinfo`'s `file:` lines (moOde's canonical queue format).
- `rbWritePls()` — factored out of `rbWriteStation()` so a promotion can reuse it.

**`command/radiobrowser.php`**
- Run the prune on `play` / `register` (bounds growth to what's actually queued).
- `remove`: if the un-favorited user/imported station (id ≥ 499) is **still queued, demote it to `u`** (keeps it resolvable; the prune removes it once it leaves the queue) instead of deleting it. Stock stations (id < 499) still go `f → r`.
- `add`: when promoting an existing `u`/`r` to favorite, create the missing `RADIO/<name>.pls` (+ ensure the logo) so it plays from the native grid. Stock `r` stations already ship theirs (guarded by `file_exists`).

**`command/queue.php`**
- Prune on `delete_playqueue_item` so removing an item from the queue cleans its `u` row immediately.

## Design

`cfg_radio.type` stays the single source of truth (no new column, no side-car JSON). `u` remains a transient marker but now has a defined lifecycle: created on play/register, promoted to `f` on favorite, and **garbage-collected when its stream leaves the queue** — so `cfg_radio` stays self-cleaning.

## Known limitation (pre-existing, unchanged)

moOde names a station's logo and `.pls` by **station name**, so two different streams sharing a name (e.g. a "France Info" MP3 and AAC variant from radio-browser) share `RADIO/France Info.pls` and the same logo and can't be told apart at the file level. The stock station list avoids this with unique names.

Tested end-to-end (play → favorite → un-favorite → remove-from-queue).
