### PR TITLE
Radio Browser: unblock HLS streams

### DIFF
--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -1160,8 +1160,6 @@ body.cv .timeline-thm input[type='range']::-webkit-slider-thumb {
 .rb-fav-toggle {position:absolute;top:.4rem;right:0;width:2rem;height:2rem;display:flex;align-items:center;justify-content:center;border-radius:50%;background-color:var(--btnshade2);font-size:1.2rem;z-index:2;cursor:pointer;}
 .rb-fav-toggle.added {color: var(--accentxts);}
 .rb-fav-toggle .fa-heart {margin-top:4px;}
-.rb-hls-badge {position:absolute;top:.4rem;left:1.25rem;padding:.1rem .4rem;border-radius:.6rem;background-color:rgba(192,57,43,.9);color:#fff;font-size:.7rem;font-weight:bold;letter-spacing:.5px;z-index:2;}
-.rb-hls .thumbHW img {opacity:.5;cursor:default;}
 #rb-covers-search #rb-showmore {display:block;width:100%;text-align:center;padding:.5rem 0 0 0;margin:0;cursor:default;}
 #rb-covers-search #rb-showmore button {font-size:.9em;background:var(--btnshade2);border-radius:3em;margin:1em auto;padding:.5em 1.25em .6em 1.25em;line-height:normal;height:auto;width:auto;}
 #rb-covers-search #rb-showmore button:hover {background:var(--btnshade2);} /* Mask hover effect */

--- a/www/inc/radio-browser.php
+++ b/www/inc/radio-browser.php
@@ -308,9 +308,6 @@ function rbShapeResults($data, $dbh) {
 			'codec' => trim($s['codec'] ?? ''),
 			'bitrate' => (int)($s['bitrate'] ?? 0),
 			'stationuuid' => trim($s['stationuuid'] ?? ''),
-			// HLS (.m3u8) streams hard-lock MPD's ffmpeg decoder (confirmed on nopi AND
-			// stock moOde Pi — upstream limitation); the UI marks these non-playable.
-			'hls' => (int)($s['hls'] ?? 0),
 			'added' => isset($favUrls[$key])
 		);
 		if (!isset($index[$key])) {

--- a/www/js/radio-browser.js
+++ b/www/js/radio-browser.js
@@ -59,17 +59,10 @@ function rbBuildTile(s, i) {
     var favClass = s.added ? 'rb-fav-toggle added' : 'rb-fav-toggle';
     var favIcon = s.added ? 'fa-solid' : 'fa-regular';
     var hires = (s.bitrate && s.bitrate >= 320) ? '<div class="lib-encoded-at-hires-badge">' + RADIO_HIRES_BADGE_TEXT + '</div>' : '';
-    // HLS (.m3u8) hard-locks MPD's decoder — mark non-playable (badge, no play/fav/menu)
-    var hls = s.hls == 1;
-    var favToggle = hls ? '' :
-        '<div class="' + favClass + '"><i class="' + favIcon + ' fa-sharp fa-heart"></i></div>';
-    var coverMenu = hls ? '' :
-        '<div class="cover-menu" data-toggle="context" data-target="#context-menu-radio-browser-item"></div>';
-    var hlsBadge = hls ? '<div class="rb-hls-badge"><i class="fa-solid fa-sharp fa-triangle-exclamation"></i> HLS</div>' : '';
+    var favToggle = '<div class="' + favClass + '"><i class="' + favIcon + ' fa-sharp fa-heart"></i></div>';
+    var coverMenu = '<div class="cover-menu" data-toggle="context" data-target="#context-menu-radio-browser-item"></div>';
 
     return '<li id="rb-' + i + '"' +
-            (hls ? ' class="rb-hls"' : '') +
-            ' data-hls="' + (hls ? 1 : 0) + '"' +
             ' data-path="' + rbEscapeHtml(s.url) + '"' +
             ' data-url="' + rbEscapeHtml(s.url) + '"' +
             ' data-name="' + rbEscapeHtml(s.name) + '"' +
@@ -83,7 +76,7 @@ function rbBuildTile(s, i) {
         '<div class="db-icon db-song db-browse db-action">' +
             '<div class="thumbHW">' +
                 '<img loading="lazy" src="' + logo.replace(/&/g, '&amp;') + '" onerror="this.src=\'' + DEFAULT_RADIO_COVER + '\'">' +
-                favToggle + hlsBadge +
+                favToggle +
             '</div>' +
         '</div>' +
         coverMenu +
@@ -386,12 +379,7 @@ $(document).ready(function() {
 
     // Tile interactions (event delegation across the search/recent tabs)
     $('#container-radio-browser').on('click', '.database-radio img', function() {
-        var $li = $(this).closest('li');
-        if ($li.data('hls') == 1) {
-            notify(NOTIFY_TITLE_ALERT, 'mpd_error', 'HLS stream (.m3u8) — not supported by MPD', NOTIFY_DURATION_SHORT);
-            return;
-        }
-        rbPlay($li);
+        rbPlay($(this).closest('li'));
     });
     $('#container-radio-browser').on('click', '.rb-fav-toggle', function(e) {
         e.stopPropagation();


### PR DESCRIPTION
Remove the non-playable treatment of hls=1 stations: the tile badge, the disabled play/favorite/context-menu, and the 'hls' key in the API payload.

HLS streams are now handed to MPD like any other station.
