### PR TITLE
Modals: fix aria-hidden on focusable controls

### DIFF
--- a/www/footer.php
+++ b/www/footer.php
@@ -7,7 +7,7 @@
 -->
 <!-- ABOUT -->
 <div id="about-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="about-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<p id="moode-logotype"><img src="images/moode-logotype.png"></p>
 	</div>
 	<div class="modal-body">
@@ -38,13 +38,13 @@
 		</ul>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Close" class="btn singleton" data-dismiss="modal" aria-hidden="true">Close</button>
+		<button aria-label="Close" class="btn singleton" data-dismiss="modal">Close</button>
 	</div>
 </div>
 
 <!-- CONFIGURE -->
 <div id="configure-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="configure-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="configure-modal-label">Configuration settings</h3>
 	</div>
 	<div class="modal-body">
@@ -74,19 +74,19 @@
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Close" class="btn singleton" data-dismiss="modal" aria-hidden="true">Close</button>
+		<button aria-label="Close" class="btn singleton" data-dismiss="modal">Close</button>
 	</div>
 </div>
 
 <!-- DASHBOARD -->
 <div id="dashboard-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="dashboard-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="dashboard-modal-label">Dashboard</h3>
 	</div>
 	<div id="dashboard-modal-body" class="modal-body">
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn singleton" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn singleton" data-dismiss="modal">Cancel</button>
 	</div>
 </div>
 
@@ -108,44 +108,44 @@
 
 <!-- AUDIO INFO -->
 <div id="audioinfo-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="audioinfo-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="audioinfo-modal-label">Audio information</h3>
 	</div>
 	<div class="modal-body">
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Close" class="btn singleton" data-dismiss="modal" aria-hidden="true">Close</button>
+		<button aria-label="Close" class="btn singleton" data-dismiss="modal">Close</button>
 	</div>
 </div>
 
 <!-- SYSTEM INFO -->
 <div id="sysinfo-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="sysinfo-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="sysinfo-modal-label">System information</h3>
 	</div>
 	<div class="modal-body">
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Close" class="btn singleton" data-dismiss="modal" aria-hidden="true">Close</button>
+		<button aria-label="Close" class="btn singleton" data-dismiss="modal">Close</button>
 	</div>
 </div>
 
 <!-- QUICK HELP -->
 <div id="quickhelp-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="help-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="help-modal-label">Quick Help</h3>
 	</div>
 	<div class="modal-body">
 		<div id="quickhelp"></div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Close" class="btn singleton" data-dismiss="modal" aria-hidden="true">Close</button>
+		<button aria-label="Close" class="btn singleton" data-dismiss="modal">Close</button>
 	</div>
 </div>
 
 <!-- POWER -->
 <div id="power-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="power-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="power-modal-label">Power Options</h3>
 	</div>
 	<div class="modal-body">
@@ -153,7 +153,7 @@
 		<button aria-label="Restart" id="system-restart" data-dismiss="modal" class="btn btn-primary btn-large btn-block" style="margin-bottom:15px;">Restart</button>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn singleton" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn singleton" data-dismiss="modal">Cancel</button>
 	</div>
 </div>
 

--- a/www/js/bootstrap.js
+++ b/www/js/bootstrap.js
@@ -50,7 +50,7 @@
 			var c = this;
 			b = a.Event("hide"), this.$element.trigger(b);
 			if (!this.isShown || b.isDefaultPrevented()) return;
