### PR TITLE
Fix blank Folder view when refreshing on a saved-playlist listing

### DIFF
--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -951,9 +951,15 @@ jQuery(document).ready(function($) { 'use strict';
 	});
 	$('#db-refresh').click(function(e) {
         UI.dbPos[UI.dbPos[10]] = 0;
-		$.getJSON('command/music-library.php?cmd=lsinfo', {'path': UI.path}, function(data) {
-			renderFolderView(data, UI.path);
-        });
+        if (UI.dbCmd == 'get_pl_items_fv') {
+            $.getJSON('command/playlist.php?cmd=get_pl_items_fv', {'path': UI.path}, function(data) {
+                renderFolderView(data, UI.path);
+            });
+        } else {
+            $.getJSON('command/music-library.php?cmd=lsinfo', {'path': UI.path}, function(data) {
+                renderFolderView(data, UI.path);
+            });
+        }
 	});
 	$('#btn-db-import, #btn-pl-import').click(function(e) {
 		$('#db-import-file').val('');


### PR DESCRIPTION
### Problem

In Folder view, opening a saved playlist shows its tracks (fetched via
`get_pl_items_fv`). If you then switch to Radio or Playlist and come back to
Folder, the pane goes **blank** — the current listing disappears and you have
to navigate back up the tree and re-enter the playlist to see it again.

### Cause

Returning to Folder view calls `makeActive('folder', …)`, which fires
`$('#db-refresh').click()`. The `db-refresh` handler unconditionally re-issues
`lsinfo` on `UI.path`. When the current listing is a saved playlist, `UI.path`
holds the playlist path, and `lsinfo` on it returns nothing → empty pane.

`UI.dbCmd` already tracks whether the current listing came from `lsinfo` or
`get_pl_items_fv`, but `db-refresh` ignored it.

### Fix

Make `db-refresh` honor `UI.dbCmd`: re-fetch via `get_pl_items_fv` when the
current listing is a saved playlist, otherwise `lsinfo` as before. Mirrors the
endpoint choice already made in the `.db-browse` click handler.

### Testing

Folder view → open a saved playlist → switch to Radio (or Playlist) → back to
Folder: the playlist tracks now stay displayed. Plain folder listings are
unchanged.

Single-file change (`www/js/scripts-panels.js`).

<img width="691" height="451" alt="1" src="https://github.com/user-attachments/assets/e4e556de-bc2b-4ba4-867c-bda5ab5ca0cf" />
<img width="928" height="354" alt="2" src="https://github.com/user-attachments/assets/6747074b-9f1d-492d-abcd-3dd11f1db1c1" />
<img width="939" height="375" alt="3" src="https://github.com/user-attachments/assets/b5ec95d3-3ed4-4d26-bbb7-d8a9c38853a8" />
