### PR TITLE
Guard ALSA "Default" output mode against the Peppy + LADSPA DSP crash

### DIFF
--- a/www/snd-config.php
+++ b/www/snd-config.php
@@ -145,8 +145,14 @@ if (isset($_POST['update_alsavolume_max'])) {
 // Output mode
 if (isset($_POST['update_alsa_output_mode'])) {
 	if (isset($_POST['alsa_output_mode']) && $_POST['alsa_output_mode'] != $_SESSION['alsa_output_mode']) {
-		phpSession('write', 'alsa_output_mode', $_POST['alsa_output_mode']);
-		submitJob('alsa_output_mode', $_POST['alsa_output_mode']);
+		if ($_POST['alsa_output_mode'] == 'plughw' && $_SESSION['peppy_display'] == '1' &&
+			($_SESSION['crossfeed'] != 'Off' || $_SESSION['alsaequal'] != 'Off' || $_SESSION['eqfa12p'] != 'Off')) {
+			$_SESSION['notify']['title'] = NOTIFY_TITLE_ALERT;
+			$_SESSION['notify']['msg'] = 'To run Peppy when Crossfeed, Graphic or Parametric EQ is on, set ALSA output mode to Direct or IEC958.';
+		} else {
+			phpSession('write', 'alsa_output_mode', $_POST['alsa_output_mode']);
+			submitJob('alsa_output_mode', $_POST['alsa_output_mode']);
+		}
 	}
 }
 // Loopback


### PR DESCRIPTION
## Problem
With PeppyMeter on together with a LADSPA-based DSP (Graphic EQ / Parametric
EQ / Crossfeed), switching ALSA output mode to Default (plughw) rebuilds the
chain into `_audioout → LADSPA → peppy → plughw:card,0`. MPD cannot open it:
the plughw slave under the meter/copy + LADSPA collapses hw_params to an empty
interval → SIGABRT, surfaced in the UI as "Socket open failed".

## Existing invariant
moOde already forbids this combo on three entry paths — enabling Parametric EQ
and Graphic EQ (snd-config.php), and enabling Peppy (per-config.php).

## The gap
The fourth path — changing ALSA output mode itself (`update_alsa_output_mode`)
— had no guard, so a user in Direct with Peppy + an EQ active could switch to
Default and crash MPD.

## Fix
Mirror the existing per-config.php guard in the output-mode handler: refuse a
switch to plughw while Peppy is on with Crossfeed/Graphic/Parametric EQ,
reusing the same notification string. Single-file change; no effect on any
already-legal combination.

## Testing
Real Pi hardware (DIYINHK USB DAC): Direct + Peppy + Parametric EQ → switch to
Default → before: "Socket open failed"; after: refused with notification, mode
stays Direct, MPD alive. Counter-tests pass (Peppy + no DSP → Default allowed;
Peppy off → Default allowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
