### PR TITLE
Reset the input-source scrim so static-message renderers render consistently

### DIFF
--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -803,6 +803,7 @@ function inpSrcIndicator(cmd, msgText) {
     $('#inpsrc-msg').css({width:'100%', top:'50%', bottom:'unset'});
     $('#inpsrc-metadata').hide();
 	$('#inpsrc-cover').html('');
+    $('#inpsrc-style').css('display', 'none');
 
     // Set the button and preamp volume
     // NOTE: Preamp volume #id will only exist if audioin != Local


### PR DESCRIPTION
Scope: this fixes an inconsistent-rendering bug, not the legibility of the
overlay text. See the note at the end.

The dark scrim (#inpsrc-style) is designed for the metadata screen: its
gradient is bottom-heavy (alpha 0.9 at 100%) and #inpsrc-metadata sits at
bottom:0. updateInpsrcMeta shows it, but nothing ever hides it again.

After a metadata renderer has been shown (AirPlay/Spotify/Deezer), the scrim
stays on and bleeds into the static-message screens drawn by inpSrcIndicator
(Bluetooth, Squeezelite, Plexamp, RoonBridge, Multiroom receiver), where the
message is centered and no scrim was ever intended. Two consequences:

- the same screen renders differently depending on which renderer ran before,
- the dark gradient ignores the Prefs > Theme setting on light themes.

inpSrcIndicator now hides the scrim, mirroring the updateInpsrcMeta call that
shows it. One line, symmetric with the existing show.

Test procedure
1. Set Prefs > Theme to a light theme, for example Whiteshade.
2. Reload the UI and connect Bluetooth first, without opening AirPlay/Spotify
   beforehand: the "Bluetooth Active" message shows with no dark scrim.
3. Start AirPlay or Spotify: the metadata screen shows the scrim behind the
   bottom text, as intended.
4. Return to Bluetooth: still no scrim; the screen is identical to step 2 and
   independent of navigation history. Before this change it kept the dark
   scrim left over from step 3.

Note on legibility
This PR does not make the overlay text legible when a cover backdrop is drawn
behind it (renderer_backdrop = Yes). That is a separate problem, and removing
the Cover Backdrop option is the right cure for it.