### PR TITLE
Bluetooth: show the pairing modal on config pages too

### DIFF
--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -785,6 +785,14 @@ function engineCmdLite() {
                     // causing engine-cmd.php to start releasing idle connections
                     console.log(cmd[0]);
                     break;
+                case 'pairreq':
+                    // cmd: pairreq,<id>,<method>,<code>,<name_b64>,<icon>
+                    btPairRequest(cmd[1], cmd[2], cmd[3], cmd[4]);
+                    break;
+                case 'paircancel':
+                    // cmd: paircancel,<id> (timed out or the device gave up)
+                    btPairCancel(cmd[1]);
+                    break;
                 default:
                     console.log('engineCmdLite(): ' + cmd[0]);
                     break;


### PR DESCRIPTION
Follow-up to #784: `engineCmdLite()` has no `case` for `pairreq`/`paircancel`, so the modal never shows on a config page — including Configure > Bluetooth, where pairing is started — and the request just expires after 60s.

The two cases mirror `cdsp_update_config`, `reset_view` and `close_notification`, which already live in both loops; `#btpair-modal` is in `footer.php`, so nothing else was needed.

Tested on x86: paired from a phone with the browser on Configure > Bluetooth and the local display on the playback page — both showed the modal and Confirm completed the pairing.