-			this.isShown = !1, this.escape(), a(document).off("focusin.modal"), this.$element.removeClass("in").attr("aria-hidden", !0), a.support.transition && this.$element.hasClass("fade") ? this.hideWithTransition() : this.hideModal()
+			this.isShown = !1, this.escape(), a(document).off("focusin.modal"), this.$element[0].contains(document.activeElement) && document.activeElement.blur() /* @swizzle */, this.$element.removeClass("in").attr("aria-hidden", !0), a.support.transition && this.$element.hasClass("fade") ? this.hideWithTransition() : this.hideModal()
 		},
 		enforceFocus: function() {
 			var b = this;

--- a/www/templates/cdsp-config.html
+++ b/www/templates/cdsp-config.html
@@ -285,7 +285,7 @@
 <form class="form-horizontal" method="post">
 	<div id="remove-pipeline" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="remove-pipeline-label" aria-hidden="true">
 		<input id="config_remove_id" type="hidden" name="cdsp_config" value="$_selected_config"/>
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Remove Configuration?</h3>
 		</div>
 		<div class="modal-body txtmid">
@@ -295,7 +295,7 @@
 			</span>
 		</div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="remove" value="1" $_disable_rm>Yes</button>
 		</div>
 	</div>
@@ -305,7 +305,7 @@
 	<div id="remove-coeff" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="remove-coeff-label" aria-hidden="true">
 		<input id="coeff_remove_id" type="hidden" name="cdsp_coeffs" value="$_selected_coeff"/>
 		<div class="modal-header">
-			<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+			<button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Remove Convolution?</h3>
 		</div>
 		<div class="modal-body txtmid">
@@ -315,7 +315,7 @@
 			</span>
 		</div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="remove" value="1" $_disable_rm>Yes</button>
 		</div>
 	</div>
@@ -324,7 +324,7 @@
 <form class="form-horizontal" method="post">
 	<div id="copy-pipeline" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="copy-pipeline-label" aria-hidden="true">
 		<input type="hidden" name="cdsp_config" value="$_selected_config"/>
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Copy pipeline?</h3>
 		</div>
 		<div class="modal-body">
@@ -342,7 +342,7 @@
 			</div>
 		</div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="copy_pipeline" value="1">Yes</button>
 		</div>
 	</div>
@@ -350,7 +350,7 @@
 
 <form class="form-horizontal" method="post">
 	<div id="create-new-pipeline" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="new-pipeline-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Create new pipeline?</h3>
 		</div>
 		<div class="modal-body">
@@ -362,7 +362,7 @@
 			</div>
 		</div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="create_new_pipeline" value="1">Yes</button>
 		</div>
 	</div>

--- a/www/templates/eqg-config.html
+++ b/www/templates/eqg-config.html
@@ -92,7 +92,7 @@
 
 <form class="form-horizontal" method="post">
 	<div id="rm-curve" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="rm-curve-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Remove EQ curve?</h3>
 		</div>
 		<div class="modal-body txtmid">
@@ -102,7 +102,7 @@
 			</span>
 		</div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="remove_curve" value="1" $_disable_rm>Yes</button>
 		</div>
 	</div>
@@ -110,7 +110,7 @@
 
 <form class="form-horizontal" method="post">
 	<div id="new-curvename" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="new-curvename-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Create new curve</h3>
 		</div>
 		<div class="modal-body">
@@ -125,7 +125,7 @@
 			</div>
 		</div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="new_curve" value="1">Create</button>
 		</div>
 	</div>

--- a/www/templates/eqp-config.html
+++ b/www/templates/eqp-config.html
@@ -142,7 +142,7 @@
 <form class="form-horizontal" method="post">
 	<div id="rm-curve" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="rm-curve-label" aria-hidden="true">
 		<input type="hidden" name="curve_id" value="$_selected_curve_id"/>
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Remove EQ curve?</h3>
 		</div>
 		<div class="modal-body txtmid">
@@ -152,7 +152,7 @@
 			</span>
 		</div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="rmcurve" value="1" $_disable_rm>Yes</button>
 		</div>
 	</div>
@@ -160,7 +160,7 @@
 
 <form class="form-horizontal" method="post">
 	<div id="new-curvename" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="new-curvename-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Create new curve</h3>
 		</div>
 		<div class="modal-body">
@@ -176,7 +176,7 @@
 			</div>
 		</div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="newcurvename" value="1">Create</button>
 		</div>
 	</div>

--- a/www/templates/indextpl.html
+++ b/www/templates/indextpl.html
@@ -365,7 +365,7 @@
 
 <!-- ADVANCED SEARCH -->
 <div id="dbsearch-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="dbsearch-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3>Advanced search</h3>
 	</div>
 	<div class="modal-body" id="container-dbsearch">
@@ -467,14 +467,14 @@
         </div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn" data-dismiss="modal">Cancel</button>
 		<button aria-label="Submit" class="btn btn-primary" id="db-search-submit" data-dismiss="modal">Submit</button>
 	</div>
 </div>
 
 <!-- SAVED SEARCHES (TAG/ALBUM VIEW) -->
 <div id="saved-search-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="saved-search-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="saved-search-modal-label">Saved searches</h3>
 	</div>
 	<div class="modal-body">
@@ -497,7 +497,7 @@
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
+		<button aria-label="Close" class="btn" data-dismiss="modal">Close</button>
 		<button aria-label="Save" id="btn-save-search" class="btn btn-primary" data-dismiss="modal" disabled>Save</button>
 	</div>
 </div>
@@ -513,7 +513,7 @@
 
 <!-- QUEUE ITEM DELETE/MOVE -->
 <div id="delete-playqueue-item-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="delete-playqueue-item-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="delete-playqueue-item-modal-label">Remove Queue items?</h3>
 	</div>
 	<div class="modal-body">
@@ -531,13 +531,13 @@
         </div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn" data-dismiss="modal">Cancel</button>
 		<button aria-label="Delete" class="btn btn-delete-playqueue-item btn-primary" data-dismiss="modal">Remove</button>
 	</div>
 </div>
 
 <div id="move-playqueue-item-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="move-playqueue-item-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="move-playqueue-item-modal-label">Move Queue items?</h3>
 	</div>
 	<div class="modal-body">
@@ -561,14 +561,14 @@
         </div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn" data-dismiss="modal">Cancel</button>
 		<button aria-label="Move" class="btn btn-move-playqueue-item btn-primary" data-dismiss="modal">Move</button>
 	</div>
 </div>
 
 <!-- SAVE QUEUE TO PLAYLIST -->
 <div id="save-queue-to-playlist-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="save-queue-to-playlist-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="save-queue-to-playlist-modal-label">Save Queue to playlist</h3>
 	</div>
 	<div class="modal-body">
@@ -585,14 +585,14 @@
 		</form>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn" data-dismiss="modal">Cancel</button>
 		<button aria-label="Save" id="btn-save-queue-to-playlist" class="btn btn-primary" data-dismiss="modal">Save</button>
 	</div>
 </div>
 
 <!-- IMPORT PLAYLIST -->
 <div id="import-playlist-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="import-playlist-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="import-playlist-modal-label">Upload playlist</h3>
 	</div>
 	<div class="modal-body">
@@ -626,14 +626,14 @@
 		</form>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn" data-dismiss="modal">Cancel</button>
 		<button aria-label="Import" id="btn-import-playlist" class="btn btn-primary" data-dismiss="modal">Import</button>
 	</div>
 </div>
 
 <!-- SET FAVORITES PLAYLIST -->
 <div id="set-favorites-playlist-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="newpl-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="set-favorites-playlist-modal-label">Set Favorites Playlist Name</h3>
 	</div>
 	<div class="modal-body">
@@ -651,14 +651,14 @@
 		</form>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn" data-dismiss="modal">Cancel</button>
 		<button aria-label="Set" id="btn-set-favorites-name" class="btn btn-primary" data-dismiss="modal">Save</button>
 	</div>
 </div>
 
 <!-- MULTIROOM RECEIVERS -->
 <div id="multiroom-rx-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="multiroom-rx-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="multiroom-rx-modal-label">Receivers</h3>
 	</div>
 	<div class="modal-body">
@@ -669,13 +669,13 @@
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn singleton" data-dismiss="modal" aria-hidden="true">Close</button>
+		<button aria-label="Close" class="btn singleton" data-dismiss="modal">Close</button>
 	</div>
 </div>
 
 <!-- PREFERENCES -->
 <div id="preferences-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="preferences-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="preferences-modal-label">Preferences</h3>
 	</div>
 	<div class="modal-body" id="container-preferences">
@@ -1832,14 +1832,14 @@
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn" data-dismiss="modal">Cancel</button>
 		<button aria-label="Update" id="btn-preferences-update" class="btn btn-primary" data-dismiss="modal">Save</button>
 	</div>
 </div>
 
 <!-- CLOCK RADIO -->
 <div id="clockradio-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="clockradio-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="clockradio-modal-label">Clock radio settings</h3>
 	</div>
 	<div class="modal-body">
@@ -1971,14 +1971,14 @@
         </div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn" data-dismiss="modal">Cancel</button>
 		<button aria-label="Update" id="btn-clockradio-update" class="btn btn-primary" data-dismiss="modal">Save</button>
 	</div>
 </div>
 
 <!-- RADIO STATION NEW/EDIT/DELETE -->
 <div id="new-station-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="new-station-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="new-station-modal-label">New station</h3>
 	</div>
 	<div class="modal-body">
@@ -2118,14 +2118,14 @@
         </div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn" data-dismiss="modal">Cancel</button>
 		<button aria-label="Create" id="btn-create-station" class="btn btn-primary" data-dismiss="modal">Create</button>
 	</div>
 </div>
 
 <!-- USE THIS AS A MODEL WHEN REFACTORING -->
 <div id="edit-station-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="edit-station-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="edit-station-modal-label">Edit station</h3>
 	</div>
 	<div class="modal-body">
@@ -2267,27 +2267,27 @@
         </div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn" data-dismiss="modal">Cancel</button>
 		<button aria-label="Update" id="btn-update-station" class="btn btn-primary" data-dismiss="modal">Save</button>
 	</div>
 </div>
 
 <div id="delete-station-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="delete-station-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="delete-station-modal-label">Delete station?</h3>
 	</div>
 	<div class="modal-body">
 		<h4 id="station-path"></h4>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn" data-dismiss="modal">Cancel</button>
 		<button aria-label="Delete" id="btn-del-station" class="btn btn-primary" data-dismiss="modal">Delete</button>
 	</div>
 </div>
 
 <!-- RADIO MANAGER -->
 <div id="radio-manager-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="radio-manager-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="radio-manager-modal-label">Radio Manager</h3>
 	</div>
 	<div class="modal-body">
@@ -2636,14 +2636,14 @@
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn" data-dismiss="modal">Cancel</button>
 		<button aria-label="Update" id="btn-upd-radio-manager" class="btn btn-primary" data-dismiss="modal">Save</button>
 	</div>
 </div>
 
 <!-- RADIO BROWSER MANAGER-->
 <div id="radio-browser-manager-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="radio-browser-manager-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="radio-browser-manager-modal-label">Radio Browser Manager</h3>
 	</div>
 	<div class="modal-body">
@@ -2678,13 +2678,13 @@
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Close" class="btn singleton" data-dismiss="modal" aria-hidden="true">Close</button>
+		<button aria-label="Close" class="btn singleton" data-dismiss="modal">Close</button>
 	</div>
 </div>
 
 <!-- PLAYLIST NEW/EDIT/DELETE -->
 <div id="new-playlist-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="new-playlist-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="new-playlist-modal-label">New playlist</h3>
 	</div>
 	<div class="modal-body">
@@ -2719,13 +2719,13 @@
         </div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn" data-dismiss="modal">Cancel</button>
 		<button aria-label="Create" id="btn-create-playlist" class="btn btn-primary" data-dismiss="modal">Create</button>
 	</div>
 </div>
 
 <div id="view-playlist-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="view-playlist-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="view-playlist-modal-label">View playlist</h3>
 	</div>
 	<div class="modal-body">
@@ -2735,12 +2735,12 @@
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Close" class="btn singleton" data-dismiss="modal" aria-hidden="true">Close</button>
+		<button aria-label="Close" class="btn singleton" data-dismiss="modal">Close</button>
 	</div>
 </div>
 
 <div id="edit-playlist-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="edit-playlist-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="edit-playlist-modal-label">Edit playlist</h3>
 	</div>
 	<div class="modal-body">
@@ -2791,27 +2791,27 @@
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn" data-dismiss="modal">Cancel</button>
 		<button aria-label="Save" id="btn-update-playlist" class="btn btn-primary" data-dismiss="modal">Save</button>
 	</div>
 </div>
 
 <div id="delete-playlist-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="delete-playlist-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="delete-playlist-modal-label">Delete playlist?</h3>
 	</div>
 	<div class="modal-body">
 		<h4 id="playlist-path" class="txtmid"></h4>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn" data-dismiss="modal">Cancel</button>
 		<button aria-label="Delete" id="btn-del-playlist" class="btn btn-primary" data-dismiss="modal">Delete</button>
 	</div>
 </div>
 
 <!-- PLAYLIST MANAGER -->
 <div id="playlist-manager-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="playlist-manager-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="playlist-manager-modal-label">Playlist Manager</h3>
 	</div>
 	<div class="modal-body">
@@ -2863,14 +2863,14 @@
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn" data-dismiss="modal">Cancel</button>
 		<button aria-label="Update" id="btn-upd-playlist-manager" class="btn btn-primary" data-dismiss="modal">Save</button>
 	</div>
 </div>
 
 <!-- ADD TO PLAYLIST -->
 <div id="add-to-playlist-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="add-to-playlist-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="add-to-playlist-modal-label">Add to playlist</h3>
 	</div>
 	<div class="modal-body">
@@ -2883,14 +2883,14 @@
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Cancel" class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+		<button aria-label="Cancel" class="btn" data-dismiss="modal">Cancel</button>
 		<button aria-label="Add" id="btn-add-to-playlist" class="btn btn-primary" data-dismiss="modal">Add</button>
 	</div>
 </div>
 
 <!-- PLAYBACK HISTORY LOG -->
 <div id="playhistory-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="playhistory-modal-label" aria-hidden="true">
-	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3 id="playhistory-modal-label">Playback history</h3>
 	</div>
 	<div id="playhistory-search">
@@ -2908,7 +2908,7 @@
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Close" class="btn singleton" data-dismiss="modal" aria-hidden="true">Close</button>
+		<button aria-label="Close" class="btn singleton" data-dismiss="modal">Close</button>
 	</div>
 </div>
 
@@ -2928,7 +2928,7 @@
 		<div aria-label="Volume Display dB" class="volume-display-db"></div>
 	</div>
 	<div class="modal-footer">
-		<button aria-label="Close" class="btn singleton" data-dismiss="modal" aria-hidden="true">Close</button>
+		<button aria-label="Close" class="btn singleton" data-dismiss="modal">Close</button>
 	</div>
 </div>
 

--- a/www/templates/lib-config.html
+++ b/www/templates/lib-config.html
@@ -197,12 +197,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="remount-sources" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="remount-sources-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Re-mount NAS sources?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="remount_nas_sources" value="novalue">Yes</button>
 		</div>
 	</div>
@@ -210,12 +210,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="regen-mpddb" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="regen-mpddb-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Regenerate Music Database?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="regen_library" value="novalue">Yes</button>
 		</div>
 	</div>
@@ -223,14 +223,14 @@
 
 <form class="form-horizontal" method="post">
 	<div id="analyze-mpddb" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="analyze-mpddb-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Analyze Music Database?</h3>
 		</div>
 		<div class="modal-body">
 			<h4>This can take a while if there are a large number of number of tracks.</h4>
 		</div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="analyze_mpd_db" value="novalue">Yes</button>
 		</div>
 	</div>
@@ -238,12 +238,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="clear-libcache" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="clear-libcache-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Clear library tag cache?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="clear_libcache" value="novalue">Yes</button>
 		</div>
 	</div>
@@ -251,12 +251,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="regen-thmcache" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="regen-thmcache-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Regenerate thumbnail cache?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="regen_thmcache" value="novalue">Yes</button>
 		</div>
 	</div>

--- a/www/templates/lib-nas-config.html
+++ b/www/templates/lib-nas-config.html
@@ -142,19 +142,19 @@
 
 <form class="form-horizontal" method="post">
 	<div id="remove-nas-source" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="remove-nas-source-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Remove NAS source: $_name?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="remove_nas_source" value="1">Yes</button>
 		</div>
 	</div>
 </form>
 
 <div id="moode-log" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="moode-log-label" aria-hidden="true">
-	<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3>Moode Log</h3>
 	</div>
 	<div class="modal-body">
@@ -163,13 +163,13 @@
 		</pre>
 	</div>
 	<div class="modal-footer">
-		<button class="btn singleton" data-dismiss="modal" aria-hidden="true">Close</button>
+		<button class="btn singleton" data-dismiss="modal">Close</button>
 	</div>
 </div>
 
 <form class="form-horizontal" method="post">
 	<div id="manual-server" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="manual-server-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Manual path entry</h3>
 		</div>
 		<div class="modal-body">
@@ -183,7 +183,7 @@
 			</div>
 		</div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="manualentry" value="1">Ok</button>
 		</div>
 	</div>

--- a/www/templates/lib-nvme-config.html
+++ b/www/templates/lib-nvme-config.html
@@ -60,19 +60,19 @@
 
 <form class="form-horizontal" method="post">
 	<div id="remove-nvme-mount" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="remove-nvme-mount-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Remove NVMe mount: $_name?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="remove_nvme_source" value="1">Yes</button>
 		</div>
 	</div>
 </form>
 
 <div id="moode-log" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="moode-log-label" aria-hidden="true">
-	<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3>Moode Log</h3>
 	</div>
 	<div class="modal-body">
@@ -81,6 +81,6 @@
 		</pre>
 	</div>
 	<div class="modal-footer">
-		<button class="btn singleton" data-dismiss="modal" aria-hidden="true">Close</button>
+		<button class="btn singleton" data-dismiss="modal">Close</button>
 	</div>
 </div>

--- a/www/templates/lib-nvme-format.html
+++ b/www/templates/lib-nvme-format.html
@@ -45,7 +45,7 @@
 
 <form class="form-horizontal" method="post">
 	<div id="format-nvme-drive-modal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="format-nvme-drive-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Format NVMe drive?</h3>
 		</div>
 		<div class="modal-body txtmid">
@@ -55,7 +55,7 @@
 			<input id="modal-nvme-drive-label" type="hidden" name="nvme_drive_label" value="$_nvme_drive_label">
 		</div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button id="btn-format-nvme-drive-submit" class="btn btn-primary btn-submit" type="submit" name="nvme_format_drive" value="1">Yes</button>
 		</div>
 	</div>

--- a/www/templates/lib-sata-config.html
+++ b/www/templates/lib-sata-config.html
@@ -53,19 +53,19 @@
 
 <form class="form-horizontal" method="post">
 	<div id="remove-sata-mount" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="remove-sata-mount-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Remove SATA mount: $_name?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="remove_sata_source" value="1">Yes</button>
 		</div>
 	</div>
 </form>
 
 <div id="moode-log" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="moode-log-label" aria-hidden="true">
-	<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+	<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 		<h3>Moode Log</h3>
 	</div>
 	<div class="modal-body">
@@ -74,6 +74,6 @@
 		</pre>
 	</div>
 	<div class="modal-footer">
-		<button class="btn singleton" data-dismiss="modal" aria-hidden="true">Close</button>
+		<button class="btn singleton" data-dismiss="modal">Close</button>
 	</div>
 </div>

--- a/www/templates/net-config.html
+++ b/www/templates/net-config.html
@@ -220,7 +220,7 @@
 
 <form class="form-horizontal" method="post">
 	<div id="manual-ssid" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="manual-ssid-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Manual SSID entry</h3>
 		</div>
 		<div class="modal-body">
@@ -236,7 +236,7 @@
 			</div>
 		</div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="manualssid" value="1">Ok</button>
 		</div>
 	</div>
@@ -244,7 +244,7 @@
 
 <form class="form-horizontal" method="post">
 	<div id="manage-saved-networks" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="manage-saved-networks-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Manage saved networks</h3>
 		</div>
 		<div class="modal-body">
@@ -253,7 +253,7 @@
 			</div>
 		</div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="update-saved-networks" value="1">Update</button>
 		</div>
 	</div>

--- a/www/templates/peppy-config.html
+++ b/www/templates/peppy-config.html
@@ -150,12 +150,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="install-moode-meters" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="install-moode-meters-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Install Latest Moode Meters?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="install_moode_meters" value="1">Yes</button>
 		</div>
 	</div>

--- a/www/templates/per-config.html
+++ b/www/templates/per-config.html
@@ -396,12 +396,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="restart-local-display" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="restart-local-display-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Restart Local Display?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="update_restart_local_display" value="novalue">Yes</button>
 		</div>
 	</div>
@@ -409,12 +409,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="restart-peppy-display" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="restart-peppy-display-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Restart Peppy Display?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="update_restart_peppy_display" value="novalue">Yes</button>
 		</div>
 	</div>

--- a/www/templates/rcp-config.html
+++ b/www/templates/rcp-config.html
@@ -281,12 +281,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="clear-rcucache" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="clear-rcucache-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Clear Cover URL cache?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="update_clear_rcucache" value="novalue">Yes</button>
 		</div>
 	</div>

--- a/www/templates/ren-config.html
+++ b/www/templates/ren-config.html
@@ -458,12 +458,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="bt-restart" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="bt-restart-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Restart Bluetooth controller?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="btrestart" value="1">Yes</button>
 		</div>
 	</div>
@@ -471,7 +471,7 @@
 
 <!--DELETE:form class="form-horizontal" method="post">
 	<div id="install-airplay" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="install-airplay-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Build and Install Shairport-sync?</h3>
 		</div>
 		<div class="modal-body">
@@ -479,7 +479,7 @@
 			The build and install process can take some time so please be patient and periodically REFRESH the status screen.
 		</div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="install_airplay" value="1">Yes</button>
 		</div>
 	</div>
@@ -487,12 +487,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="airplay-restart" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="airplay-restart-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Restart AirPlay renderer?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="airplayrestart" value="1">Yes</button>
 		</div>
 	</div>
@@ -500,7 +500,7 @@
 
 <!--DELETE:form class="form-horizontal" method="post">
 	<div id="install-spotify" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="install-spotify-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Build and Install Librespot?</h3>
 		</div>
 		<div class="modal-body">
@@ -508,7 +508,7 @@
 			The build and install process can take some time so please be patient and periodically REFRESH the status screen.
 		</div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="install_spotify" value="1">Yes</button>
 		</div>
 	</div>
@@ -516,12 +516,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="spotify-restart" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="spotify-restart-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Restart Spotify connect renderer?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="spotifyrestart" value="1">Yes</button>
 		</div>
 	</div>
@@ -529,12 +529,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="spotify-clear-credentials" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="spotify-clear-credentials-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Clear credential cache?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="spotify_clear_credentials" value="1">Yes</button>
 		</div>
 	</div>
@@ -542,12 +542,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="deezer-restart" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="deezer-restart-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Restart Deezer connect renderer?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="deezerrestart" value="1">Yes</button>
 		</div>
 	</div>
@@ -555,12 +555,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="sl-restart" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="sl-restart-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Restart Squeezelite renderer?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="slrestart" value="1">Yes</button>
 		</div>
 	</div>
@@ -568,12 +568,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="upnp-restart" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="upnp-restart-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Restart UPnP renderer?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="upnprestart" value="1">Yes</button>
 		</div>
 	</div>
@@ -581,12 +581,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="pa-restart" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="pa-restart-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Restart Plexamp renderer?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="parestart" value="1">Yes</button>
 		</div>
 	</div>
@@ -594,12 +594,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="rb-restart" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="rb-restart-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Restart RoonBridge renderer?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="rbrestart" value="1">Yes</button>
 		</div>
 	</div>

--- a/www/templates/snd-config.html
+++ b/www/templates/snd-config.html
@@ -524,12 +524,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="mpd-restart" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="mpd-restart-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Restart MPD service?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="mpdrestart" value="1">Yes</button>
 		</div>
 	</div>

--- a/www/templates/sys-config.html
+++ b/www/templates/sys-config.html
@@ -661,7 +661,7 @@
 
 <form class="form-horizontal" method="post">
 	<div id="view-pkgcontent" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="view-pkgcontent-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3 id="view-pkgcontent-label">Package content</h3>
 		</div>
 		<div class="modal-body">
@@ -669,19 +669,19 @@
 			$_pkg_relnotes
 		</div>
 		<div class="modal-footer">
-			<button class="btn singleton" data-dismiss="modal" aria-hidden="true">Close</button>
+			<button class="btn singleton" data-dismiss="modal">Close</button>
 		</div>
 	</div>
 </form>
 
 <form class="form-horizontal" method="post">
 	<div id="rebuild-dlnadb" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="rebuild-dlnadb-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Rebuild DLNA database?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="rebuild_dlnadb" value="1">Yes</button>
 		</div>
 	</div>
@@ -689,12 +689,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="clear-playbackhist" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="clear-playbackhist-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Clear playback history?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="update_clear_playhistory" value="novalue">Yes</button>
 		</div>
 	</div>
@@ -702,12 +702,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="clear-syslogs" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="clear-syslogs-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Clear system logs?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="update_clear_syslogs" value="novalue">Yes</button>
 		</div>
 	</div>

--- a/www/templates/trx-config.html
+++ b/www/templates/trx-config.html
@@ -247,12 +247,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="restart-tx" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="restart-tx-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Restart Sender?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="multiroom_tx_restart" value="1">Yes</button>
 		</div>
 	</div>
@@ -260,12 +260,12 @@
 
 <form class="form-horizontal" method="post">
 	<div id="restart-rx" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="restart-rx-label" aria-hidden="true">
-		<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
 			<h3>Restart Receiver?</h3>
 		</div>
 		<div class="modal-body"></div>
 		<div class="modal-footer">
-			<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="multiroom_rx_restart" value="1">Yes</button>
 		</div>
 	</div>


### PR DESCRIPTION
Chrome logs `Blocked aria-hidden on an element because its descendant retained focus` every time a modal is dismissed. Two causes:

- The dismiss buttons carry `aria-hidden="true"` themselves — the Bootstrap 2 markup idiom, which is invalid on a focusable element. Dropped from all of them, and the header `×` buttons that had no accessible name get the `aria-label="Close"` the others already carry.
- `Modal.hide()` marks the dialog hidden while the clicked button still holds focus, and on Esc or a backdrop click the focus sits on the dialog itself. `bootstrap.js` now blurs out of the dialog first (`@swizzle`).

Also aligns two footer buttons whose `aria-label` read "Cancel" over a "Close" caption.

No visual change.
