### PR TITLE
Peppy: don't leave the meter on a track change

### DIFF
--- a/www/daemon/touchmon.php
+++ b/www/daemon/touchmon.php
@@ -18,6 +18,7 @@ require_once __DIR__ . '/../inc/sql.php';
 //debugLog('touchmon: Started');
 $timeoutArg = !isset($argv[1]) ? TOUCHMON_TIMEOUT_DEFAULT : $argv[1];
 $timeout = $timeoutArg;
+$closedCount = 0;
 $dbh = sqlConnect();
 sysCmd('rm ' . TOUCHMON_LOG . ' > /dev/null');
 sysCmd('killall -s9 xinput > /dev/null');
@@ -80,9 +81,16 @@ while (true) {
 			}
 		}
 		// Switch to WebUI
+		// MPD closes the ALSA device between tracks, so a single closed reading is
+		// not proof that playback stopped. Require a few in a row.
 		if (isPeppyOn($dbh) === true && isAudioPlaying() === false) {
-			//debugLog('touchmon: - switch to webui');
-			exec('sudo moodeutl --setdisplay webui');
+			if (++$closedCount >= TOUCHMON_CLOSED_COUNT) {
+				//debugLog('touchmon: - switch to webui');
+				exec('sudo moodeutl --setdisplay webui');
+				$closedCount = 0;
+			}
+		} else {
+			$closedCount = 0;
 		}
 	} else {
 		//debugLog('touchmon: - WARNING: peppyalsa is not enabled');

--- a/www/inc/constants.php
+++ b/www/inc/constants.php
@@ -136,6 +136,7 @@ const PEPPY_GAIN_MON_LOG = '/tmp/moode_peppy_gain.log';
 // Peppy touch monitor
 const TOUCHMON_LOG = '/tmp/moode_touchmon.log';
 const TOUCHMON_TIMEOUT_DEFAULT = 15;
+const TOUCHMON_CLOSED_COUNT = 3;
 // Notifications
 const NOTIFY_TITLE_INFO = '<i class="fa fa-solid fa-sharp fa-circle-check" style="color:#27ae60;"></i> Info';
 const NOTIFY_TITLE_ALERT = '<i class="fa fa-solid fa-sharp fa-circle-xmark" style="color:#e74c3c;"></i> Alert';


### PR DESCRIPTION
## Problem

The touch monitor switches back to the WebUI on the **first** reading where the ALSA
device is closed:

```php
if (isPeppyOn($dbh) === true && isAudioPlaying() === false) {
    exec('sudo moodeutl --setdisplay webui');
}
```

But MPD closes and reopens the device between tracks — always when the format
changes, often even when it doesn't — and `isAudioPlaying()` samples
`moodeutl --hwparams | grep closed` once a second. A poll landing in that window
sends the screen back to the WebUI, where it stays for the whole
`TOUCHMON_TIMEOUT_DEFAULT` before coming back.

User-visible effect: changing tracks from a phone or a browser makes the meter drop
out for fifteen seconds. It is most obvious on a playlist mixing formats, where every
track change closes the device.

## Fix

The switch *to* Peppy is already debounced by the timeout; only the switch away from
it acts on a single sample. This makes it symmetric — `TOUCHMON_CLOSED_COUNT`
consecutive closed readings are required before switching. A real stop still
switches, three seconds later.

- `www/inc/constants.php` — new `TOUCHMON_CLOSED_COUNT`, next to the existing
  touchmon settings
- `www/daemon/touchmon.php` — count consecutive closed readings, reset on any open one

## Testing

Tested on moOde 10.2.4 with a playlist alternating FLAC 96 kHz and DSD64/128/256:
the meter stays up across every track change, and still yields to the WebUI on stop.

_Who, what ?? Peppy ? DoP ??_
