### PR TITLE
Bluetooth: don't let a failed hciconfig call kill the pairing agent

### DIFF
--- a/etc/systemd/system/bt-agent.service
+++ b/etc/systemd/system/bt-agent.service
@@ -8,7 +8,7 @@ Type=simple
 KillSignal=SIGINT
 ExecStart=/usr/bin/bt-agent -c NoInputNoOutput
 ExecStartPost=/bin/sleep 1
-ExecStartPost=/bin/hciconfig hci0 sspmode 1
+ExecStartPost=-/bin/hciconfig hci0 sspmode 1
 
 [Install]
 WantedBy=bluetooth.target

--- a/www/daemon/worker.php
+++ b/www/daemon/worker.php
@@ -3228,11 +3228,11 @@ function runQueuedJob() {
 			if (empty($_SESSION['w_queueargs'])) {
 				sysCmd('echo "* ' . '" > ' . BT_PINCODE_CONF);
 				sysCmd("sed -i s'|ExecStart=/usr/bin/bt-agent.*|ExecStart=/usr/bin/bt-agent -c NoInputNoOutput|' /etc/systemd/system/bt-agent.service");
-				sysCmd("sed -i s'|ExecStartPost=/bin/hciconfig.*|ExecStartPost=/bin/hciconfig hci0 sspmode 1|' /etc/systemd/system/bt-agent.service");
+				sysCmd("sed -i s'|ExecStartPost=.*hciconfig.*|ExecStartPost=-/bin/hciconfig hci0 sspmode 1|' /etc/systemd/system/bt-agent.service");
 			} else {
 				sysCmd('echo "* ' . $_SESSION['w_queueargs'] . '" > ' . BT_PINCODE_CONF);
 				sysCmd("sed -i s'|ExecStart=/usr/bin/bt-agent.*|ExecStart=/usr/bin/bt-agent -c NoInputNoOutput -p " . BT_PINCODE_CONF . "|' /etc/systemd/system/bt-agent.service");
-				sysCmd("sed -i s'|ExecStartPost=/bin/hciconfig.*|ExecStartPost=/bin/hciconfig hci0 sspmode 0|' /etc/systemd/system/bt-agent.service");
+				sysCmd("sed -i s'|ExecStartPost=.*hciconfig.*|ExecStartPost=-/bin/hciconfig hci0 sspmode 0|' /etc/systemd/system/bt-agent.service");
 			}
 			sysCmd('systemctl daemon-reload');
 			sysCmd('systemctl restart bt-agent');


### PR DESCRIPTION
## Problem

Setting a Bluetooth PIN code adds `hciconfig hci0 sspmode 0` to `bt-agent.service`.
Some controllers reject that call — a USB dongle here returns
`Can't set Simple Pairing mode on hci0: Input/output error (5)`. Without a `-` prefix
systemd fails the whole unit, so `bt-agent` is stopped and Bluetooth pairing no longer
works at all until the PIN code is removed.

## Fix

- `etc/systemd/system/bt-agent.service` — prefix the call with `-` so a rejected
  `sspmode` no longer fails the unit
- `www/daemon/worker.php` — widen the two `sed` patterns so they keep matching the line
  once it carries the prefix, otherwise the `sspmode` toggle stops working silently

## Testing

Pi 3B: the call succeeds, nothing changes and the toggle still works. Machine with a USB
dongle that rejects it: `bt-agent` goes from `failed` to `active`.
