### PR TITLE
fix highlighting and scrolling to current radio station when navigating from playback view to stations view

### DIFF
--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -5163,7 +5163,7 @@ function getRVHeaderCount() {
             if ($(this).hasClass('horiz-rule-radioview')) {
                 count = count + 1;
             }
-            if ($(this).children('span').text() == RADIO.json[MPD.json['file']]['name']) {
+            if ($(this).find('.station-name').text() == RADIO.json[MPD.json['file']]['name']) {
                 UI.radioPos = index;
                 return false;
             }

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -2898,6 +2898,7 @@ function customScroll(list, itemNum, speed) {
     		listSelector = '#database-radio';
     		scrollSelector = listSelector;
     		chDivisor = list == 'radio' ? 6 : 600;
+    		itemNum = list == 'radio' ? itemNum + 1 : itemNum;
             break;
         case 'playlist':
         case 'playlist_headers':

--- a/www/js/scripts-library.js
+++ b/www/js/scripts-library.js
@@ -1305,7 +1305,7 @@ $('#database-radio').on('click', 'img', function(e) {
     }
 
 	setTimeout(function() {
-        customScroll('radio', UI.radioPos + 1, 200);
+        customScroll('radio', UI.radioPos, 200);
 	}, DEFAULT_TIMEOUT);
 });
 


### PR DESCRIPTION
Here are fixes to 2 issues I've noticed that both occur when navigating back from radio playback view to radio stations view.
1. if grouping is enabled (e.g. favorites first), the wrong station gets highlighted.
2. if the current station is the first on a row, the list is scrolled to the row above.