### PR TITLE
Peppy: bind the softvol control to the hardware mixer element (removes a double attenuation)

### DIFF
--- a/etc/alsa/conf.d/peppy.conf.hide
+++ b/etc/alsa/conf.d/peppy.conf.hide
@@ -10,7 +10,7 @@ pcm.softvol_and_peppyalsa {
 type softvol
 slave.pcm "peppyalsa"
 control {
-# ALSA mixer (hardware mixer or "PCM" if none )
+# ALSA control element (hardware mixer element or "PCM" if none)
 name "PCM"
 card 0
 }

--- a/www/daemon/worker.php
+++ b/www/daemon/worker.php
@@ -745,6 +745,13 @@ workerLog('worker: ALSA mode:     ' . ALSA_OUTPUT_MODE_NAME[$_SESSION['alsa_outp
 // ALSA mixer
 phpSession('write', 'amixname', getAlsaMixerName($_SESSION['adevname']));
 workerLog('worker: ALSA mixer:    ' . ($_SESSION['amixname'] == 'none' ? 'none exists' : $_SESSION['amixname']));
+// Drop a stray softvol control left under the simple mixer name by an earlier release.
+// ALSA restores it at boot, where it shadows the hardware control. Only application
+// created controls are removed, so a hardware element is never touched.
+if ($_SESSION['amixname'] != 'none') {
+	sysCmd('alsactl clean ' . $_SESSION['cardnum'] . ' "name=\'' . $_SESSION['amixname'] . '\'"');
+	sysCmd('alsactl store ' . $_SESSION['cardnum']);
+}
 // HDMI mixer initialize (after first boot a test signal needs to be sent to "register" the mixer with ALSA)
 if ($_SESSION['alsa_output_mode'] == 'iec958') {
 	$result = getAlsaVolume($_SESSION['amixname']);

--- a/www/inc/alsa.php
+++ b/www/inc/alsa.php
@@ -68,6 +68,18 @@ function getAlsaMixerName($deviceName) {
 	return $mixerName;
 }
 
+// Get the raw ALSA control element name for a simple mixer control
+function getAlsaCtlElemName($mixerName, $cardNum) {
+	$elemName = $mixerName . ' Playback Volume';
+	foreach (sysCmd('amixer -c ' . $cardNum . ' controls') as $control) {
+		if (str_contains($control, "name='" . $elemName . "'")) {
+			return $elemName;
+		}
+	}
+
+	return $mixerName;
+}
+
 function getAlsaVolume($mixerName) {
 	$maxLoops = 3;
 	$sleepTime = 1;

--- a/www/inc/audio.php
+++ b/www/inc/audio.php
@@ -294,7 +294,11 @@ function updPeppyConfs($cardNum, $outputMode) {
 	}
 	sysCmd("sed -i 's/^slave.pcm.*/slave.pcm \"" . $alsaDevice . "\"/' " . ALSA_PLUGIN_PATH . '/_peppyout.conf');
 	// ALSA mixer
-	$alsaMixer = $_SESSION['amixname'] == 'none' ? 'PCM' : $_SESSION['amixname'];
+	// The softvol control{} block takes a raw control element name. A simple mixer name
+	// never matches, which makes softvol create its own 0-255 control alongside the
+	// hardware one instead of binding to it.
+	$alsaMixer = $_SESSION['amixname'] == 'none' ?
+		'PCM' : getAlsaCtlElemName($_SESSION['amixname'], $cardNum);
 	$peppyConfFile = file_exists(ALSA_PLUGIN_PATH . '/peppy.conf.hide') ? '/peppy.conf.hide' : '/peppy.conf';
 	sysCmd("sed -i 's/^name.*/name \"" . $alsaMixer . "\"/' " . ALSA_PLUGIN_PATH . $peppyConfFile);
 	sysCmd("sed -i 's/^card.*/card " . $cardNum . "/' " . ALSA_PLUGIN_PATH . $peppyConfFile);


### PR DESCRIPTION
With Peppy in the audio chain, a DAC that has a hardware volume control gets its volume attenuated twice — once in the DAC, once by a softvol control that should never have been created. This also makes the displayed dB describe only half of the real attenuation, which is enhancement item 10, Display accurate dB volume when Peppy is in the audio chain.


## Cause

`updPeppyConfs()` writes `$_SESSION['amixname']` into the softvol `control { name }` block of `peppy.conf`. That block takes a **raw ALSA control element** name, but `amixname` is the **simple mixer** name:

| | name |
|---|---|
| raw control element | `DIYINHK USB Audio 2.0  Playback Volume` |
| written by moOde | `DIYINHK USB Audio 2.0 ` |

The name never matches, so the hardware-control bypass in alsa-lib (`pcm_softvol.c`: `if (!(access & ACCESS_USER)) return 1;` → `*pcmp = slave`) never fires. Softvol creates its own user control instead of binding to the hardware one:

```
numid=4  'DIYINHK USB Audio 2.0  Playback Volume'  0-127  dBminmax -127.00 → 0.00     (hardware)
numid=9  'DIYINHK USB Audio 2.0 '                  0-255  dBscale  -51.00, 0.20/step  (softvol)
```

The simple-mixer layer then merges both elements under one name and writes the same percentage to both — measured on a DIYINHK USB DAC with Peppy on:

| MPD volume | softvol | hardware | real attenuation | dB displayed |
|---|---|---|---|---|
| 70 % | 236/255 → -3.8 dB | 118/127 → -9.0 dB | **-12.8 dB** | -8.97 dB |
| 40 % | 208/255 → -9.4 dB | 104/127 → -22.9 dB | **-32.3 dB** | -22.91 dB |

So the volume is attenuated twice, `getMappedDbVol()` reports only the hardware half, and software attenuation is applied to a DAC that has hardware volume.

## Fix

`getAlsaCtlElemName()` resolves the raw element name and `updPeppyConfs()` writes that, so softvol binds to the hardware control and bypasses itself. The peppyalsa meter and `_peppyout` stay in the chain (`*pcmp = slave`). Devices with no hardware volume are unchanged: `amixname == 'none'` → `PCM`, softvol legitimately created.

## Migration (second commit)

The stray control was persisted by `alsactl` in `asound.state` (`access 'read write user'`) and restored at boot, before MPD — so it kept shadowing the hardware control even with Peppy turned off. Existing installs would see no benefit from the fix alone, hence the purge in `worker.php`. `alsactl clean` only removes application-created controls, so a hardware element is never touched, and it is a no-op once clean.

## Result

After a reboot, playing, Peppy chain open:

```
peppy.conf  name "DIYINHK USB Audio 2.0  Playback Volume"
amixer      numid 2/3/4/5 only — no 0-255 control
sget        Limits 0 - 127 ; Playback 109 [86%] [-18.00dB]   (MPD volume 50)
```

The displayed dB now matches the real attenuation, applied once. PeppyMeter still runs.

One behaviour change: on a DAC with hardware volume the VU meter no longer follows the volume knob, since the digital stream is full-scale. That reactivity was a side effect of the double attenuation. Selecting *Software* MPD volume pins the DAC at 0 dB and attenuates upstream of peppyalsa, which keeps the meter reactive.

## Out of scope

In *Software* mode no dB is displayed at all, because `getMappedDbVol()` reads `amixer` and no ALSA control is driven. It could be computed from MPD's own curve (`gain = (exp(v / 25) - 1) / (e^4 - 1)`, `SoftwareMixerPlugin.cxx`), as the code already does for CamillaDSP. 
That is a separate enhancement, deliberately kept out of this fix.