### PR TITLE
Peppy: guard the meter against native DSD (temporary, until alsa-lib is fixed)

### DIFF
--- a/etc/alsa/conf.d/peppy.conf.hide
+++ b/etc/alsa/conf.d/peppy.conf.hide
@@ -3,7 +3,23 @@
 #########################################
 pcm.peppy {
 type plug
-slave.pcm "softvol_and_peppyalsa"
+slave.pcm "peppy_pcmguard"
+}
+
+# Only negotiates linear PCM: native DSD is refused here so the player
+# converts upstream instead of reaching the meter, whose s16 scope
+# aborts on DSD. Unity gain, bit-transparent. Remove when alsa-lib
+# pcm_meter handles DSD (alsa-project/alsa-lib#516/#517).
+pcm.peppy_pcmguard {
+type route
+slave {
+pcm "softvol_and_peppyalsa"
+channels 2
+}
+ttable {
+0.0 = 1
+1.1 = 1
+}
 }
 
 pcm.softvol_and_peppyalsa {


### PR DESCRIPTION
Since #769 the Peppy chain is transparent on hardware-volume DACs — which is correct, but exposes a latent alsa-lib defect: type meter's s16 scope has no DSD conversion and aborts the caller (pcm_meter.c:1222), killing MPD on Peppy + DSD-capable DAC + hardware volume + dop "no" + a DSD file. Before #769 the stray softvol refused DSD by accident, so MPD always converted and the bug never fired.

This adds a unity route above the meter that restores exactly that behaviour, deliberately: native DSD is refused at negotiation, MPD falls back to dsd2pcm, the meter reads PCM. Unity gain, no control created (no double attenuation), bit-transparent for PCM, and DoP passes unharmed (markers verified intact below the route). Transparent to users — nothing to enable.

Validated on a fresh Pi 3B (stock 10.3.1 develop, stock alsa-lib/peppy-alsa): the crash config plays S32_LE @352800 with live needles, 0 aborts; DoP unaffected.

Temporary by design: revert when a meter-fixed alsa-lib ships (moode-player/pkgbuild#24, or upstream alsa-project/alsa-lib#516/#517 reaching a base OS). Existing installs would need the postinstall to lay the updated file.