### PR TITLE
Bluetooth: don't store the "Pincode set" placeholder as the PIN code

### DIFF
--- a/www/ren-config.php
+++ b/www/ren-config.php
@@ -35,7 +35,7 @@ if (isset($_POST['update_bt_settings'])) {
 if (isset($_POST['btrestart']) && $_POST['btrestart'] == 1 && $_SESSION['btsvc'] == '1') {
 	submitJob('btsvc', '', NOTIFY_TITLE_INFO, NAME_BLUETOOTH . NOTIFY_MSG_SVC_MANUAL_RESTART);
 }
-if (isset($_POST['update_bt_pin_code']) && $_POST['update_bt_pin_code'] != 'Pincode set') {
+if (isset($_POST['update_bt_pin_code']) && $_POST['bt_pin_code'] != 'Pincode set') {
 	phpSession('write', 'bt_pin_code', $_POST['bt_pin_code']);
 	$notify = $_SESSION['btsvc'] == '1' ?
 		array('title' => NOTIFY_TITLE_INFO, 'msg' => NAME_BLUETOOTH_PAIRING_AGENT . NOTIFY_MSG_SVC_RESTARTED) :


### PR DESCRIPTION
## Problem

With a Bluetooth PIN code set, the input field shows the `Pincode set` placeholder.
Submitting the Renderers page again stores that string as the PIN: `/etc/bluetooth/pin.conf`
ends up holding `* Pincode set` and the code the user chose is lost.

The guard meant to prevent this tests the submit button's value instead of the input
field, so it never matches.

## Fix

- `www/ren-config.php` — test the input field, like the Deezer, Qobuz and SMB pages
  already do for their own `Password set` placeholder

## Testing

Pi 3B: reproduced before the change, PIN preserved after, and clearing the PIN still works.
