### PR TITLE
Radio Browser: unify station-logo rendering through the on-demand logo proxy

### DIFF
--- a/www/command/radiobrowser.php
+++ b/www/command/radiobrowser.php
@@ -221,7 +221,7 @@ switch ($cmd) {
 		rbAddRecent(array(
 			'name' => $name,
 			'url' => $url,
-			'favicon' => rbCacheImage($favicon),
+			'favicon' => $favicon,
 			'country' => trim($station['country'] ?? ''),
 			'tags' => trim($station['tags'] ?? ''),
 			'bitrate' => (int)$bitrate,

--- a/www/inc/radio-browser.php
+++ b/www/inc/radio-browser.php
@@ -134,26 +134,6 @@ function rbCacheSet($key, $data) {
 	@file_put_contents(RADIOBROWSER_CACHE . '/' . $key . '.json', json_encode($data));
 }
 
-// Download a station favicon into the local image cache; return a same-origin web path
-function rbCacheImage($url) {
-	if (empty($url) || str_contains($url, 'encrypted-tbn0.gstatic.com')) {
-		return '';
-	}
-	$hash = md5($url);
-	$file = RADIOBROWSER_IMAGE_CACHE . '/' . $hash . '.png';
-	$webPath = 'imagesw/radio-logos/cache/' . $hash . '.png';
-	if (file_exists($file) && (time() - filemtime($file) < RADIOBROWSER_CACHE_TTL_STATIC)) {
-		return $webPath;
-	}
-	$data = rbHttpGet($url, 3);
-	if ($data !== false && strlen($data) > 100 && strlen($data) < 51200) {
-		if (@file_put_contents($file, $data)) {
-			return $webPath;
-		}
-	}
-	return '';
-}
-
 // --- Station logo handling (ported from RubaTron's Radio Browser api.php) --------------
 // Creates the three JPGs moOde expects for a radio station logo, synchronously (so they
 // exist before the stream plays / the tile renders): <name>.jpg (400), thumbs/<name>.jpg
@@ -317,8 +297,8 @@ function rbShapeResults($data, $dbh) {
 		// Return the raw favicon URL — do NOT cache inline here. Caching 30 external
 		// images synchronously in one request stalls search for tens of seconds (a
 		// slow/dead host blocks the whole loop). The tile <img> instead points at the
-		// same-origin 'logo' proxy below, so images are fetched+cached per-image and in
-		// parallel by the browser (rbCacheImage mechanism preserved, just on demand).
+		// same-origin 'logo' proxy below (rbServeLogo), so images are fetched+cached
+		// per-image and in parallel by the browser, on demand.
 		$favicon = trim($s['favicon'] ?? '');
 		$station = array(
 			'name' => trim($s['name'] ?? ''),
@@ -478,10 +458,11 @@ function rbPruneOrphanStations($keepUrl = '') {
 	phpSession('close');
 }
 
-// Same-origin logo proxy: fetch+cache ONE favicon on demand (rbCacheImage mechanism)
-// and stream it. Search returns raw favicon URLs; each tile's <img> points here, so
-// the browser loads logos in parallel and a slow/dead host only delays its own tile,
-// never the search response. Streams the cached PNG; 302s to the default cover on miss.
+// Same-origin logo proxy: fetch+cache ONE favicon on demand and stream it. Search AND
+// Recent both return raw favicon URLs, so every tile's <img> points here — a single
+// render path. The browser loads logos in parallel and a slow/dead host only delays its
+// own tile. Content-Type is set from the bytes (getimagesize), not the cache filename,
+// so JPG/PNG are served correctly; 302s to the default cover on miss.
 function rbServeLogo($url) {
 	if (session_status() === PHP_SESSION_ACTIVE) {
 		session_write_close(); // release the session lock so parallel image requests don't serialise


### PR DESCRIPTION
### Problem

The Radio Browser rendered station logos through two different paths depending
on the tab:

- **Search** returns the raw favicon URL; each tile's `<img>` points at the
  same-origin `?cmd=logo` proxy (`rbServeLogo`), which fetches + caches the
  image on demand and streams it with a Content-Type derived from the actual
  bytes (`getimagesize`).
- **Recently played** stored a *pre-cached* same-origin path
  (`imagesw/radio-logos/cache/<hash>.png`) produced by `rbCacheImage`, served
  statically by nginx.

Two consequences:

1. **Inconsistent MIME.** The cache file is always named `.png` regardless of
   the real image format, so a JPEG favicon shown in *Recently played* is served
   with `Content-Type: image/png` (a mislabel — it renders only because browsers
   sniff `<img>` bytes). The Search path never had this issue because the proxy
   sets the Content-Type from the bytes.
2. **A synchronous fetch in the play handler.** `rbCacheImage($favicon)` did a
   blocking `rbHttpGet($url, 3)` while handling `?cmd=play`, delaying the play
   response by up to 3 s on a slow favicon host — for an image that isn't even
   needed to start playback.

### Fix

Store the **raw favicon URL** in the recently-played history (like Search
already does), so both tabs resolve logos through the single `rbServeLogo`
proxy:

- One render path for Search and Recently played.
- Content-Type comes from the bytes, not the `.png` cache filename → JPEG/PNG
  are served correctly.
- The play handler no longer performs a synchronous favicon fetch.
- `rbCacheImage()` becomes dead code and is removed.

Both tabs share the same on-disk cache file (same `md5(url)`), so there is no
extra network cost — a logo already fetched by Search is served straight from
cache when the station later appears in Recently played.

### Scope

- No schema change, no new endpoint, no frontend change (the JS `rbLogoUrl`
  helper already proxies any `http(s)` favicon and passes same-origin paths
  through — feeding it the raw URL is enough).
- Does **not** touch the permanent per-station logos (`thumbs/<name>.jpg` via
  `rbEnsureLogo`) used by the native Radio view; that mechanism is unchanged.

### Testing

Validated on moOde (x86 build): Search and Recently played both render logos via
the proxy with correct Content-Type; play response is no longer stalled by a
slow favicon host.
