### PR TITLE
Fix no Bluetooth audio when a graphic EQ, crossfeed or parametric EQ is active

### DIFF
--- a/www/daemon/worker.php
+++ b/www/daemon/worker.php
@@ -3148,6 +3148,9 @@ function runQueuedJob() {
 					break;
 			}
 
+			// Regenerate the Bluetooth A2DP sink device (AUDIODEV) for the new DSP head
+			updDspAndBtInConfs($_SESSION['cardnum'], $_SESSION['alsa_output_mode']);
+
 			// Restart MPD
 			// NOTE: Don't restart if already done in the camillaDSP section
 			if ($_SESSION['w_queue'] != 'camilladsp' || ($_SESSION['w_queue'] == 'camilladsp' && empty($queueArgs[1]))) {

--- a/www/inc/audio.php
+++ b/www/inc/audio.php
@@ -273,6 +273,15 @@ function updDspAndBtInConfs($cardNum, $outputMode) {
 		} else {
 			$alsaDevice = 'peppy';
 		}
+	// LADSPA heads (alsaequal/crossfeed/eqfa12p) can't be opened via plug:_audioout; open directly
+	} else if ($_SESSION['alsaequal'] != 'Off') {
+		$alsaDevice = 'alsaequal';
+	} else if ($_SESSION['camilladsp'] != 'off') {
+		$alsaDevice = 'plug:_audioout';
+	} else if ($_SESSION['crossfeed'] != 'Off') {
+		$alsaDevice = 'crossfeed';
+	} else if ($_SESSION['eqfa12p'] != 'Off') {
+		$alsaDevice = 'eqfa12p';
 	} else {
 		// A2DP sink: convert the fixed-format decoded PCM at the top of the chain
 		$alsaDevice = 'plug:_audioout';


### PR DESCRIPTION
### Problem

Since the A2DP sink is routed through `plug:_audioout`, **Bluetooth playback produces no sound** whenever **Graphic EQ (alsaequal)**, **Crossfeed** or **Parametric EQ (eqfa12p)** is enabled. The stream cuts out the moment audio starts.

### Root cause

When one of those DSPs heads `_audioout`, `bluealsa-aplay` opening `plug:_audioout` → `_audioout` (`type copy`) → LADSPA plugin fails ALSA hw_params negotiation and aborts before any audio:

```
Opening ALSA playback PCM: name=plug:_audioout channels=2 rate=48000
pcm_params.c:170: snd_pcm_hw_param_get_min: Assertion `!snd_interval_empty(i)' failed.
Main process exited, code=killed, status=6/ABRT
```

The culprit is the `plug:` wrapped over the `type copy` `_audioout` in front of a LADSPA (`type equal` / `type ladspa`) plugin. It is specific to those plugins:

- **alsaequal / crossfeed / eqfa12p** (LADSPA) → **crash**
- **camilladsp** (`alsa_cdsp`) and **invert-polarity** (`type route`) → negotiate fine, unaffected
- MPD is unaffected because it opens `_audioout` directly, without the extra `plug:` on top.

### Fix

Two parts:

1. **`www/inc/audio.php`** — In `updDspAndBtInConfs()`, route the A2DP sink device (`AUDIODEV`) straight at the active LADSPA plugin (`alsaequal` / `crossfeed` / `eqfa12p`). Each is itself a `type plug` and converts the fixed-format decoded PCM internally, so the crash-prone `plug:` → `copy` → LADSPA stack is avoided. All other cases (`camilladsp`, `invpolarity`, no-DSP, peppy) keep their current `AUDIODEV`. The branch order mirrors the `updAudioOutAndBtOutConfs()` head priority so `AUDIODEV` always matches the actual `_audioout` head.

2. **`www/daemon/worker.php`** — The DSP enable/disable jobs only refreshed the `_audioout` head (`updAudioOutAndBtOutConfs()`), never the A2DP sink device, so `AUDIODEV` was never regenerated on an EQ toggle and part 1 alone would not take effect. Added a single `updDspAndBtInConfs()` call after the DSP `switch`.

**Bonus:** the EQ / crossfeed now actually applies to the Bluetooth stream.

### Testing

Validated end-to-end on a Raspberry Pi 3B, by ear, toggling each DSP from the Web UI (no manual intervention):

- 2 DACs: a soft-volume USB DAC and a hardware-volume USB DAC (DIYINHK D20)
- Output modes: Default (`plughw`) and Direct (`hw`)
- Every DSP head × hardware and software volume:

| DSP | HW volume | SW volume |
|-----|-----------|-----------|
| Graphic EQ (alsaequal) | ✅ | ✅ |
| Parametric EQ (eqfa12p) | ✅ | ✅ |
| Crossfeed | ✅ | ✅ |
| CamillaDSP | ✅ | ✅ |
| Invert polarity | ✅ | ✅ |

Before the fix each LADSPA case reproduced the `SIGABRT` above; after it, Bluetooth plays with the effect applied.
