### PR TITLE
Album/Radio/Playlist views: center cover thumbnails vertically instead of bottom-aligning them

### DIFF
--- a/www/css/panels.css
+++ b/www/css/panels.css
@@ -616,8 +616,9 @@ img.lib-artistart {
 #albumcovers .lib-entry, .database-radio .lib-entry, .database-playlist .lib-entry {width:var(--thumbcols);text-align:center;display:inline-block;vertical-align:top;height:auto;font-size:.95em;padding:0 0 .4em 0;}
 #albumcovers .lib-entry img, .database-radio img, .database-playlist img {
 	position:absolute;
-	left:var(--thumbmargin);
-	bottom:0;
+	top:50%;
+	left:calc(50% + var(--thumbmargin));
+	transform:translate(-50%, -50%);
 	object-fit:contain;
 	width:var(--thumbimagesize);
 	max-height:var(--thumbimagesize);


### PR DESCRIPTION
## Problem

In the cover grids (Album view, Radio view — native and Radio Browser — and Playlist view),
the cover image is absolutely positioned inside the fixed square `.thumbHW` box with `bottom:0`.
Because the image keeps its aspect ratio (`width:var(--thumbimagesize)`, `object-fit:contain`),
any non-square cover is shorter than its box and hangs at the bottom of it, while square covers
fill it. Radio logos are frequently non-square, so a row of tiles looks ragged: some logos sit
low, others fill the whole cell.


## Change

One rule in `www/css/panels.css` — center the image in its box rather than pinning it to the bottom:


### Test

Doesn't alter other ALBUM VIEW, RADIO VIEW (native) or PLAYLIST VIEW

### Before: 

<img width="1351" height="853" alt="center-before" src="https://github.com/user-attachments/assets/c8e88b62-b66b-4ac4-b383-2dd02833c10d" />

### After:

<img width="1407" height="894" alt="center-after" src="https://github.com/user-attachments/assets/84b79879-f875-44f5-8fc0-dc0e525b0d63" />
