### PR TITLE
Qobuz Connect renderer

### DIFF
--- a/etc/alsa/conf.d/qbzd-devices.conf
+++ b/etc/alsa/conf.d/qbzd-devices.conf
@@ -1,0 +1,9 @@
+#########################################
+# This file is managed by moOde
+#########################################
+# ALSA hints so the qbzd Qobuz Connect renderer can select
+# moOde's output chains by name
+pcm._audioout.hint.show on
+pcm._audioout.hint.description "Moode Audio Output"
+pcm.btstream.hint.show on
+pcm.btstream.hint.description "Moode Bluetooth Stream"

--- a/usr/local/bin/moodeutl
+++ b/usr/local/bin/moodeutl
@@ -26,6 +26,7 @@ $features = array(
 	FEAT_SQUEEZELITE => 'Squeezelite renderer',
 	FEAT_UPMPDCLI => 'UPnP client for MPD',
 	FEAT_DEEZER => 'Deezer Connect renderer',
+	FEAT_QOBUZ => 'Qobuz Connect renderer',
 	FEAT_ROONBRIDGE => 'RoonBridge renderer',
 	FEAT_LOCALDISPLAY => 'Local display',
 	FEAT_INPSOURCE => 'Input source select',
@@ -163,16 +164,17 @@ switch ($option) {
 		echo VERSION . "\n";
 		break;
 	case '--help':
-		//[--bluetooth | --airplay | --spotify | --deezer | --upnp | --squeezelite | --plexamp | --roonbridge]
+		//[--bluetooth | --airplay | --spotify | --deezer | --qobuz | --upnp | --squeezelite | --plexamp | --roonbridge]
 		$btArg = $featBitmask & FEAT_BLUETOOTH ? '--bluetooth | ' : '';
 		$apArg = $featBitmask & FEAT_AIRPLAY ? '--airplay | ' : '';
 		$spArg = $featBitmask & FEAT_SPOTIFY ? '--spotify | ' : '';
 		$dzArg = $featBitmask & FEAT_DEEZER ? '--deezer | ' : '';
+		$qbArg = $featBitmask & FEAT_QOBUZ ? '--qobuz | ' : '';
 		$upArg = $featBitmask & FEAT_UPMPDCLI ? '--upnp | ' : '';
 		$slArg = $featBitmask & FEAT_SQUEEZELITE ? '--squeezelite | ' : '';
 		$paArg = $featBitmask & FEAT_PLEXAMP ? '--plexamp | ' : '';
 		$rbArg = $featBitmask & FEAT_ROONBRIDGE ? '--roonbridge | ' : '';
-		$rendererList = rtrim($btArg . $apArg . $spArg . $dzArg . $upArg . $slArg . $paArg . $rbArg, ' | ');
+		$rendererList = rtrim($btArg . $apArg . $spArg . $dzArg . $qbArg . $upArg . $slArg . $paArg . $rbArg, ' | ');
 		echo
 "Usage: moodeutl [OPTION]
 Moode utility functions
@@ -530,6 +532,17 @@ function stopAllRenderers($featBitmask) {
 	} else {
 		echo "- deezer connect\tfeature disabled\n";
 	}
+	if ($featBitmask & FEAT_QOBUZ) {
+		$qobuzSvc = trim(sqlQuery("SELECT value FROM cfg_system WHERE param='qobuzsvc'"));
+		if ($qobuzSvc == '1') {
+			sysCmd('/var/www/util/restart-renderer.php --qobuz --stop');
+			echo "- qobuz connect\t\tstopped\n";
+		} else {
+			echo "- qobuz connect\t\tnot on\n";
+		}
+	} else {
+		echo "- qobuz connect\t\tfeature disabled\n";
+	}
 	if ($featBitmask & FEAT_UPMPDCLI) {
 		$upSvc = trim(sqlQuery("SELECT value FROM cfg_system WHERE param='upnpsvc'"));
 		if ($upSvc == '1') {
@@ -578,8 +591,8 @@ function stopAllRenderers($featBitmask) {
 
 function restartRenderer($argv) {
 	$renderers = array('--bluetooth' => 'btsvc', '--airplay' => 'airplaysvc', '--spotify' => 'spotifysvc',
-		'--deezer' => 'deezersvc', '--upnp' => 'upnpsvc', '--squeezelite' => 'slsvc', '--plexamp' => 'pasvc',
-		'--roonbridge' => 'rbsvc');
+		'--deezer' => 'deezersvc', '--qobuz' => 'qobuzsvc', '--upnp' => 'upnpsvc', '--squeezelite' => 'slsvc',
+		'--plexamp' => 'pasvc', '--roonbridge' => 'rbsvc');
 
 	if (!isset($argv[2])) {
 		echo 'Missing 2nd argument [renderer name]' . "\n";
@@ -593,7 +606,7 @@ function restartRenderer($argv) {
 		}
 	} else {
 		echo 'Invalid renderer name' . "\n";
-		echo 'Valid names are: --bluetooth, --airplay, --spotify, --deezer, --upnp, --squeezelite, --plexamp, --roonbridge' . "\n";
+		echo 'Valid names are: --bluetooth, --airplay, --spotify, --deezer, --qobuz, --upnp, --squeezelite, --plexamp, --roonbridge' . "\n";
 		return;
 	}
 
@@ -603,15 +616,15 @@ function restartRenderer($argv) {
 
 function rendererOnoff($argv) {
 	$renderers = array('--bluetooth' => 'btsvc', '--airplay' => 'airplaysvc', '--spotify' => 'spotifysvc',
-		'--deezer' => 'deezersvc', '--upnp' => 'upnpsvc', '--squeezelite' => 'slsvc', '--plexamp' => 'pasvc',
-		'--roonbridge' => 'rbsvc');
+		'--deezer' => 'deezersvc', '--qobuz' => 'qobuzsvc', '--upnp' => 'upnpsvc', '--squeezelite' => 'slsvc',
+		'--plexamp' => 'pasvc', '--roonbridge' => 'rbsvc');
 
 	if (!isset($argv[2])) {
 		echo 'Missing 2nd argument [renderer name]' . "\n";
 		return;
 	} else if (!array_key_exists($argv[2], $renderers)) {
 		echo 'Invalid renderer name' . "\n";
-		echo 'Valid names are: --bluetooth, --airplay, --spotify, --deezer, --upnp, --squeezelite, --plexamp, --roonbridge' . "\n";
+		echo 'Valid names are: --bluetooth, --airplay, --spotify, --deezer, --qobuz, --upnp, --squeezelite, --plexamp, --roonbridge' . "\n";
 		return;
 	} else if (!isset($argv[3])) {
 		echo 'Missing 3nd argument [on|off]' . "\n";

--- a/var/local/www/commandw/qbzevent.sh
+++ b/var/local/www/commandw/qbzevent.sh
@@ -147,9 +147,14 @@ deactivate () {
 if [[ $QBZ_EVENT == "PlaybackStateChanged" ]]; then
 	if [[ $QBZ_STATE == "playing" || $QBZ_STATE == "loading" ]]; then
 		activate
-	elif [[ $QBZ_STATE == "paused" || $QBZ_STATE == "stopped" ]]; then
+	elif [[ $QBZ_STATE == "stopped" ]]; then
 		deactivate
 	fi
+	# NOTE: paused KEEPS the render (AirPlay/Spotify parity — their flags are
+	# session-scoped). The session still owns the audio device while paused,
+	# and any renderUI rebuild (page load, window resize) reads qbzactive from
+	# cfg_system — deactivating on pause made the overlay vanish on reload or
+	# resize whenever playback happened to be paused.
 fi
 
 if [[ $QBZ_EVENT == "QconnectSessionChanged" ]]; then
@@ -173,6 +178,11 @@ if [[ $QBZ_EVENT == "PlaybackError" ]]; then
 		echo $((RETRIES_LEFT - 1)) > $RETRY_FILE
 		sleep 1
 		qbzd play -q
+	else
+		# Out of retries (or MPD grabbed the device): since paused no longer
+		# deactivates, release the render here or a failed start would leave
+		# the UI locked on a silent session.
+		deactivate
 	fi
 fi
 

--- a/var/local/www/commandw/qbzevent.sh
+++ b/var/local/www/commandw/qbzevent.sh
@@ -216,10 +216,21 @@ if [[ $QBZ_EVENT == "TrackStarted" ]]; then
 	# Playback started: replenish the failed-start retry budget
 	echo $RETRY_BUDGET > $RETRY_FILE
 	SFORMAT="FLAC $QBZ_BIT_DEPTH/$QBZ_SAMPLE_RATE kHz"
-	# Output format (post volume normalization/resampling) from the control API
-	OFORMAT=$(curl -s --max-time 2 $QBZD_API/api/now-playing | jq -r 'select(.playback.bit_depth != null) | "PCM \(.playback.bit_depth)/\(.playback.sample_rate / 1000) kHz"')
+	# Output format from the control API. /api/status, NOT /api/now-playing: the
+	# latter is login-gated and the pairing flow never logs in (the casting app
+	# hands over its own session), so it answers needs_auth and this fell back to
+	# claiming the OUTPUT was FLAC. /api/status also carries the rate the DEVICE
+	# runs at (qbzd 2.0.2.moode25+), which is the number that differs from the
+	# source whenever something in the chain resamples.
+	AUDIO_JSON=$(curl -s --max-time 2 $QBZD_API/api/status | jq -c '.audio // {}' 2>/dev/null)
+	OFORMAT=$(jq -rn --argjson a "${AUDIO_JSON:-{\}}" '
+		(if $a.output_sample_rate != null then $a.output_sample_rate else $a.sample_rate end) as $r
+		| if $a.bit_depth != null and $r != null then "PCM \($a.bit_depth)/\($r / 1000) kHz" else empty end
+	' 2>/dev/null)
 	if [[ -z $OFORMAT ]]; then
-		OFORMAT=$SFORMAT
+		# Never fall back to SFORMAT: the decoder always emits PCM, so echoing the
+		# source container here is the one answer that is certainly wrong.
+		OFORMAT="PCM $QBZ_BIT_DEPTH/$QBZ_SAMPLE_RATE kHz"
 	fi
 	METADATA_JSON=$(jq -n -c \
 		--arg a "update_qbzmeta" \

--- a/var/local/www/commandw/qbzevent.sh
+++ b/var/local/www/commandw/qbzevent.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright 2014 The moOde audio player project / Tim Curtis
+#
+# Qobuz Connect (qbzd) event hook. qbzd forks this script once per daemon
+# event with the event described in QBZ_* environment variables (set via
+# QBZD_HOOK, see startQobuz() in inc/renderer.php).
+#
+
+LOGFILE="/var/log/moode_qbzevent.log"
+DEBUG=$(sudo moodeutl -d -gv debuglog)
+SQLDB=/var/local/www/db/moode-sqlite3.db
+
+QBZMETA_CACHE_FILE="/var/local/www/qbzmeta.json"
+QBZD_API="http://127.0.0.1:8182"
+# Budget for retrying a start that failed because the audio device was still
+# busy (e.g. shairport-sync releasing it late). qbzd does not retry on its own.
+RETRY_FILE="/tmp/qbzevent-retry-budget"
+RETRY_BUDGET=5
+
+debug_log () {
+	if [[ $DEBUG == '0' ]]; then
+		return 0
+	fi
+	echo "$1"
+	TIME=$(date +'%Y%m%d %H%M%S')
+	echo "$TIME $1" >> $LOGFILE
+}
+
+PLAYER_EVENTS=(
+PlaybackStateChanged
+TrackStarted
+QconnectSessionChanged
+PlaybackError
+)
+
+MATCH=0
+for MATCH_EVENT in "${PLAYER_EVENTS[@]}"
+do
+	if [[ $QBZ_EVENT == $MATCH_EVENT ]]; then
+		MATCH=1
+		debug_log "Process: "$QBZ_EVENT
+	fi
+done
+# Exit and log if not a match
+if [[ $MATCH == 0 ]]; then
+	debug_log "Logged:  "$QBZ_EVENT
+	exit 0
+fi
+
+# qbzd forks this script once per event without waiting so invocations can
+# overlap: serialize them (and their cfg_system updates) to preserve ordering
+exec 9> /tmp/qbzevent.lock
+flock 9
+
+# cfg_system (rows come back in id order)
+RESULT=$(sqlite3 -cmd '.timeout 5000' $SQLDB "SELECT value FROM cfg_system WHERE param IN ('alsavolume_max','alsavolume','amixname','camilladsp_volume_sync','inpactive','multiroom_tx','rsmafterqbz','qbzactive') ORDER BY id")
+readarray -t arr <<<"$RESULT"
+ALSAVOLUME_MAX=${arr[0]}
+ALSAVOLUME=${arr[1]}
+AMIXNAME=${arr[2]}
+CDSP_VOLSYNC=${arr[3]}
+INPACTIVE=${arr[4]}
+MULTIROOM_TX=${arr[5]}
+RSMAFTERQBZ=${arr[6]}
+QBZACTIVE=${arr[7]}
+RX_ADDRESSES=$(sudo moodeutl -d -gv rx_addresses)
+
+if [[ $INPACTIVE == '1' ]]; then
+	exit 1
+fi
+
+activate () {
+	if [[ $QBZACTIVE == '1' ]]; then
+		return 0
+	fi
+	QBZACTIVE='1'
+	$(sqlite3 -cmd '.timeout 5000' $SQLDB "UPDATE cfg_system SET value='1' WHERE param='qbzactive'")
+	# Take over the audio device
+	/usr/bin/mpc stop > /dev/null
+	# Send to front-end
+	/var/www/util/send-fecmd.php "qbzactive1"
+	# Arm the failed-start retry budget, but never replenish it here: a retry
+	# goes through loading (re-activation) again and would otherwise reset its
+	# own budget. Only a real start (TrackStarted) replenishes.
+	if [[ ! -f $RETRY_FILE ]]; then
+		echo $RETRY_BUDGET > $RETRY_FILE
+	fi
+
+	# Local
+	if [[ $CDSP_VOLSYNC == "on" ]]; then
+		# Set 0dB CDSP volume
+		sed -i '0,/- -.*/s//- 0.0/' /var/lib/cdsp/statefile.yml
+	elif [[ $ALSAVOLUME != "none" ]]; then
+		# Set 0dB ALSA volume
+		/var/www/util/sysutil.sh set-alsavol "$AMIXNAME" $ALSAVOLUME_MAX
+	fi
+
+	# Multiroom receivers
+	if [[ $MULTIROOM_TX == "On" ]]; then
+		for IP_ADDR in $RX_ADDRESSES; do
+			RESULT=$(curl -G -S -s --data-urlencode "cmd=trx_control -set-alsavol" http://$IP_ADDR/command/)
+			if [[ $RESULT != "" ]]; then
+				RESULT=$(curl -G -S -s --data-urlencode "cmd=trx_control -set-alsavol" http://$IP_ADDR/command/)
+				if [[ $RESULT != "" ]]; then
+					echo $(date +%F" "%T) "Event: trx_control -set-alsavol failed: $IP_ADDR" >> $LOGFILE
+				fi
+			fi
+		done
+	fi
+}
+
+deactivate () {
+	if [[ $QBZACTIVE == '0' ]]; then
+		return 0
+	fi
+	QBZACTIVE='0'
+	# Worker picks this up and sends qbzactive0 to front-end
+	$(sqlite3 -cmd '.timeout 5000' $SQLDB "UPDATE cfg_system SET value='0' WHERE param='qbzactive'")
+	# NOTE: the retry budget survives deactivation on purpose. A failed start
+	# arrives as loading -> paused -> PlaybackError, so the budget must still
+	# be there when the PlaybackError event is processed after the pause.
+
+	# Local
+	/var/www/util/vol.sh -restore
+
+	if [[ $CDSP_VOLSYNC == "on" ]]; then
+		# Restore CDSP volume
+		systemctl restart mpd2cdspvolume
+	fi
+
+	# Multiroom receivers
+	if [[ $MULTIROOM_TX == "On" ]]; then
+		for IP_ADDR in $RX_ADDRESSES; do
+			RESULT=$(curl -G -S -s --data-urlencode "cmd=set_volume -restore" http://$IP_ADDR/command/)
+			if [[ $RESULT != "" ]]; then
+				RESULT=$(curl -G -S -s --data-urlencode "cmd=set_volume -restore" http://$IP_ADDR/command/)
+				if [[ $RESULT != "" ]]; then
+					echo $(date +%F" "%T) "Event: set_volume -restore failed: $IP_ADDR" >> $LOGFILE
+				fi
+			fi
+		done
+	fi
+}
+
+if [[ $QBZ_EVENT == "PlaybackStateChanged" ]]; then
+	if [[ $QBZ_STATE == "playing" || $QBZ_STATE == "loading" ]]; then
+		activate
+	elif [[ $QBZ_STATE == "paused" || $QBZ_STATE == "stopped" ]]; then
+		deactivate
+	fi
+fi
+
+if [[ $QBZ_EVENT == "QconnectSessionChanged" ]]; then
+	if [[ $QBZ_SESSION_ACTIVE == "false" ]]; then
+		WAS_ACTIVE=$QBZACTIVE
+		deactivate
+		# Session gone: no more start attempts to retry
+		rm -f $RETRY_FILE
+		if [[ $WAS_ACTIVE == '1' && $RSMAFTERQBZ == "Yes" ]]; then
+			/usr/bin/mpc play > /dev/null
+		fi
+	fi
+fi
+
+# A start attempt can fail because the audio device is still busy: retry
+if [[ $QBZ_EVENT == "PlaybackError" ]]; then
+	debug_log "Error:   "$QBZ_MESSAGE
+	RETRIES_LEFT=$(cat $RETRY_FILE 2> /dev/null || echo 0)
+	MPD_PLAYING=$(/usr/bin/mpc status | grep playing)
+	if [[ $RETRIES_LEFT -gt 0 && -z $MPD_PLAYING ]]; then
+		echo $((RETRIES_LEFT - 1)) > $RETRY_FILE
+		sleep 1
+		qbzd play -q
+	fi
+fi
+
+# Update metadata and send to front-end
+if [[ $QBZ_EVENT == "TrackStarted" ]]; then
+	activate
+	# Playback started: replenish the failed-start retry budget
+	echo $RETRY_BUDGET > $RETRY_FILE
+	SFORMAT="FLAC $QBZ_BIT_DEPTH/$QBZ_SAMPLE_RATE kHz"
+	# Output format (post volume normalization/resampling) from the control API
+	OFORMAT=$(curl -s --max-time 2 $QBZD_API/api/now-playing | jq -r 'select(.playback.bit_depth != null) | "PCM \(.playback.bit_depth)/\(.playback.sample_rate / 1000) kHz"')
+	if [[ -z $OFORMAT ]]; then
+		OFORMAT=$SFORMAT
+	fi
+	METADATA_JSON=$(jq -n -c \
+		--arg a "update_qbzmeta" \
+		--arg b "$QBZ_TITLE" \
+		--arg c "$QBZ_ARTIST" \
+		--arg d "$QBZ_ALBUM" \
+		--arg e "$QBZ_DURATION" \
+		--arg f "$QBZ_COVER_URL" \
+		--arg g "$SFORMAT" \
+		--arg h "$OFORMAT" \
+		'{fecmd: $a, title: $b, artist: $c, album: $d, duration: $e, cover_url: $f, sformat: $g, oformat: $h}')
+	echo -e "$METADATA_JSON" > $QBZMETA_CACHE_FILE
+	/var/www/util/send-fecmd.php "$METADATA_JSON"
+fi

--- a/var/local/www/commandw/qbzevent.sh
+++ b/var/local/www/commandw/qbzevent.sh
@@ -111,8 +111,32 @@ activate () {
 	fi
 }
 
+# True while qbzd still owns playback: playing, or paused with a live Connect
+# session (the session keeps the audio device across a pause, AirPlay parity).
+# Fail-safe: an unreachable control API answers "not active" so a dead daemon
+# always releases the UI.
+still_active () {
+	local STATE
+	STATE=$(curl -s --max-time 2 $QBZD_API/api/status | \
+		jq -r '"\(.playback.state) \(.qconnect.session_active)"' 2>/dev/null)
+	case "$STATE" in
+		"playing true"|"paused true") return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
 deactivate () {
 	if [[ $QBZACTIVE == '0' ]]; then
+		return 0
+	fi
+	# Verify against the daemon before tearing the render down. Transient
+	# stopped/error events fire during normal operation — a gapless track
+	# transition, a superseded stream being abandoned on track change — and
+	# acting on them dropped the overlay mid-playback, so every later UI
+	# rebuild (click, resize, page load) showed the library panel instead.
+	debug_log "Deact?:  from $QBZ_EVENT (state=$QBZ_STATE session_active=$QBZ_SESSION_ACTIVE)"
+	if still_active; then
+		debug_log "Keep:    render (daemon still active)"
 		return 0
 	fi
 	QBZACTIVE='0'

--- a/var/local/www/db/moode-sqlite3.db.sql
+++ b/var/local/www/db/moode-sqlite3.db.sql
@@ -261,6 +261,7 @@ CREATE TABLE cfg_qobuz (id INTEGER PRIMARY KEY, param CHAR (32), value CHAR (32)
 INSERT INTO cfg_qobuz (id, param, value) VALUES (1, 'quality', 'hires_plus');
 INSERT INTO cfg_qobuz (id, param, value) VALUES (2, 'gapless', 'Yes');
 INSERT INTO cfg_qobuz (id, param, value) VALUES (3, 'normalize_volume', 'No');
+INSERT INTO cfg_qobuz (id, param, value) VALUES (4, 'pairing', 'Yes');
 
 -- Table: cfg_radio
 CREATE TABLE cfg_radio (id INTEGER PRIMARY KEY, station CHAR (128), name CHAR (128), type CHAR (1), logo CHAR (128), genre CHAR (32), broadcaster CHAR (32), language CHAR (32), country CHAR (32), region CHAR (32), bitrate CHAR (32), format CHAR (32), geo_fenced CHAR (3), home_page CHAR (32), monitor CHAR (32));

--- a/var/local/www/db/moode-sqlite3.db.sql
+++ b/var/local/www/db/moode-sqlite3.db.sql
@@ -263,7 +263,11 @@ INSERT INTO cfg_qobuz (id, param, value) VALUES (2, 'gapless', 'Yes');
 INSERT INTO cfg_qobuz (id, param, value) VALUES (3, 'normalize_volume', 'No');
 INSERT INTO cfg_qobuz (id, param, value) VALUES (4, 'pairing', 'Yes');
 INSERT INTO cfg_qobuz (id, param, value) VALUES (5, 'buffer_seconds', '2');
-INSERT INTO cfg_qobuz (id, param, value) VALUES (6, 'volume_mode', 'software');
+INSERT INTO cfg_qobuz (id, param, value) VALUES (6, 'volume_mode', 'auto');
+INSERT INTO cfg_qobuz (id, param, value) VALUES (7, 'output_mode', 'auto');
+INSERT INTO cfg_qobuz (id, param, value) VALUES (8, 'stream_first', 'Yes');
+INSERT INTO cfg_qobuz (id, param, value) VALUES (9, 'track_cache', 'No');
+INSERT INTO cfg_qobuz (id, param, value) VALUES (10, 'quality_fallback', 'fallback');
 
 -- Table: cfg_radio
 CREATE TABLE cfg_radio (id INTEGER PRIMARY KEY, station CHAR (128), name CHAR (128), type CHAR (1), logo CHAR (128), genre CHAR (32), broadcaster CHAR (32), language CHAR (32), country CHAR (32), region CHAR (32), bitrate CHAR (32), format CHAR (32), geo_fenced CHAR (3), home_page CHAR (32), monitor CHAR (32));

--- a/var/local/www/db/moode-sqlite3.db.sql
+++ b/var/local/www/db/moode-sqlite3.db.sql
@@ -266,7 +266,7 @@ INSERT INTO cfg_qobuz (id, param, value) VALUES (5, 'buffer_seconds', '2');
 INSERT INTO cfg_qobuz (id, param, value) VALUES (6, 'volume_mode', 'auto');
 INSERT INTO cfg_qobuz (id, param, value) VALUES (7, 'output_mode', 'auto');
 INSERT INTO cfg_qobuz (id, param, value) VALUES (8, 'stream_first', 'Yes');
-INSERT INTO cfg_qobuz (id, param, value) VALUES (9, 'track_cache', 'No');
+INSERT INTO cfg_qobuz (id, param, value) VALUES (9, 'track_cache', 'Yes');
 INSERT INTO cfg_qobuz (id, param, value) VALUES (10, 'quality_fallback', 'fallback');
 
 -- Table: cfg_radio

--- a/var/local/www/db/moode-sqlite3.db.sql
+++ b/var/local/www/db/moode-sqlite3.db.sql
@@ -256,6 +256,12 @@ INSERT INTO cfg_plugin (id, component, type, plugin, version) VALUES (3, 'render
 INSERT INTO cfg_plugin (id, component, type, plugin, version) VALUES (4, 'renderer', 'spotify-connect', 'v8-librespot', '0.8.0-1moode1');
 INSERT INTO cfg_plugin (id, component, type, plugin, version) VALUES (5, 'system', 'nqptp', 'v1-nqptp', '1.2.6-1moode1');
 
+-- Table: cfg_qobuz
+CREATE TABLE cfg_qobuz (id INTEGER PRIMARY KEY, param CHAR (32), value CHAR (32));
+INSERT INTO cfg_qobuz (id, param, value) VALUES (1, 'quality', 'hires_plus');
+INSERT INTO cfg_qobuz (id, param, value) VALUES (2, 'gapless', 'Yes');
+INSERT INTO cfg_qobuz (id, param, value) VALUES (3, 'normalize_volume', 'No');
+
 -- Table: cfg_radio
 CREATE TABLE cfg_radio (id INTEGER PRIMARY KEY, station CHAR (128), name CHAR (128), type CHAR (1), logo CHAR (128), genre CHAR (32), broadcaster CHAR (32), language CHAR (32), country CHAR (32), region CHAR (32), bitrate CHAR (32), format CHAR (32), geo_fenced CHAR (3), home_page CHAR (32), monitor CHAR (32));
 INSERT INTO cfg_radio (id, station, name, type, logo, genre, broadcaster, language, country, region, bitrate, format, geo_fenced, home_page, monitor) VALUES (1, 'http://strm112.1.fm/blues_mobile_mp3', '1.FM - Blues Radio', 'r', 'local', 'Blues', '1.FM', 'English', 'Switzerland', 'Europe', '192', 'MP3', 'No', '', 'No');
@@ -907,7 +913,7 @@ INSERT INTO cfg_system (id, param, value) VALUES (77, 'cardnum', '0');
 INSERT INTO cfg_system (id, param, value) VALUES (78, 'btsvc', '0');
 INSERT INTO cfg_system (id, param, value) VALUES (79, 'btname', 'Moode Bluetooth');
 INSERT INTO cfg_system (id, param, value) VALUES (80, 'camilladsp_volume_sync', 'off');
-INSERT INTO cfg_system (id, param, value) VALUES (81, 'feat_bitmask', '228279');
+INSERT INTO cfg_system (id, param, value) VALUES (81, 'feat_bitmask', '490423');
 INSERT INTO cfg_system (id, param, value) VALUES (82, 'library_recently_added', '2592000000');
 INSERT INTO cfg_system (id, param, value) VALUES (83, 'btactive', '0');
 INSERT INTO cfg_system (id, param, value) VALUES (84, 'deezersvc', '0');
@@ -1002,6 +1008,10 @@ INSERT INTO cfg_system (id, param, value) VALUES (172, 'library_onetouch_pl', 'S
 INSERT INTO cfg_system (id, param, value) VALUES (173, 'scnsaver_mode', 'Cover art');
 INSERT INTO cfg_system (id, param, value) VALUES (174, 'scnsaver_layout', 'Default');
 INSERT INTO cfg_system (id, param, value) VALUES (175, 'scnsaver_xmeta', 'Yes');
+INSERT INTO cfg_system (id, param, value) VALUES (176, 'rsmafterqbz', 'No');
+INSERT INTO cfg_system (id, param, value) VALUES (177, 'qbzactive', '0');
+INSERT INTO cfg_system (id, param, value) VALUES (178, 'qobuzsvc', '0');
+INSERT INTO cfg_system (id, param, value) VALUES (179, 'qobuzname', 'Moode Qobuz');
 
 -- Table: cfg_theme
 CREATE TABLE cfg_theme (id INTEGER PRIMARY KEY, theme_name CHAR (32), tx_color CHAR (32), bg_color CHAR (32), mbg_color CHAR (32));

--- a/var/local/www/db/moode-sqlite3.db.sql
+++ b/var/local/www/db/moode-sqlite3.db.sql
@@ -262,6 +262,8 @@ INSERT INTO cfg_qobuz (id, param, value) VALUES (1, 'quality', 'hires_plus');
 INSERT INTO cfg_qobuz (id, param, value) VALUES (2, 'gapless', 'Yes');
 INSERT INTO cfg_qobuz (id, param, value) VALUES (3, 'normalize_volume', 'No');
 INSERT INTO cfg_qobuz (id, param, value) VALUES (4, 'pairing', 'Yes');
+INSERT INTO cfg_qobuz (id, param, value) VALUES (5, 'buffer_seconds', '2');
+INSERT INTO cfg_qobuz (id, param, value) VALUES (6, 'volume_mode', 'software');
 
 -- Table: cfg_radio
 CREATE TABLE cfg_radio (id INTEGER PRIMARY KEY, station CHAR (128), name CHAR (128), type CHAR (1), logo CHAR (128), genre CHAR (32), broadcaster CHAR (32), language CHAR (32), country CHAR (32), region CHAR (32), bitrate CHAR (32), format CHAR (32), geo_fenced CHAR (3), home_page CHAR (32), monitor CHAR (32));

--- a/www/CONTRIBS.html
+++ b/www/CONTRIBS.html
@@ -93,6 +93,8 @@
 		<a href="https://github.com/project-owner" target="_blank">https://github.com/project-owner</a><br>
 		Pleezer by Roderick Van Domburg<br>
 		<a href="https://github.com/roderickvd/pleezer" target="_blank">https://github.com/roderickvd/pleezer</a><br>
+		QBZ (qbzd) by vicrodh<br>
+		<a href="https://github.com/vicrodh/qbz" target="_blank">https://github.com/vicrodh/qbz</a><br>
 		Qix color-convert by Heather Arthur and Josh Junon<br>
 		<a href="https://github.com/Qix-/color-convert" target="_blank">https://github.com/Qix-/color-convert</a><br>
 		RPi.GPIO by Ben Croston<br>

--- a/www/CONTRIBS.html
+++ b/www/CONTRIBS.html
@@ -93,8 +93,8 @@
 		<a href="https://github.com/project-owner" target="_blank">https://github.com/project-owner</a><br>
 		Pleezer by Roderick Van Domburg<br>
 		<a href="https://github.com/roderickvd/pleezer" target="_blank">https://github.com/roderickvd/pleezer</a><br>
-		QBZ (qbzd) by vicrodh<br>
-		<a href="https://github.com/vicrodh/qbz" target="_blank">https://github.com/vicrodh/qbz</a><br>
+		QBZ (qbzd) by vicrodh, forker by Filippo Vicentini<br>
+		<a href="https://github.com/PhilipVinc/qbz" target="_blank">https://github.com/PhilipVinc/qbz</a><br>
 		Qix color-convert by Heather Arthur and Josh Junon<br>
 		<a href="https://github.com/Qix-/color-convert" target="_blank">https://github.com/Qix-/color-convert</a><br>
 		RPi.GPIO by Ben Croston<br>

--- a/www/audioinfo.php
+++ b/www/audioinfo.php
@@ -33,6 +33,7 @@ $btActive = ($_SESSION['audioout'] == 'Local' && strpos($result[0], 'bluealsa-ap
 $aplActive = sqlQuery("SELECT value FROM cfg_system WHERE param='aplactive'", $dbh)[0]['value'];
 $spotActive = sqlQuery("SELECT value FROM cfg_system WHERE param='spotactive'", $dbh)[0]['value'];
 $deezActive = sqlQuery("SELECT value FROM cfg_system WHERE param='deezactive'", $dbh)[0]['value'];
+$qbzActive = sqlQuery("SELECT value FROM cfg_system WHERE param='qbzactive'", $dbh)[0]['value'];
 $slActive = sqlQuery("SELECT value FROM cfg_system WHERE param='slactive'", $dbh)[0]['value'];
 $paActive = sqlQuery("SELECT value FROM cfg_system WHERE param='paactive'", $dbh)[0]['value'];
 $rbActive = sqlQuery("SELECT value FROM cfg_system WHERE param='rbactive'", $dbh)[0]['value'];
@@ -72,6 +73,12 @@ if ($btActive === true && $_SESSION['audioout'] == 'Local') {
 } else if ($deezActive == '1') {
 	$_file = 'Deezer stream';
 	$metadata = json_decode(file_get_contents(DEEZMETA_CACHE_FILE), true);
+	$_encoded_at = $metadata['sformat'];
+	$_decoded_to = $metadata['oformat'];
+	$_decode_rate = '';
+} else if ($qbzActive == '1') {
+	$_file = 'Qobuz stream';
+	$metadata = json_decode(file_get_contents(QBZMETA_CACHE_FILE), true);
 	$_encoded_at = $metadata['sformat'];
 	$_decoded_to = $metadata['oformat'];
 	$_decode_rate = '';
@@ -181,6 +188,8 @@ if ($btActive === true) {
 	$renderer = 'Spotify Connect &rarr; ';
 } else if ($deezActive == '1') {
 	$renderer = 'Deezer Connect &rarr; ';
+} else if ($qbzActive == '1') {
+	$renderer = 'Qobuz Connect &rarr; ';
 } else if ($slActive == '1') {
 	$renderer = 'Squeezelite &rarr; ';
 } else if ($paActive == '1') {
@@ -268,7 +277,7 @@ $alsaVol = getAlsaVolumeDb($_SESSION['amixname']);
 $cdspVol = CamillaDSP::getCDSPVol() . 'dB';
 $_volume_levels = 'Knob ' . $knobVol . ', ALSA ' . $alsaVol . ', CDSP ' . $cdspVol;
 
-if ($aplActive == '1' || $spotActive == '1' || $deezActive == '1' || $slActive == '1' || $paActive == '1' || $rbActive == '1' ||
+if ($aplActive == '1' || $spotActive == '1' || $deezActive == '1' || $qbzActive == '1' || $slActive == '1' || $paActive == '1' || $rbActive == '1' ||
 	$btActive === true || $_SESSION['audioout'] == 'Bluetooth' || $_SESSION['inpactive'] == '1') {
 	// Renderer active
 	// NOTE: Class 'off' hides the item
@@ -280,7 +289,7 @@ if ($aplActive == '1' || $spotActive == '1' || $deezActive == '1' || $slActive =
 	$_replaygain = 'off';
 	$_vol_normalize = 'off';
 
-	if ($aplActive == '1' || $spotActive == '1' || $deezActive == '1') {
+	if ($aplActive == '1' || $spotActive == '1' || $deezActive == '1' || $qbzActive == '1') {
 		$_peq = $_SESSION['eqfa12p'] == 'Off' ? 'off' : $_SESSION['eqfa12p'];
 		$_geq = $_SESSION['alsaequal'] == 'Off' ? 'off' : $_SESSION['alsaequal'];
         $_camilladsp = getCamillaDspConfigName($_SESSION['camilladsp']);

--- a/www/audioinfo.php
+++ b/www/audioinfo.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/inc/common.php';
 require_once __DIR__ . '/inc/alsa.php';
 require_once __DIR__ . '/inc/cdsp.php';
 require_once __DIR__ . '/inc/mpd.php';
+require_once __DIR__ . '/inc/renderer.php';
 require_once __DIR__ . '/inc/music-library.php';
 require_once __DIR__ . '/inc/session.php';
 require_once __DIR__ . '/inc/sql.php';
@@ -224,6 +225,19 @@ if ($_SESSION['invert_polarity'] == '1') {
 }
 
 $outputModeName = ALSA_OUTPUT_MODE_NAME[$_SESSION['alsa_output_mode']];
+
+// Qobuz Connect routed straight to the DAC does not pass through moOde's chain
+// at all, so the DSP stages and output mode above describe something that is
+// not in the signal path. Replace them with what qbzd actually opened.
+if ($qbzActive == '1') {
+	$qbzRouting = qobuzDirectRouting();
+	if ($qbzRouting['direct']) {
+		$dsp = '';
+		$peppyAlsa = '';
+		$outputMode = 'hw';
+		$outputModeName = ALSA_OUTPUT_MODE_NAME['hw'];
+	}
+}
 
 // Peppy ALSA
 $peppyAlsa = ($_SESSION['peppy_display'] == '1' || $_SESSION['enable_peppyalsa'] == '1') ? 'PeppyALSA &rarr; ' : '';

--- a/www/command/renderer.php
+++ b/www/command/renderer.php
@@ -33,7 +33,7 @@ switch ($_GET['cmd']) {
 	 	}
 		phpSession('close');
 
-	 	// AirPlay, Spotify Connect, Deezer Connect and RoonBridge are session based, they can be restarted to effect a disconnect
+	 	// AirPlay, Spotify Connect, Deezer Connect, Qobuz Connect and RoonBridge are session based, they can be restarted to effect a disconnect
 	 	// NOTE: 'disconnect_renderer' is passed to worker so MPD play can be resumed if indicated
 	 	if (submitJob($_POST['job'], $_GET['cmd'])) {
 	 		echo json_encode('job submitted');
@@ -48,6 +48,9 @@ switch ($_GET['cmd']) {
 		break;
 	case 'get_deezmeta':
 		echo trim(file_get_contents(DEEZMETA_CACHE_FILE));
+		break;
+	case 'get_qbzmeta':
+		echo trim(file_get_contents(QBZMETA_CACHE_FILE));
 		break;
 	case 'get_spotmeta':
 		echo trim(file_get_contents(SPOTMETA_CACHE_FILE));

--- a/www/daemon/watchdog.sh
+++ b/www/daemon/watchdog.sh
@@ -18,6 +18,7 @@ FPM_MIN_LIMIT=32
 FPM_CNT=$(pgrep -c -f "php-fpm: pool www")
 MPD_RUNNING=$(pgrep -c -x "mpd")
 SPOTIFY_RUNNING=$(pgrep -c -x "librespot")
+QOBUZ_RUNNING=$(pgrep -c -x "qbzd")
 AIRPLAY_RUNNING=$(pgrep -c -f "LC_ALL=C /usr/bin/shairport-sync")
 TRX_RX_RUNNING=$(pgrep -c -x "trx-rx")
 
@@ -123,6 +124,24 @@ while true; do
 		fi
 	fi
 
+	# Qobuz Connect
+	QOBUZ_SVC=$(sqlite3 $SQLDB "SELECT value FROM cfg_system WHERE param='qobuzsvc'")
+	if [[ $QOBUZ_SVC = "1" ]]; then
+		if [[ $QOBUZ_RUNNING = 0 ]]; then
+			counter=0
+			while [ $counter -lt 3 ]; do
+				sleep 1
+				QOBUZ_RUNNING=$(pgrep -c -x qbzd)
+				if [[ $QOBUZ_RUNNING != 0 ]]; then break; fi
+				((counter++))
+			done
+			if [[ $QOBUZ_RUNNING = 0 ]]; then
+				message_log "CRITICAL ERROR: Restarted Qobuz Connect after crash detected"
+				moodeutl -R --qobuz
+			fi
+		fi
+	fi
+
 	# Multiroom receiver
 	MULTIROOM_RX=$(sqlite3 $SQLDB "SELECT value FROM cfg_system WHERE param='multiroom_rx'")
 	if [[ $MULTIROOM_RX = "On" ]]; then
@@ -182,6 +201,7 @@ while true; do
 	FPM_CNT=$(pgrep -c -f "php-fpm: pool www")
 	MPD_RUNNING=$(pgrep -c -x "mpd")
 	SPOTIFY_RUNNING=$(pgrep -c -x "librespot")
+	QOBUZ_RUNNING=$(pgrep -c -x "qbzd")
 	AIRPLAY_RUNNING=$(pgrep -c -f "LC_ALL=C /usr/bin/shairport-sync")
 	TRX_RX_RUNNING=$(pgrep -c -x "trx-rx")
 

--- a/www/daemon/worker.php
+++ b/www/daemon/worker.php
@@ -187,6 +187,7 @@ sysCmd('touch ' . DASHBOARD_CACHE_FILE);
 sysCmd('touch ' . SHAIRPORT_SYNC_LOG);
 sysCmd('touch ' . LIBRESPOT_LOG);
 sysCmd('touch ' . PLEEZER_LOG);
+sysCmd('touch ' . QBZD_LOG);
 sysCmd('touch ' . SPOTEVENT_LOG);
 sysCmd('touch ' . DEEZEVENT_LOG);
 sysCmd('touch ' . SPSEVENT_LOG);
@@ -212,6 +213,7 @@ sysCmd('chmod 0666 /var/local/www/sysinfo.txt');
 sysCmd('chmod 0666 ' . SHAIRPORT_SYNC_LOG);
 sysCmd('chmod 0666 ' . LIBRESPOT_LOG);
 sysCmd('chmod 0666 ' . PLEEZER_LOG);
+sysCmd('chmod 0666 ' . QBZD_LOG);
 sysCmd('chmod 0666 ' . SPOTEVENT_LOG);
 sysCmd('chmod 0666 ' . DEEZEVENT_LOG);
 sysCmd('chmod 0666 ' . SPSEVENT_LOG);
@@ -277,6 +279,7 @@ if ($importedHostName != $_SESSION['hostname']) { // != 'moode'
 	airplayname		Moode AirPlay
 	spotifyname		Moode Spotify
 	deezername		Moode Deezer
+	qobuzname		Moode Qobuz
 	upnpname		Moode UPNP
 	dlnaname		Moode DLNA
 	squeezelite		Moode		In cfg_sl PLAYERNAME and squeezelite.conf, no session var
@@ -296,6 +299,8 @@ if ($importedHostName != $_SESSION['hostname']) { // != 'moode'
 	phpSession('write', 'spotifyname', ucfirst($importedHostName) . ' Spotify');
 	// Deezer Connect
 	phpSession('write', 'deezername', ucfirst($importedHostName) . ' Deezer');
+	// Qobuz Connect
+	phpSession('write', 'qobuzname', ucfirst($importedHostName) . ' Qobuz');
 	// Squeezelite
 	$newName = ucfirst($importedHostName);
 	$result = sqlQuery("UPDATE cfg_sl SET value='" . $newName . "' WHERE param='PLAYERNAME'", $dbh);
@@ -1160,6 +1165,23 @@ if ($_SESSION['feat_bitmask'] & FEAT_DEEZER) {
 }
 workerLog('worker: Deezer Connect:  ' . $status);
 
+// Start Qobuz Connect renderer
+if ($_SESSION['feat_bitmask'] & FEAT_QOBUZ) {
+	if (isQobuzInstalled()) {
+		if (isset($_SESSION['qobuzsvc']) && $_SESSION['qobuzsvc'] == 1) {
+			$status = 'started';
+			startQobuz();
+		} else {
+			$status = 'available';
+		}
+	} else {
+		$status = 'not installed';
+	}
+} else {
+	$status = 'n/a';
+}
+workerLog('worker: Qobuz Connect:   ' . $status);
+
 // Start Squeezelite renderer
 if ($_SESSION['feat_bitmask'] & FEAT_SQUEEZELITE) {
 	if (isset($_SESSION['slsvc']) && $_SESSION['slsvc'] == 1) {
@@ -1599,7 +1621,7 @@ if (chkRendererActive() === true) {
 	phpSession('write', 'volknob', '0');
 	sysCmd('/var/www/util/vol.sh 0');
 	$result = sqlQuery("UPDATE cfg_system SET value='0' WHERE param='btactive' OR param='aplactive' OR
-		param='spotactive' OR param='deezactive' OR param='slactive' OR param='paactive' OR param='rbactive' OR
+		param='spotactive' OR param='deezactive' OR param='qbzactive' OR param='slactive' OR param='paactive' OR param='rbactive' OR
 		param='inpactive'", $dbh);
 	workerLog('worker: Active flags:         at least one true');
 	workerLog('worker: Reset flags:          all reset to false');
@@ -1701,6 +1723,9 @@ $clkradio_stop_days = explode(',', substr($_SESSION['clkradio_stop'], 9));
 $aplactive = '0';
 $spotactive = '0';
 $deezactive = '0';
+$qbzactive = '0';
+$qbztrackid = '';
+$qbzretry = 0;
 $slactive = '0';
 $paactive = '0';
 $rbactive = '0';
@@ -1938,6 +1963,10 @@ while (true) {
 	if ($_SESSION['deezersvc'] == '1') {
 		//debugLog('** chkDeezActive');
 		chkDeezActive();
+	}
+	if ($_SESSION['qobuzsvc'] == '1') {
+		//debugLog('** chkQbzActive');
+		chkQbzActive();
 	}
 	if ($_SESSION['slsvc'] == '1') {
 		//debugLog('** chkSlActive');
@@ -2183,6 +2212,85 @@ function chkDeezActive() {
 		}
 	}
 }
+// Qobuz Connect
+function chkQbzActive() {
+	// qbzd has no event hook facility so poll its control API
+	$result = sysCmd('curl -s --max-time 2 http://127.0.0.1:8182/api/status');
+	$status = json_decode(implode('', $result), true);
+	if (is_null($status) || !isset($status['playback']['state'])) {
+		return;
+	}
+	$state = $status['playback']['state'];
+
+	if ($state == 'playing' || $state == 'loading' || $state == 'buffering') {
+		// Do this section only once
+		if ($GLOBALS['qbzactive'] == '0') {
+			$GLOBALS['qbzactive'] = '1';
+			phpSession('write', 'qbzactive', '1');
+			$GLOBALS['scnsaver_timeout'] = $_SESSION['scnsaver_timeout'];
+			sendFECmd('qbzactive1');
+			// Take over the audio device
+			if (!empty(sysCmd('mpc status | grep playing')[0])) {
+				sysCmd('mpc stop');
+			}
+			if ($_SESSION['alsavolume'] != 'none') {
+				setALSAVolTo0dB($_SESSION['alsavolume_max']);
+			}
+			// Budget for retrying a start that failed because the device was still busy
+			$GLOBALS['qbzretry'] = 5;
+		} else if ($state == 'playing' && !empty(sysCmd('mpc status | grep playing')[0])) {
+			// MPD was started while Qobuz is playing: yield the device
+			sysCmd('qbzd pause -q');
+		}
+		// Update metadata after a track change
+		if ($state == 'playing' && $GLOBALS['qbztrackid'] !== $status['playback']['track_id']) {
+			$GLOBALS['qbztrackid'] = $status['playback']['track_id'];
+			updQbzMeta();
+		}
+	} else {
+		if ($GLOBALS['qbzactive'] == '1') {
+			// A start attempt that immediately drops back to paused means qbzd could not
+			// open the audio device (e.g. shairport-sync releasing it late): retry
+			if ($state == 'paused' && $GLOBALS['qbzretry'] > 0 && empty(sysCmd('mpc status | grep playing')[0])) {
+				$GLOBALS['qbzretry'] = $GLOBALS['qbzretry'] - 1;
+				sysCmd('qbzd play -q');
+				return;
+			}
+			// Do this section only once
+			$GLOBALS['qbzactive'] = '0';
+			$GLOBALS['qbztrackid'] = '';
+			phpSession('write', 'qbzactive', '0');
+			sendFECmd('qbzactive0');
+			sysCmd('/var/www/util/vol.sh -restore');
+			if ($status['qconnect']['session_active'] === false && $_SESSION['rsmafterqbz'] == 'Yes') {
+				sysCmd('mpc play');
+			}
+		}
+	}
+}
+
+function updQbzMeta() {
+	$result = sysCmd('curl -s --max-time 2 http://127.0.0.1:8182/api/now-playing');
+	$nowPlaying = json_decode(implode('', $result), true);
+	if (is_null($nowPlaying) || !isset($nowPlaying['track'])) {
+		return;
+	}
+	$track = $nowPlaying['track'];
+	$playback = $nowPlaying['playback'];
+	$metadata = array(
+		'fecmd' => 'update_qbzmeta',
+		'title' => $track['title'],
+		'artist' => $track['artist'],
+		'album' => $track['album'],
+		'duration' => $track['duration_secs'],
+		'cover_url' => $track['artwork_url'],
+		'sformat' => 'FLAC ' . $track['bit_depth'] . '/' . $track['sample_rate'] . ' kHz',
+		'oformat' => 'PCM ' . $playback['bit_depth'] . '/' . ($playback['sample_rate'] / 1000) . ' kHz'
+	);
+	$metadataJson = json_encode($metadata, JSON_UNESCAPED_SLASHES);
+	file_put_contents(QBZMETA_CACHE_FILE, $metadataJson);
+	sysCmd('/var/www/util/send-fecmd.php ' . escapeshellarg($metadataJson));
+}
 // Squeezelite
 function chkSlActive() {
 	// Get directly from sql since external slpower.sh script does not update the session
@@ -2234,7 +2342,7 @@ function chkRbActive() {
 	$result = sysCmd('pgrep -c mono-sgen');
 	if ($result[0] > 0) {
 		$rendererNotActive = ($_SESSION['btactive'] == '0' && $GLOBALS['aplactive'] == '0' && $GLOBALS['spotactive'] == '0'
-			&& $GLOBALS['deezactive'] == '0' && $GLOBALS['slactive'] == '0' && $_SESSION['paactive']
+			&& $GLOBALS['deezactive'] == '0' && $GLOBALS['qbzactive'] == '0' && $GLOBALS['slactive'] == '0' && $_SESSION['paactive']
 			&& $_SESSION['rxactive'] == '0' && $GLOBALS['inpactive'] == '0');
 		$mpdNotPlaying = empty(sysCmd('mpc status | grep playing')[0]) ? true : false;
 		$alsaOutputActive = sysCmd('cat /proc/asound/card' . $_SESSION['cardnum'] . '/pcm0p/sub0/hw_params')[0] == 'closed' ? false : true;
@@ -2573,6 +2681,8 @@ function updExtMetaFile() {
 		$renderer = 'Spotify Active';
 	} else if ($GLOBALS['deezactive'] == '1') {
 		$renderer = 'Deezer Active';
+	} else if ($GLOBALS['qbzactive'] == '1') {
+		$renderer = 'Qobuz Active';
 	} else if ($GLOBALS['slactive'] == '1') {
 		$renderer = 'Squeezelite Active';
 	} else if ($GLOBALS['rbactive'] == '1') {
@@ -3026,6 +3136,10 @@ function runQueuedJob() {
 					stopDeezer();
 					startDeezer();
 				}
+				if ($_SESSION['qobuzsvc'] == 1) {
+					stopQobuz();
+					startQobuz();
+				}
 				if ($_SESSION['slsvc'] == 1) {
 					stopSqueezelite();
 					cfgSqueezelite();
@@ -3087,6 +3201,10 @@ function runQueuedJob() {
 				if ($_SESSION['deezersvc'] == 1) {
 					stopDeezer();
 					startDeezer();
+				}
+				if ($_SESSION['qobuzsvc'] == 1) {
+					stopQobuz();
+					startQobuz();
 				}
 				if ($_SESSION['slsvc'] == 1) {
 					stopSqueezelite();
@@ -3217,6 +3335,10 @@ function runQueuedJob() {
 				stopDeezer();
 				startDeezer();
 			}
+			if ($_SESSION['qobuzsvc'] == 1) {
+				stopQobuz();
+				startQobuz();
+			}
 			// Reenable HTTP server (if indicated)
 			setMpdHttpd();
 
@@ -3309,6 +3431,33 @@ function runQueuedJob() {
 			if ($_SESSION['w_queueargs'] == 'disconnect_renderer' && $_SESSION['rsmafterdeez'] == 'Yes') {
 				sysCmd('mpc play');
 			}
+			break;
+		case 'qobuzsvc':
+			stopQobuz();
+			if ($_SESSION['qobuzsvc'] == 1) {
+				startQobuz();
+			}
+
+			if ($_SESSION['w_queueargs'] == 'disconnect_renderer' && $_SESSION['rsmafterqbz'] == 'Yes') {
+				sysCmd('mpc play');
+			}
+			break;
+		case 'install_qobuz':
+			$fullLog = $_SESSION['home_dir'] . '/install_qobuz.log';
+			sysCmd('rm "' . $fullLog . '"');
+			sysCmd('/var/www/util/qobuz-installer.sh > "' . $fullLog . '" 2>&1 &');
+			break;
+		case 'qobuz_login':
+			// One-shot OAuth listener: prints the login URL to the log then waits
+			// for the browser callback. The URL is shown on the Qobuz Config screen.
+			// NOTE: exec -a requires bash (sysCmd runs sh) and sets argv[0] so use pkill -f
+			sysCmd('pkill -f qbzd-login 2> /dev/null');
+			$ipAddr = sysCmd("hostname -I | awk '{print $1}'")[0];
+			sysCmd('truncate ' . QOBUZ_LOGIN_LOG . ' --size 0');
+			sysCmd("bash -c 'exec -a qbzd-login qbzd login --callback-host " . $ipAddr . ' > ' . QOBUZ_LOGIN_LOG . " 2>&1 &'");
+			break;
+		case 'qobuz_logout':
+			sysCmd('qbzd logout');
 			break;
 		case 'slsvc':
 			if ($_SESSION['slsvc'] == '1') {
@@ -3413,6 +3562,10 @@ function runQueuedJob() {
 			if ($_SESSION['deezersvc'] == 1) {
 				stopDeezer();
 				startDeezer();
+			}
+			if ($_SESSION['qobuzsvc'] == 1) {
+				stopQobuz();
+				startQobuz();
 			}
 			break;
 		case 'multiroom_tx_restart':

--- a/www/daemon/worker.php
+++ b/www/daemon/worker.php
@@ -1724,8 +1724,6 @@ $aplactive = '0';
 $spotactive = '0';
 $deezactive = '0';
 $qbzactive = '0';
-$qbztrackid = '';
-$qbzretry = 0;
 $slactive = '0';
 $paactive = '0';
 $rbactive = '0';
@@ -2214,82 +2212,33 @@ function chkDeezActive() {
 }
 // Qobuz Connect
 function chkQbzActive() {
-	// qbzd has no event hook facility so poll its control API
-	$result = sysCmd('curl -s --max-time 2 http://127.0.0.1:8182/api/status');
-	$status = json_decode(implode('', $result), true);
-	if (is_null($status) || !isset($status['playback']['state'])) {
-		return;
-	}
-	$state = $status['playback']['state'];
-
-	if ($state == 'playing' || $state == 'loading' || $state == 'buffering') {
+	// Get directly from SQL since qbzevent.sh script can't update the session
+	$result = sqlQuery("SELECT value FROM cfg_system WHERE param='qbzactive'", $GLOBALS['dbh']);
+	if ($result[0]['value'] == '1') {
 		// Do this section only once
 		if ($GLOBALS['qbzactive'] == '0') {
 			$GLOBALS['qbzactive'] = '1';
-			phpSession('write', 'qbzactive', '1');
 			$GLOBALS['scnsaver_timeout'] = $_SESSION['scnsaver_timeout'];
-			sendFECmd('qbzactive1');
-			// Take over the audio device
-			if (!empty(sysCmd('mpc status | grep playing')[0])) {
-				sysCmd('mpc stop');
-			}
-			if ($_SESSION['alsavolume'] != 'none') {
-				setALSAVolTo0dB($_SESSION['alsavolume_max']);
-			}
-			// Budget for retrying a start that failed because the device was still busy
-			$GLOBALS['qbzretry'] = 5;
-		} else if ($state == 'playing' && !empty(sysCmd('mpc status | grep playing')[0])) {
-			// MPD was started while Qobuz is playing: yield the device
+			// NOTE: This is now done by the qbzevent.sh script
+			//sendFECmd('qbzactive1');
+		} else if (!empty(sysCmd('mpc status | grep playing')[0])) {
+			// MPD started while Qobuz is playing: pause Qobuz so the two never
+			// fight over the audio device (most-recent-wins). The Qobuz Active
+			// overlay already blocks MPD starts from the UI, but not from paths
+			// that bypass it: external MPD clients, mpc from a shell, or the
+			// Alarm clock. Other renderers keep the device and let the MPD play
+			// attempt fail; Qobuz yields instead. This has to live here rather
+			// than in qbzevent.sh because the trigger is an MPD-side action
+			// that qbzd cannot emit an event for.
 			sysCmd('qbzd pause -q');
 		}
-		// Update metadata after a track change
-		if ($state == 'playing' && $GLOBALS['qbztrackid'] !== $status['playback']['track_id']) {
-			$GLOBALS['qbztrackid'] = $status['playback']['track_id'];
-			updQbzMeta();
-		}
 	} else {
+		// Do this section only once
 		if ($GLOBALS['qbzactive'] == '1') {
-			// A start attempt that immediately drops back to paused means qbzd could not
-			// open the audio device (e.g. shairport-sync releasing it late): retry
-			if ($state == 'paused' && $GLOBALS['qbzretry'] > 0 && empty(sysCmd('mpc status | grep playing')[0])) {
-				$GLOBALS['qbzretry'] = $GLOBALS['qbzretry'] - 1;
-				sysCmd('qbzd play -q');
-				return;
-			}
-			// Do this section only once
 			$GLOBALS['qbzactive'] = '0';
-			$GLOBALS['qbztrackid'] = '';
-			phpSession('write', 'qbzactive', '0');
 			sendFECmd('qbzactive0');
-			sysCmd('/var/www/util/vol.sh -restore');
-			if ($status['qconnect']['session_active'] === false && $_SESSION['rsmafterqbz'] == 'Yes') {
-				sysCmd('mpc play');
-			}
 		}
 	}
-}
-
-function updQbzMeta() {
-	$result = sysCmd('curl -s --max-time 2 http://127.0.0.1:8182/api/now-playing');
-	$nowPlaying = json_decode(implode('', $result), true);
-	if (is_null($nowPlaying) || !isset($nowPlaying['track'])) {
-		return;
-	}
-	$track = $nowPlaying['track'];
-	$playback = $nowPlaying['playback'];
-	$metadata = array(
-		'fecmd' => 'update_qbzmeta',
-		'title' => $track['title'],
-		'artist' => $track['artist'],
-		'album' => $track['album'],
-		'duration' => $track['duration_secs'],
-		'cover_url' => $track['artwork_url'],
-		'sformat' => 'FLAC ' . $track['bit_depth'] . '/' . $track['sample_rate'] . ' kHz',
-		'oformat' => 'PCM ' . $playback['bit_depth'] . '/' . ($playback['sample_rate'] / 1000) . ' kHz'
-	);
-	$metadataJson = json_encode($metadata, JSON_UNESCAPED_SLASHES);
-	file_put_contents(QBZMETA_CACHE_FILE, $metadataJson);
-	sysCmd('/var/www/util/send-fecmd.php ' . escapeshellarg($metadataJson));
 }
 // Squeezelite
 function chkSlActive() {

--- a/www/daemon/worker.php
+++ b/www/daemon/worker.php
@@ -3408,6 +3408,17 @@ function runQueuedJob() {
 		case 'qobuz_logout':
 			sysCmd('qbzd logout');
 			break;
+		case 'qobuz_clear_credentials':
+			// Same effect as Logout on the Qobuz Config screen, but reachable
+			// when the daemon reports needs_auth and the Logout button is
+			// therefore hidden — which is exactly the state a stale or
+			// undecryptable token file leaves behind. Also kills a stuck
+			// browser-login listener and truncates its log so the screen stops
+			// offering a dead login URL.
+			sysCmd('pkill -f qbzd-login 2> /dev/null');
+			sysCmd('truncate ' . QOBUZ_LOGIN_LOG . ' --size 0 2> /dev/null');
+			sysCmd('qbzd logout');
+			break;
 		case 'slsvc':
 			if ($_SESSION['slsvc'] == '1') {
 				cfgSqueezelite();

--- a/www/inc/audio.php
+++ b/www/inc/audio.php
@@ -188,6 +188,10 @@ function setAudioOut($output) {
 		stopDeezer();
 		startDeezer();
 	}
+	if ($_SESSION['qobuzsvc'] == '1') {
+		stopQobuz();
+		startQobuz();
+	}
 
 	// Set HTTP server state
 	setMpdHttpd();

--- a/www/inc/autocfg.php
+++ b/www/inc/autocfg.php
@@ -109,6 +109,7 @@ function autoConfigSettings() {
 		['requires' => ['airplayname'], 'handler' => 'setSessVarSql'],
 		['requires' => ['spotifyname'], 'handler' => 'setSessVarSql'],
 		['requires' => ['deezername'], 'handler' => 'setSessVarSql'],
+		['requires' => ['qobuzname'], 'handler' => 'setSessVarSql'],
 		['requires' => ['squeezelitename'], 'handler' => function($values) {
 			$dbh = sqlConnect();
 			$currentName= sqlQuery("select value from cfg_sl where param='PLAYERNAME'", $dbh)[0]['value'];
@@ -465,6 +466,8 @@ function autoConfigSettings() {
 		['requires' => ['rsmafterspot'], 'handler' => 'setSessVarSql'],
 		['requires' => ['deezersvc'], 'handler' => 'setSessVarSql'],
 		['requires' => ['rsmafterdeez'], 'handler' => 'setSessVarSql'],
+		['requires' => ['qobuzsvc'], 'handler' => 'setSessVarSql'],
+		['requires' => ['rsmafterqbz'], 'handler' => 'setSessVarSql'],
 		['requires' => ['slsvc'], 'handler' => 'setSessVarSql'],
 		['requires' => ['rsmaftersl'], 'handler' => 'setSessVarSql'],
 		['requires' => ['pasvc'], 'handler' => 'setSessVarSql'],
@@ -545,6 +548,15 @@ function autoConfigSettings() {
 				updateDeezCredentials($values['deezer_email'], $values['deezer_password']);
 			}, 'custom_write' => function($values) {
 				return getCfgTableParams('cfg_deezer', $values, 'deezer_');
+		}],
+		'Qobuz Connect',
+		['requires' => ['qobuz_quality'],
+			'optionals' => ['qobuz_gapless', 'qobuz_normalize_volume'],
+			'handler' => function($values, $optionals) {
+				$mergedValues = array_merge($values, $optionals);
+				setCfgTableParams('cfg_qobuz', $mergedValues, 'qobuz_');
+			}, 'custom_write' => function($values) {
+				return getCfgTableParams('cfg_qobuz', $values, 'qobuz_');
 		}],
 		'Squeezelite',
 		['requires' => ['squeezelite_PLAYERNAME', 'squeezelite_AUDIODEVICE', 'squeezelite_ALSAPARAMS', 'squeezelite_OUTPUTBUFFERS',

--- a/www/inc/common.php
+++ b/www/inc/common.php
@@ -321,7 +321,7 @@ function parseDelimFile($data, $delim) {
 // Determine if a renderer is active
 function chkRendererActive() {
 	$result = sqlQuery("SELECT value from cfg_system WHERE param in (
-		'btactive', 'aplactive', 'spotactive', 'deezactive', 'slactive', 'paactive',
+		'btactive', 'aplactive', 'spotactive', 'deezactive', 'qbzactive', 'slactive', 'paactive',
 		'rbactive', 'inpactive')", sqlConnect());
 
 	$active = false;
@@ -419,6 +419,7 @@ function storeBackLink($section, $tpl) {
 		'eqg-config.html'	=> '/snd-config.php',
 		'eqp-config.html'	=> '/snd-config.php',
 		'gpio-config.html'	=> '/per-config.php',
+		'qbz-config.html'	=> '/ren-config.php',
 		'spo-config.html' 	=> '/ren-config.php',
 		'sqe-config.html'	=> '/ren-config.php',
 		'lib-nas-config.html' => '/lib-config.php',

--- a/www/inc/constants.php
+++ b/www/inc/constants.php
@@ -19,6 +19,8 @@ const MOUNTMON_LOG = '/var/log/moode_mountmon.log';
 const SHAIRPORT_SYNC_LOG = '/var/log/moode_shairport-sync.log';
 const LIBRESPOT_LOG = '/var/log/moode_librespot.log';
 const PLEEZER_LOG = '/var/log/moode_pleezer.log';
+const QBZD_LOG = '/var/log/moode_qbzd.log';
+const QOBUZ_LOGIN_LOG = '/var/log/moode_qobuz_login.log';
 const SPOTEVENT_LOG = '/var/log/moode_spotevent.log';
 const DEEZEVENT_LOG = '/var/log/moode_deezevent.log';
 const SPSEVENT_LOG = '/var/log/moode_spsevent.log';
@@ -54,6 +56,7 @@ const RADIOBROWSER_LIMIT = 28; // Fixed search/page size
 const APLMETA_CACHE_FILE = '/var/local/www/aplmeta.json';
 const DEEZMETA_CACHE_FILE = '/var/local/www/deezmeta.json';
 const DEEZ_CREDENTIALS_FILE = '/etc/deezer/deezer.toml';
+const QBZMETA_CACHE_FILE = '/var/local/www/qbzmeta.json';
 const SPOTMETA_CACHE_FILE = '/var/local/www/spotmeta.json';
 const ITUNES_API_BASE_URL = 'https://itunes.apple.com/search';
 // SQLite
@@ -162,6 +165,7 @@ const NAME_BLUETOOTH = 'Bluetooth Controller';
 const NAME_BLUETOOTH_PAIRING_AGENT = 'Pairing Agent';
 const NAME_SPOTIFY = 'Spotify Connect';
 const NAME_DEEZER = 'Deezer Connect';
+const NAME_QOBUZ = 'Qobuz Connect';
 const NAME_SQUEEZELITE = 'Squeezelite';
 const NAME_UPNP = 'UPnP';
 const NAME_DLNA = 'DLNA';
@@ -242,8 +246,9 @@ const FEAT_BLUETOOTH    = 16384;	// y Bluetooth renderer
 const FEAT_DEVTWEAKS    = 32768;	//   Developer tweaks
 const FEAT_MULTIROOM    = 65536;	// y Multiroom audio
 const FEAT_PEPPYDISPLAY = 131072;	// y Peppy display
+const FEAT_QOBUZ        = 262144;	// y Qobuz Connect renderer
 //						-------
-//						  228279
+//						  490423
 
 // Selective resampling bitmask
 const SOX_UPSAMPLE_ALL			= 3; // Upsample if source < target rate

--- a/www/inc/constants.php
+++ b/www/inc/constants.php
@@ -57,6 +57,12 @@ const APLMETA_CACHE_FILE = '/var/local/www/aplmeta.json';
 const DEEZMETA_CACHE_FILE = '/var/local/www/deezmeta.json';
 const DEEZ_CREDENTIALS_FILE = '/etc/deezer/deezer.toml';
 const QBZMETA_CACHE_FILE = '/var/local/www/qbzmeta.json';
+// Build id of the installed qbzd, recorded by qobuz-installer.sh. The binary
+// only knows its own Cargo version, so a moOde-specific build (2.0.2.moode7)
+// would otherwise be indistinguishable from plain upstream 2.0.2.
+const QBZD_BUILD_FILE = '/var/local/www/qbzd-build';
+// Source of the moOde qbzd builds while Qobuz Connect pairing is unmerged.
+const QBZD_FORK_URL = 'https://github.com/PhilipVinc/qbz/tree/feature/external/qbzd-connect-pairing';
 const SPOTMETA_CACHE_FILE = '/var/local/www/spotmeta.json';
 const ITUNES_API_BASE_URL = 'https://itunes.apple.com/search';
 // SQLite

--- a/www/inc/peripheral.php
+++ b/www/inc/peripheral.php
@@ -62,6 +62,10 @@ function restartMpdAndRenderers($resetAlsaCtl) {
 		stopDeezer();
 		startDeezer();
 	}
+	if ($_SESSION['qobuzsvc'] == 1) {
+		stopQobuz();
+		startQobuz();
+	}
 }
 function allowPeppyInAlsaChain() {
 	// NOTE: MPD cant play ALSA chain: _audioout -> [alsaequal or eqfa12p] -> peppy -> btstream

--- a/www/inc/renderer.php
+++ b/www/inc/renderer.php
@@ -329,6 +329,89 @@ function updateDeezCredentials($email, $password) {
 	fclose($fh);
 }
 
+// Hz as a compact kHz string: 96000 -> "96", 44100 -> "44.1". formatRate() in
+// music-library.php is a lookup table that returns NULL for a rate it does not
+// list, and pulling that include in for one number is not worth it.
+function qobuzKhz($hz) {
+	return rtrim(rtrim(number_format($hz / 1000, 1, '.', ''), '0'), '.');
+}
+
+// $_SESSION lookup with a default. Several of the DSP flags below do not exist
+// as cfg_system rows on every moOde release (10.3.2 has no crossfeed, eqfa12p,
+// invert_polarity or enable_peppyalsa), and an undefined key compared against
+// 'Off' reads as ON — which would block a direct handoff for a feature that is
+// not even installed. Defaults are therefore all "feature absent", except the
+// ALSA output mode, where an unknown value must NOT be taken for Direct.
+function qobuzSess($key, $default) {
+	return isset($_SESSION[$key]) && $_SESSION[$key] !== '' ? $_SESSION[$key] : $default;
+}
+
+// Whether Qobuz playback should be handed straight to the DAC, and why not when
+// it should not. Shared by startQobuz(), which applies it, and qbz-config.php /
+// audioinfo.php, which display it — a second copy of this predicate would drift
+// and make the UI describe something the daemon is not doing.
+//
+// The rule behind "auto": moOde's _audioout is a bare hardware passthrough only
+// when nothing is inserted into it (see updAudioOutAndBtOutConfs() in audio.php).
+// In exactly that case qbzd can open the DAC itself and lose nothing, which is
+// what lets a track's own rate reach the hardware instead of whatever rate the
+// shared chain happens to be running at.
+function qobuzDirectRouting() {
+	$cfgQobuz = array();
+	foreach (sqlRead('cfg_qobuz', sqlConnect()) as $row) {
+		$cfgQobuz[$row['param']] = $row['value'];
+	}
+	$mode = isset($cfgQobuz['output_mode']) ? $cfgQobuz['output_mode'] : 'auto';
+	$device = 'hw:' . qobuzSess('cardnum', '0') . ',0';
+	$alsaMode = qobuzSess('alsa_output_mode', 'plughw');
+
+	if ($mode == 'software') {
+		return array('direct' => false, 'device' => '', 'reason' => 'Output routing is set to Software');
+	}
+
+	// Hard blockers: there is no hw: device to hand over, whatever was asked for.
+	$hard = '';
+	if (qobuzSess('audioout', 'Local') != 'Local') {
+		$hard = 'audio output is Bluetooth';
+	} else if (qobuzSess('multiroom_tx', 'Off') == 'On') {
+		$hard = 'Multiroom sender is on';
+	} else if ($alsaMode == 'iec958') {
+		$hard = 'ALSA output mode is S/PDIF';
+	}
+	if ($hard != '') {
+		return array('direct' => false, 'device' => '', 'reason' => $hard);
+	}
+
+	if ($mode == 'direct') {
+		return array('direct' => true, 'device' => $device, 'reason' => '');
+	}
+
+	// Auto: take the DAC only when moOde's own chain is empty. Each of these
+	// means the chain has something in it that a direct handoff would bypass.
+	$soft = '';
+	if ($alsaMode != 'hw') {
+		$modeName = isset(ALSA_OUTPUT_MODE_NAME[$alsaMode]) ? ALSA_OUTPUT_MODE_NAME[$alsaMode] : $alsaMode;
+		$soft = 'ALSA output mode is ' . $modeName . ', not Direct';
+	} else if (qobuzSess('alsaequal', 'Off') != 'Off') {
+		$soft = 'Graphic EQ is on';
+	} else if (qobuzSess('camilladsp', 'off') != 'off') {
+		$soft = 'CamillaDSP is on';
+	} else if (qobuzSess('crossfeed', 'Off') != 'Off') {
+		$soft = 'Crossfeed is on';
+	} else if (qobuzSess('eqfa12p', 'Off') != 'Off') {
+		$soft = 'Parametric EQ is on';
+	} else if (qobuzSess('invert_polarity', '0') != '0') {
+		$soft = 'Polarity inversion is on';
+	} else if (qobuzSess('peppy_display', '0') == '1' || qobuzSess('enable_peppyalsa', '0') == '1') {
+		$soft = 'PeppyALSA is on';
+	}
+	if ($soft != '') {
+		return array('direct' => false, 'device' => '', 'reason' => $soft);
+	}
+
+	return array('direct' => true, 'device' => $device, 'reason' => '');
+}
+
 // Qobuz Connect
 function startQobuz() {
 	$result = sqlRead('cfg_qobuz', sqlConnect());
@@ -347,21 +430,58 @@ function startQobuz() {
 	// device name, and the qconnect startup mode are read once at boot. The
 	// settings CLI writes the stores directly (creating them if needed); its
 	// running-daemon nudge is a harmless no-op while qbzd is down.
-	sysCmd('qbzd settings set audio.device "' . $device . '"');
+	// Output routing. These three settings are coupled: the bit-perfect path is
+	// only reached with backend=alsa AND a device id is_hw_device() accepts, so
+	// they are always written together and never exposed separately.
+	$routing = qobuzDirectRouting();
+	if ($routing['direct']) {
+		sysCmd('qbzd settings set audio.backend alsa');
+		sysCmd('qbzd settings set audio.device "' . $routing['device'] . '"');
+		sysCmd('qbzd settings set audio.alsa_plugin hw');
+	} else {
+		// Explicit, not just "leave it": a box that once went direct must come
+		// back to the shared chain when DSP is switched on, or the DSP silently
+		// stops applying to Qobuz.
+		sysCmd('qbzd settings set audio.backend system');
+		sysCmd('qbzd settings set audio.device "' . $device . '"');
+	}
 	sysCmd('qbzd settings set playback.quality ' . $cfgQobuz['quality']);
-	sysCmd('qbzd settings set audio.gapless_enabled ' . ($cfgQobuz['gapless'] == 'Yes' ? 'true' : 'false'));
+	// Gapless needs the NEXT track in the cache — the prefetch is a no-op in
+	// streaming-only mode — so it cannot work on a box that does not cache,
+	// whatever the Gapless setting says.
+	$cacheTracks = (isset($cfgQobuz['track_cache']) ? $cfgQobuz['track_cache'] : 'No') == 'Yes';
+	sysCmd('qbzd settings set audio.gapless_enabled ' .
+		(($cacheTracks && $cfgQobuz['gapless'] == 'Yes') ? 'true' : 'false'));
+	sysCmd('qbzd settings set audio.streaming_only ' . ($cacheTracks ? 'false' : 'true'));
+	sysCmd('qbzd settings set audio.stream_first_track ' .
+		((isset($cfgQobuz['stream_first']) ? $cfgQobuz['stream_first'] : 'Yes') == 'Yes' ? 'true' : 'false'));
 	sysCmd('qbzd settings set audio.normalization_enabled ' . ($cfgQobuz['normalize_volume'] == 'Yes' ? 'true' : 'false'));
 	sysCmd('qbzd settings set playback.mpris false');
 	sysCmd('qbzd settings set qconnect.device_name "' . $_SESSION['qobuzname'] . '"');
 	sysCmd('qbzd settings set qconnect.pairing ' . (($cfgQobuz['pairing'] ?? 'Yes') == 'Yes' ? 'on' : 'off'));
 	sysCmd('qbzd settings set audio.stream_buffer_seconds ' . ($cfgQobuz['buffer_seconds'] ?? '2'));
-	sysCmd('qbzd settings set qconnect.volume_mode ' . ($cfgQobuz['volume_mode'] ?? 'software'));
+	// Volume. Hardware volume needs a direct handoff AND a DAC with a mixer
+	// control; anywhere else audio.alsa_hardware_volume silently does nothing,
+	// so resolve it here rather than trusting the stored value. 'auto' takes
+	// hardware whenever it is available, because software volume in direct mode
+	// scales every sample and throws away the bit-perfection just gained.
+	$hwVolume = $routing['direct'] && qobuzSess('alsavolume', 'none') != 'none';
+	$volumeMode = isset($cfgQobuz['volume_mode']) ? $cfgQobuz['volume_mode'] : 'auto';
+	if ($volumeMode == 'auto') {
+		$volumeMode = $hwVolume ? 'hardware' : 'software';
+	} else if ($volumeMode == 'hardware' && !$hwVolume) {
+		$volumeMode = 'software';
+	}
+	sysCmd('qbzd settings set qconnect.volume_mode ' . ($volumeMode == 'locked' ? 'locked' : 'software'));
+	sysCmd('qbzd settings set audio.alsa_hardware_volume ' . ($volumeMode == 'hardware' ? 'true' : 'false'));
 	// Non-interactive quality fallback: the stock value is "ask", which cannot
 	// work on a headless box — there is nobody to answer, so a track the DAC
 	// cannot do at full rate has no defined outcome. Play it at a supported
 	// rate instead of failing.
 	sysCmd('qbzd settings set audio.allow_quality_fallback true');
-	sysCmd('qbzd settings set audio.quality_fallback_behavior always_fallback');
+	sysCmd('qbzd settings set audio.quality_fallback_behavior ' .
+		((isset($cfgQobuz['quality_fallback']) ? $cfgQobuz['quality_fallback'] : 'fallback') == 'skip' ?
+			'always_skip' : 'always_fallback'));
 	// Do not restore a local queue on start. As a Connect renderer the queue
 	// belongs to the controlling app; a restored one is invisible to it and
 	// surfaced as the daemon spontaneously streaming a track nobody asked for

--- a/www/inc/renderer.php
+++ b/www/inc/renderer.php
@@ -400,6 +400,26 @@ function stopQobuz() {
 	$GLOBALS['qbzactive'] = '0';
 	sendFECmd('qbzactive0');
 }
+// Version of the installed qbzd, preferring the build id the installer recorded
+// over `qbzd --version`: the moOde test builds are cut from a fork branch and
+// carry a build suffix (2.0.2.moode7) that the binary itself cannot report,
+// since it only knows its Cargo version. Falls back to the binary for an
+// upstream install that predates the marker file.
+function qbzdVersion() {
+	if (file_exists(QBZD_BUILD_FILE)) {
+		$build = trim(file_get_contents(QBZD_BUILD_FILE));
+		if ($build != '') {
+			return $build;
+		}
+	}
+	$result = sysCmd('qbzd --version | awk \'{print $2}\'');
+	return empty($result[0]) ? 'unknown' : $result[0];
+}
+// True when the installed qbzd is a moOde fork build rather than an upstream
+// release — the Qobuz Connect pairing work is not upstream yet.
+function isQbzdForkBuild() {
+	return strpos(qbzdVersion(), 'moode') !== false;
+}
 function isQobuzInstalled() {
 	$result = sysCmd('which qbzd');
 	return empty($result) ? false : true;

--- a/www/inc/renderer.php
+++ b/www/inc/renderer.php
@@ -329,6 +329,65 @@ function updateDeezCredentials($email, $password) {
 	fclose($fh);
 }
 
+// Qobuz Connect
+function startQobuz() {
+	$result = sqlRead('cfg_qobuz', sqlConnect());
+	$cfgQobuz = array();
+	foreach ($result as $row) {
+		$cfgQobuz[$row['param']] = $row['value'];
+	}
+
+	// Output device: ALSA hint names defined in /etc/alsa/conf.d/qbzd-devices.conf
+	$device = $_SESSION['audioout'] == 'Local' ? 'Moode Audio Output' : 'Moode Bluetooth Stream';
+
+	// Logging
+	$logging = $_SESSION['debuglog'] == '1' ? ' > ' . QBZD_LOG : ' > /dev/null';
+
+	// Start the daemon then configure it via its control API
+	$cmd = 'qbzd run' . $logging . ' 2>&1 &';
+	debugLog('startQobuz(): (' . $cmd . ')');
+	sysCmd($cmd);
+
+	// Wait for the control API to come up (up to 5 secs)
+	for ($i = 0; $i < 10; $i++) {
+		usleep(500000);
+		$result = sysCmd('curl -s -o /dev/null -w "%{http_code}" --max-time 2 http://127.0.0.1:8182/api/status');
+		if (!empty($result) && $result[0] == '200') {
+			break;
+		}
+	}
+
+	// Apply settings (persisted to disk by qbzd)
+	sysCmd('qbzd settings set audio.device "' . $device . '"');
+	sysCmd('qbzd settings set playback.quality ' . $cfgQobuz['quality']);
+	sysCmd('qbzd settings set audio.gapless_enabled ' . ($cfgQobuz['gapless'] == 'Yes' ? 'true' : 'false'));
+	sysCmd('qbzd settings set audio.normalization_enabled ' . ($cfgQobuz['normalize_volume'] == 'Yes' ? 'true' : 'false'));
+	sysCmd('qbzd settings set playback.mpris false');
+	sysCmd('qbzd settings set qconnect.device_name "' . $_SESSION['qobuzname'] . '"');
+	sysCmd('qbzd qconnect enable');
+}
+function stopQobuz() {
+	sysCmd('killall -s9 qbzd');
+
+	// Local
+	sysCmd('/var/www/util/vol.sh -restore');
+	if (CamillaDSP::isMPD2CamillaDSPVolSyncEnabled()) {
+		sysCmd('systemctl restart mpd2cdspvolume');
+	}
+	// Multiroom receivers
+	if ($_SESSION['multiroom_tx'] == "On" ) {
+		updReceiverVol('-restore');
+	}
+
+	phpSession('write', 'qbzactive', '0');
+	$GLOBALS['qbzactive'] = '0';
+	sendFECmd('qbzactive0');
+}
+function isQobuzInstalled() {
+	$result = sysCmd('which qbzd');
+	return empty($result) ? false : true;
+}
+
 // UPnP
 function startUPnP() {
 	sysCmd('systemctl start upmpdcli');
@@ -404,6 +463,7 @@ function stopAllRenderers() {
 		'airplaysvc' => 'stopAirPlay',
 		'spotifysvc' => 'stopSpotify',
 		'deezersvc'  => 'stopDeezer',
+		'qobuzsvc'	 => 'stopQobuz',
 		'upnpsvc'	 => 'stopUPnP',
 		'slsvc'		 => 'stopSqueezeLite',
 		'pasvc'		 => 'stopPlexamp',

--- a/www/inc/renderer.php
+++ b/www/inc/renderer.php
@@ -354,6 +354,20 @@ function startQobuz() {
 	sysCmd('qbzd settings set playback.mpris false');
 	sysCmd('qbzd settings set qconnect.device_name "' . $_SESSION['qobuzname'] . '"');
 	sysCmd('qbzd settings set qconnect.pairing ' . (($cfgQobuz['pairing'] ?? 'Yes') == 'Yes' ? 'on' : 'off'));
+	sysCmd('qbzd settings set audio.stream_buffer_seconds ' . ($cfgQobuz['buffer_seconds'] ?? '2'));
+	sysCmd('qbzd settings set qconnect.volume_mode ' . ($cfgQobuz['volume_mode'] ?? 'software'));
+	// Non-interactive quality fallback: the stock value is "ask", which cannot
+	// work on a headless box — there is nobody to answer, so a track the DAC
+	// cannot do at full rate has no defined outcome. Play it at a supported
+	// rate instead of failing.
+	sysCmd('qbzd settings set audio.allow_quality_fallback true');
+	sysCmd('qbzd settings set audio.quality_fallback_behavior always_fallback');
+	// Do not restore a local queue on start. As a Connect renderer the queue
+	// belongs to the controlling app; a restored one is invisible to it and
+	// surfaced as the daemon spontaneously streaming a track nobody asked for
+	// after a restart.
+	sysCmd('qbzd settings set playback.persist_session false');
+	sysCmd('qbzd settings set playback.resume_playback_position false');
 	sysCmd('qbzd qconnect enable');
 
 	// QBZD_HOOK: qbzd forks the script once per daemon event (QBZ_* env vars)

--- a/www/inc/renderer.php
+++ b/www/inc/renderer.php
@@ -343,7 +343,19 @@ function startQobuz() {
 	// Logging
 	$logging = $_SESSION['debuglog'] == '1' ? ' > ' . QBZD_LOG : ' > /dev/null';
 
-	// Start the daemon then configure it via its control API.
+	// Apply settings BEFORE the daemon starts: the pairing listener, its mDNS
+	// device name, and the qconnect startup mode are read once at boot. The
+	// settings CLI writes the stores directly (creating them if needed); its
+	// running-daemon nudge is a harmless no-op while qbzd is down.
+	sysCmd('qbzd settings set audio.device "' . $device . '"');
+	sysCmd('qbzd settings set playback.quality ' . $cfgQobuz['quality']);
+	sysCmd('qbzd settings set audio.gapless_enabled ' . ($cfgQobuz['gapless'] == 'Yes' ? 'true' : 'false'));
+	sysCmd('qbzd settings set audio.normalization_enabled ' . ($cfgQobuz['normalize_volume'] == 'Yes' ? 'true' : 'false'));
+	sysCmd('qbzd settings set playback.mpris false');
+	sysCmd('qbzd settings set qconnect.device_name "' . $_SESSION['qobuzname'] . '"');
+	sysCmd('qbzd settings set qconnect.pairing ' . (($cfgQobuz['pairing'] ?? 'Yes') == 'Yes' ? 'on' : 'off'));
+	sysCmd('qbzd qconnect enable');
+
 	// QBZD_HOOK: qbzd forks the script once per daemon event (QBZ_* env vars)
 	$cmd = 'QBZD_HOOK=/var/local/www/commandw/qbzevent.sh qbzd run' . $logging . ' 2>&1 &';
 	debugLog('startQobuz(): (' . $cmd . ')');
@@ -357,15 +369,6 @@ function startQobuz() {
 			break;
 		}
 	}
-
-	// Apply settings (persisted to disk by qbzd)
-	sysCmd('qbzd settings set audio.device "' . $device . '"');
-	sysCmd('qbzd settings set playback.quality ' . $cfgQobuz['quality']);
-	sysCmd('qbzd settings set audio.gapless_enabled ' . ($cfgQobuz['gapless'] == 'Yes' ? 'true' : 'false'));
-	sysCmd('qbzd settings set audio.normalization_enabled ' . ($cfgQobuz['normalize_volume'] == 'Yes' ? 'true' : 'false'));
-	sysCmd('qbzd settings set playback.mpris false');
-	sysCmd('qbzd settings set qconnect.device_name "' . $_SESSION['qobuzname'] . '"');
-	sysCmd('qbzd qconnect enable');
 }
 function stopQobuz() {
 	sysCmd('killall -s9 qbzd');

--- a/www/inc/renderer.php
+++ b/www/inc/renderer.php
@@ -400,20 +400,24 @@ function stopQobuz() {
 	$GLOBALS['qbzactive'] = '0';
 	sendFECmd('qbzactive0');
 }
-// Version of the installed qbzd, preferring the build id the installer recorded
-// over `qbzd --version`: the moOde test builds are cut from a fork branch and
-// carry a build suffix (2.0.2.moode7) that the binary itself cannot report,
-// since it only knows its Cargo version. Falls back to the binary for an
-// upstream install that predates the marker file.
+// Version of the installed qbzd. A moOde build stamps its build id into the
+// binary (2.0.2.moode7), so ask the binary first — it describes whatever is
+// actually on disk, even if it was replaced by hand. Older binaries report only
+// their Cargo version (a bare 2.0.2), and for those the id the installer
+// recorded at install time is the better answer.
 function qbzdVersion() {
+	$result = sysCmd('qbzd --version | awk \'{print $2}\'');
+	$reported = empty($result[0]) ? '' : $result[0];
+	if (strpos($reported, 'moode') !== false) {
+		return $reported;
+	}
 	if (file_exists(QBZD_BUILD_FILE)) {
 		$build = trim(file_get_contents(QBZD_BUILD_FILE));
 		if ($build != '') {
 			return $build;
 		}
 	}
-	$result = sysCmd('qbzd --version | awk \'{print $2}\'');
-	return empty($result[0]) ? 'unknown' : $result[0];
+	return $reported == '' ? 'unknown' : $reported;
 }
 // True when the installed qbzd is a moOde fork build rather than an upstream
 // release — the Qobuz Connect pairing work is not upstream yet.

--- a/www/inc/renderer.php
+++ b/www/inc/renderer.php
@@ -343,8 +343,9 @@ function startQobuz() {
 	// Logging
 	$logging = $_SESSION['debuglog'] == '1' ? ' > ' . QBZD_LOG : ' > /dev/null';
 
-	// Start the daemon then configure it via its control API
-	$cmd = 'qbzd run' . $logging . ' 2>&1 &';
+	// Start the daemon then configure it via its control API.
+	// QBZD_HOOK: qbzd forks the script once per daemon event (QBZ_* env vars)
+	$cmd = 'QBZD_HOOK=/var/local/www/commandw/qbzevent.sh qbzd run' . $logging . ' 2>&1 &';
 	debugLog('startQobuz(): (' . $cmd . ')');
 	sysCmd($cmd);
 

--- a/www/inc/renderer.php
+++ b/www/inc/renderer.php
@@ -371,7 +371,20 @@ function startQobuz() {
 	}
 }
 function stopQobuz() {
-	sysCmd('killall -s9 qbzd');
+	// Graceful first: on SIGTERM qbzd leaves the Qobuz Connect session, so the
+	// cloud drops this renderer. SIGKILL skips that, leaving a zombie renderer
+	// registered mid-playback — the next handoff rejoins that same session, the
+	// cloud replays the stale "playing <old track> at <old position>" state,
+	// and the app ends up showing 0:00 with nothing playing. SIGKILL stays as
+	// the fallback so a wedged daemon still releases the audio device.
+	sysCmd('killall qbzd 2> /dev/null');
+	for ($i = 0; $i < 15; $i++) {
+		if (empty(sysCmd('pgrep -x qbzd'))) {
+			break;
+		}
+		usleep(200000);
+	}
+	sysCmd('killall -s9 qbzd 2> /dev/null');
 
 	// Local
 	sysCmd('/var/www/util/vol.sh -restore');

--- a/www/install_renderers.txt
+++ b/www/install_renderers.txt
@@ -33,12 +33,17 @@ Clicking the INSTALL button initiates an automated process that first builds
 the renderer from its source code and dependencies then creates a Debian package
 that installs the renderer onto the system.
 
+This applies to AirPlay and Spotify Connect. Qobuz Connect installs a prebuilt
+binary instead, so none of the build times or Debian packages described below
+apply to it.
+
 The build part of the process can be lengthy. The amount of time required depends
 on the overall speed of the Raspberry Pi including CPU, RAM, and boot media, and
 the speed of the network which is used to download the renderer sources and build
 scripts from GitHub.
 
-Some example times from testing:
+Some example times from testing (Qobuz Connect is a download, about 1 minute
+on any model):
 +----------------------------------+
 | PI MODEL   | AIRPLAY  | SPOTIFY  |
 +----------------------------------+
@@ -58,9 +63,9 @@ The summary log is named "/var/log/moode_plugin.log" and can be viewed by
 clicking the REFRESH button in the WebUI during installation or in an SSH
 terminal by the command "cat /var/log/moode_plugin.log"
 
-The full logs are in the Home Directory and are named "install_airplay.log"
-and "install_spotify.log". They can be viewed in an SSH terminal by the commands
-below. The command "tail -f" is used to view the log as its being written.
+The full logs are in the Home Directory and are named "install_airplay.log",
+"install_spotify.log" and "install_qobuz.log". They can be viewed in an SSH
+terminal by the commands below. The command "tail -f" is used to view the log as its being written.
 
 Examples:
 cat install_airplay.log

--- a/www/install_renderers.txt
+++ b/www/install_renderers.txt
@@ -18,6 +18,15 @@ AIRPLAY AND SPOTIFY CONNECT
 AirPlay and Spotify Connect renderers are not included in moOde but they can be
 built and installed via the INSTALL button in Renderer Config.
 
+QOBUZ CONNECT
+
+The Qobuz Connect renderer (qbzd) is not included in moOde but it can be
+installed via the INSTALL button in Renderer Config. Unlike AirPlay and Spotify
+Connect which are built from source code, the INSTALL button downloads a
+prebuilt qbzd binary and thus the process is fast, typically about 1 minute.
+
+The full log is in the Home Directory and is named "install_qobuz.log".
+
 INSTALLATION PROCESS
 
 Clicking the INSTALL button initiates an automated process that first builds

--- a/www/js/playerlib.js
+++ b/www/js/playerlib.js
@@ -23,8 +23,9 @@ const FEAT_BLUETOOTH    = 16384;    // y Bluetooth renderer
 const FEAT_DEVTWEAKS    = 32768;	//   Developer tweaks
 const FEAT_MULTIROOM    = 65536;	// y Multiroom audio
 const FEAT_PEPPYDISPLAY = 131072;	// y Peppy display
+const FEAT_QOBUZ        = 262144;	// y Qobuz Connect renderer
 //						-------
-//						  228279
+//						  490423
 
 const VOL_KNOB_DEBOUNCE = 150; // ms, coalesce a knob drag's intermediate values
 
@@ -578,6 +579,8 @@ function engineCmd() {
                 case 'aplactive0':
                 case 'deezactive1':
                 case 'deezactive0':
+                case 'qbzactive1':
+                case 'qbzactive0':
                 case 'spotactive1':
                 case 'spotactive0':
                     if (cmd[0].includes('apl')) {
@@ -586,6 +589,9 @@ function engineCmd() {
                     } else if (cmd[0].includes('deez')){
                         var rendererName = 'Deezer';
                         SESSION.json['deezactive'] = cmd[0].slice(-1);
+                    } else if (cmd[0].includes('qbz')) {
+                        var rendererName = 'Qobuz';
+                        SESSION.json['qbzactive'] = cmd[0].slice(-1);
                     } else if (cmd[0].includes('spot')) {
                         var rendererName = 'Spotify';
                         SESSION.json['spotactive'] = cmd[0].slice(-1);
@@ -606,6 +612,7 @@ function engineCmd() {
                     break;
                 case 'update_aplmeta':
                 case 'update_deezmeta':
+                case 'update_qbzmeta':
                 case 'update_spotmeta':
 					// cmd[1]: '"{"fecmd": "cmd", "key1": "value1", ..., "keyN": "valueN"}"'
                     updateInpsrcMeta(cmd[0], cmd[1]);
@@ -897,6 +904,8 @@ function refreshInpsrcMeta() {
         cmd = 'get_aplmeta';
     } else if (SESSION.json['deezactive'] == '1') {
         cmd = 'get_deezmeta';
+    } else if (SESSION.json['qbzactive'] == '1') {
+        cmd = 'get_qbzmeta';
     } else if (SESSION.json['spotactive'] == '1') {
         cmd = 'get_spotmeta';
     } else {
@@ -925,6 +934,7 @@ function updateInpsrcMeta(cmd, data) {
 	// Formats
 	// - AirPlay: title, artist, album, duration (in ms),  cover_url, sformat, oformat
 	// - Deezer:  title, artist, album, duration (in sec), cover_url, sformat, decoder
+	// - Qobuz:   title, artist, album, duration (in sec), cover_url, sformat, oformat
 	// - Spotify: title, artist, album, duration (in ms),  cover_url, sformat
 
 	try {
@@ -1613,6 +1623,18 @@ function renderUI() {
 
             refreshInpsrcMeta();
     	}
+        // Qobuz Connect renderer
+    	if (SESSION.json['qbzactive'] == '1') {
+            inpSrcIndicator('qbzactive1',
+                '<span id="inpsrc-msg-text">Qobuz Active</span>' +
+                '<button class="btn renderer-btn disconnect-qobuz" data-job="qobuzsvc"><i class="fa-regular fa-sharp fa-xmark"></i></button>' +
+                receiversBtn('qbzactive1') +
+                audioInfoBtn('qbzactive1') +
+                rendererRefreshBtn()
+            );
+
+            refreshInpsrcMeta();
+    	}
         // Spotify Connect renderer
     	if (SESSION.json['spotactive'] == '1') {
             inpSrcIndicator('spotactive1',
@@ -1668,7 +1690,7 @@ function renderUI() {
 // Multiroom receivers
 function receiversBtn(rendererActive = '') {
     if (SESSION.json['multiroom_tx'] == 'On') {
-        if (rendererActive == 'aplactive1' || rendererActive == 'deezactive1' || rendererActive == 'spotactive1') {
+        if (rendererActive == 'aplactive1' || rendererActive == 'deezactive1' || rendererActive == 'qbzactive1' || rendererActive == 'spotactive1') {
             // data-cmd: multiroom_rx_modal (full modal), multiroom_rx_modal_limited (just the on/off checkbox)
             var html = '<span class="context-menu"><a class="btn renderer-btn" href="#notarget" data-cmd="multiroom_rx_modal"><i class="fa-regular fa-sharp fa-speakers"></i></a></span>';
         } else {
@@ -1682,7 +1704,7 @@ function receiversBtn(rendererActive = '') {
 }
 // Audio info
 function audioInfoBtn(rendererActive = '') {
-    if (rendererActive == 'aplactive1' || rendererActive == 'deezactive1' || rendererActive == 'spotactive1') {
+    if (rendererActive == 'aplactive1' || rendererActive == 'deezactive1' || rendererActive == 'qbzactive1' || rendererActive == 'spotactive1') {
         var html = '<span><a class="btn renderer-btn" href="javascript:audioInfoPlayback()"><i class="fa-regular fa-sharp fa-music"></i></a></span>';
     } else {
         var html = '<br><span><a class="btn audioinfo-renderer" href="javascript:audioInfoPlayback()">Audio info</a></span>';
@@ -5417,6 +5439,7 @@ function rendererActive() {
         SESSION.json['deezactive'] == '1' ||
         SESSION.json['inpactive'] == '1' ||
         SESSION.json['paactive'] == '1' ||
+        SESSION.json['qbzactive'] == '1' ||
         SESSION.json['rbactive'] == '1' ||
         SESSION.json['rxactive'] == '1' ||
         SESSION.json['slactive'] == '1'

--- a/www/js/scripts-panels.js
+++ b/www/js/scripts-panels.js
@@ -1876,6 +1876,10 @@ jQuery(document).ready(function($) { 'use strict';
 		notify(NOTIFY_TITLE_INFO, 'renderer_disconnect');
         $.post('command/renderer.php?cmd=disconnect_renderer', {'job': $(this).data('job')});
 	});
+    $(document).on('click', '.disconnect-qobuz', function(e) {
+		notify(NOTIFY_TITLE_INFO, 'renderer_disconnect');
+        $.post('command/renderer.php?cmd=disconnect_renderer', {'job': $(this).data('job')});
+	});
     $(document).on('click', '.disconnect-spotify', function(e) {
 		notify(NOTIFY_TITLE_INFO, 'renderer_disconnect');
         $.post('command/renderer.php?cmd=disconnect_renderer', {'job': $(this).data('job')});

--- a/www/qbz-config.php
+++ b/www/qbz-config.php
@@ -36,11 +36,19 @@ $cfgQobuz = array();
 foreach ($result as $row) {
 	$cfgQobuz[$row['param']] = $row['value'];
 }
+// Self-heal a cfg_qobuz that predates the pairing param: without the row,
+// the generic UPDATE in the save handler would silently no-op.
+if (!isset($cfgQobuz['pairing'])) {
+	sqlInsert('cfg_qobuz', $dbh, "'pairing', 'Yes'");
+	$cfgQobuz['pairing'] = 'Yes';
+}
 
 $_select['quality'] .= "<option value=\"mp3\" " . (($cfgQobuz['quality'] == 'mp3') ? "selected" : "") . ">MP3 320 kbps</option>\n";
 $_select['quality'] .= "<option value=\"cd\" " . (($cfgQobuz['quality'] == 'cd') ? "selected" : "") . ">CD 16 bit / 44.1 kHz</option>\n";
 $_select['quality'] .= "<option value=\"hires\" " . (($cfgQobuz['quality'] == 'hires') ? "selected" : "") . ">Hi-Res 24 bit / 96 kHz</option>\n";
 $_select['quality'] .= "<option value=\"hires_plus\" " . (($cfgQobuz['quality'] == 'hires_plus') ? "selected" : "") . ">Hi-Res 24 bit / 192 kHz (Default)</option>\n";
+$_select['pairing'] .= "<option value=\"Yes\" " . (($cfgQobuz['pairing'] == 'Yes') ? "selected" : "") . ">Yes (Default)</option>\n";
+$_select['pairing'] .= "<option value=\"No\" "  . (($cfgQobuz['pairing'] == 'No')  ? "selected" : "") . ">No</option>\n";
 $_select['gapless'] .= "<option value=\"Yes\" " . (($cfgQobuz['gapless'] == 'Yes') ? "selected" : "") . ">Yes (Default)</option>\n";
 $_select['gapless'] .= "<option value=\"No\" "  . (($cfgQobuz['gapless'] == 'No')  ? "selected" : "") . ">No</option>\n";
 $_select['normalize_volume'] .= "<option value=\"Yes\" " . (($cfgQobuz['normalize_volume'] == 'Yes') ? "selected" : "") . ">Yes</option>\n";

--- a/www/qbz-config.php
+++ b/www/qbz-config.php
@@ -59,7 +59,12 @@ if ($_SESSION['qobuzsvc'] == '1') {
 			(empty($status['auth']['subscription']) ? '' : ' (' . $status['auth']['subscription'] . ')');
 	} else {
 		$_qobuz_login_hide = '';
-		$_qobuz_account_status = 'Not logged in';
+		// With the pairing surface up, a login is optional: the Qobuz app hands
+		// the player its own session tokens when someone casts to it.
+		$pairingOn = isset($status['qconnect']['pairing']) && $status['qconnect']['pairing'] === true;
+		$_qobuz_account_status = $pairingOn ?
+			'Not logged in (optional: any Qobuz app on this network can cast to this player)' :
+			'Not logged in';
 		// A login in progress prints its URL to the login log
 		$loginLog = file_exists(QOBUZ_LOGIN_LOG) ? file_get_contents(QOBUZ_LOGIN_LOG) : '';
 		if (preg_match('#https?://\S+#', $loginLog, $matches) === 1) {

--- a/www/qbz-config.php
+++ b/www/qbz-config.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright 2014 The moOde audio player project / Tim Curtis
+*/
+
+require_once __DIR__ . '/inc/common.php';
+require_once __DIR__ . '/inc/session.php';
+require_once __DIR__ . '/inc/sql.php';
+
+$dbh = sqlConnect();
+phpSession('open');
+
+if (isset($_POST['save']) && $_POST['save'] == '1') {
+	foreach ($_POST['config'] as $key => $value) {
+		chkValue($key, $value);
+		sqlUpdate('cfg_qobuz', $dbh, $key, $value);
+	}
+	$notify = $_SESSION['qobuzsvc'] == '1' ?
+		array('title' => NOTIFY_TITLE_INFO, 'msg' => NAME_QOBUZ . NOTIFY_MSG_SVC_RESTARTED) :
+		array('title' => '', 'msg' => '');
+	submitJob('qobuzsvc', '', $notify['title'], $notify['msg']);
+}
+if (isset($_POST['qobuz_login']) && $_POST['qobuz_login'] == '1') {
+	submitJob('qobuz_login', '', NOTIFY_TITLE_INFO, 'Login started, refresh this screen to view the login link');
+}
+if (isset($_POST['qobuz_logout']) && $_POST['qobuz_logout'] == '1') {
+	submitJob('qobuz_logout', '', NOTIFY_TITLE_INFO, 'Logged out from Qobuz');
+}
+
+phpSession('close');
+
+$result = sqlRead('cfg_qobuz', $dbh);
+$cfgQobuz = array();
+
+foreach ($result as $row) {
+	$cfgQobuz[$row['param']] = $row['value'];
+}
+
+$_select['quality'] .= "<option value=\"mp3\" " . (($cfgQobuz['quality'] == 'mp3') ? "selected" : "") . ">MP3 320 kbps</option>\n";
+$_select['quality'] .= "<option value=\"cd\" " . (($cfgQobuz['quality'] == 'cd') ? "selected" : "") . ">CD 16 bit / 44.1 kHz</option>\n";
+$_select['quality'] .= "<option value=\"hires\" " . (($cfgQobuz['quality'] == 'hires') ? "selected" : "") . ">Hi-Res 24 bit / 96 kHz</option>\n";
+$_select['quality'] .= "<option value=\"hires_plus\" " . (($cfgQobuz['quality'] == 'hires_plus') ? "selected" : "") . ">Hi-Res 24 bit / 192 kHz (Default)</option>\n";
+$_select['gapless'] .= "<option value=\"Yes\" " . (($cfgQobuz['gapless'] == 'Yes') ? "selected" : "") . ">Yes (Default)</option>\n";
+$_select['gapless'] .= "<option value=\"No\" "  . (($cfgQobuz['gapless'] == 'No')  ? "selected" : "") . ">No</option>\n";
+$_select['normalize_volume'] .= "<option value=\"Yes\" " . (($cfgQobuz['normalize_volume'] == 'Yes') ? "selected" : "") . ">Yes</option>\n";
+$_select['normalize_volume'] .= "<option value=\"No\" "  . (($cfgQobuz['normalize_volume'] == 'No')  ? "selected" : "") . ">No (Default)</option>\n";
+
+// Account: login status is read from the qbzd control API (only available when the service is on)
+$_qobuz_login_hide = 'hide';
+$_qobuz_logout_hide = 'hide';
+$_qobuz_login_url_msg = '';
+if ($_SESSION['qobuzsvc'] == '1') {
+	$result = sysCmd('curl -s --max-time 2 http://127.0.0.1:8182/api/status');
+	$status = json_decode(implode('', $result), true);
+	if (isset($status['auth']['state']) && $status['auth']['state'] != 'needs_auth') {
+		$_qobuz_logout_hide = '';
+		$_qobuz_account_status = 'Logged in' .
+			(empty($status['auth']['subscription']) ? '' : ' (' . $status['auth']['subscription'] . ')');
+	} else {
+		$_qobuz_login_hide = '';
+		$_qobuz_account_status = 'Not logged in';
+		// A login in progress prints its URL to the login log
+		$loginLog = file_exists(QOBUZ_LOGIN_LOG) ? file_get_contents(QOBUZ_LOGIN_LOG) : '';
+		if (preg_match('#https?://\S+#', $loginLog, $matches) === 1) {
+			$_qobuz_login_url_msg = '<span class="config-help-static">' .
+				'<a class="target-blank-link" href="' . $matches[0] . '" target="_blank">' . $matches[0] . '</a><br>' .
+				'Open this link in your browser to complete the Qobuz login, then refresh this screen.</span>';
+		}
+	}
+} else {
+	$_qobuz_account_status = 'Turn the renderer on in Renderer Config to log in.';
+}
+
+waitWorker('qbz_config');
+
+$tpl = "qbz-config.html";
+$section = basename(__FILE__, '.php');
+storeBackLink($section, $tpl);
+
+include('header.php');
+eval("echoTemplate(\"" . getTemplate("templates/$tpl") . "\");");
+include('footer.php');

--- a/www/qbz-config.php
+++ b/www/qbz-config.php
@@ -12,6 +12,17 @@ $dbh = sqlConnect();
 phpSession('open');
 
 if (isset($_POST['save']) && $_POST['save'] == '1') {
+	// Local pairing and a fixed account login are mutually exclusive in this
+	// UI: turning pairing on drops the login (and any in-flight browser login)
+	// so the renderer restart below comes up account-less. The single-slot job
+	// queue is taken by the qobuzsvc restart, so log out synchronously here.
+	if (isset($_POST['config']['pairing']) && $_POST['config']['pairing'] == 'Yes') {
+		$prevPairing = sqlQuery("SELECT value FROM cfg_qobuz WHERE param='pairing'", $dbh);
+		if (!empty($prevPairing[0]['value']) && $prevPairing[0]['value'] == 'No') {
+			sysCmd('pkill -f qbzd-login 2> /dev/null');
+			sysCmd('qbzd logout');
+		}
+	}
 	foreach ($_POST['config'] as $key => $value) {
 		chkValue($key, $value);
 		sqlUpdate('cfg_qobuz', $dbh, $key, $value);
@@ -22,7 +33,11 @@ if (isset($_POST['save']) && $_POST['save'] == '1') {
 	submitJob('qobuzsvc', '', $notify['title'], $notify['msg']);
 }
 if (isset($_POST['qobuz_login']) && $_POST['qobuz_login'] == '1') {
-	submitJob('qobuz_login', '', NOTIFY_TITLE_INFO, 'Login started, refresh this screen to view the login link');
+	// The button is disabled while pairing is on; guard the POST as well.
+	$pairing = sqlQuery("SELECT value FROM cfg_qobuz WHERE param='pairing'", $dbh);
+	if (empty($pairing[0]['value']) || $pairing[0]['value'] != 'Yes') {
+		submitJob('qobuz_login', '', NOTIFY_TITLE_INFO, 'Login started, refresh this screen to view the login link');
+	}
 }
 if (isset($_POST['qobuz_logout']) && $_POST['qobuz_logout'] == '1') {
 	submitJob('qobuz_logout', '', NOTIFY_TITLE_INFO, 'Logged out from Qobuz');
@@ -41,6 +56,17 @@ foreach ($result as $row) {
 if (!isset($cfgQobuz['pairing'])) {
 	sqlInsert('cfg_qobuz', $dbh, "'pairing', 'Yes'");
 	$cfgQobuz['pairing'] = 'Yes';
+}
+
+// Local pairing supplies the account (the casting app hands over its own
+// session), so the fixed-account Login is gated while it is on.
+$_qobuz_login_disabled = '';
+$_qobuz_login_hint = '';
+if ($cfgQobuz['pairing'] == 'Yes') {
+	$_qobuz_login_disabled = 'disabled';
+	$_qobuz_login_hint = '<span class="config-help-static">No login needed: Local pairing is on, ' .
+		'so the Qobuz app hands this player its own account when casting. ' .
+		'To use a fixed account instead, set Local pairing to No and Save.</span>';
 }
 
 $_select['quality'] .= "<option value=\"mp3\" " . (($cfgQobuz['quality'] == 'mp3') ? "selected" : "") . ">MP3 320 kbps</option>\n";
@@ -67,12 +93,7 @@ if ($_SESSION['qobuzsvc'] == '1') {
 			(empty($status['auth']['subscription']) ? '' : ' (' . $status['auth']['subscription'] . ')');
 	} else {
 		$_qobuz_login_hide = '';
-		// With the pairing surface up, a login is optional: the Qobuz app hands
-		// the player its own session tokens when someone casts to it.
-		$pairingOn = isset($status['qconnect']['pairing']) && $status['qconnect']['pairing'] === true;
-		$_qobuz_account_status = $pairingOn ?
-			'Not logged in (optional: any Qobuz app on this network can cast to this player)' :
-			'Not logged in';
+		$_qobuz_account_status = 'Not logged in';
 		// A login in progress prints its URL to the login log
 		$loginLog = file_exists(QOBUZ_LOGIN_LOG) ? file_get_contents(QOBUZ_LOGIN_LOG) : '';
 		if (preg_match('#https?://\S+#', $loginLog, $matches) === 1) {

--- a/www/qbz-config.php
+++ b/www/qbz-config.php
@@ -5,6 +5,7 @@
 */
 
 require_once __DIR__ . '/inc/common.php';
+require_once __DIR__ . '/inc/renderer.php';
 require_once __DIR__ . '/inc/session.php';
 require_once __DIR__ . '/inc/sql.php';
 
@@ -53,12 +54,41 @@ foreach ($result as $row) {
 }
 // Self-heal a cfg_qobuz that predates a param: without the row, the generic
 // UPDATE in the save handler would silently no-op.
-$qobuzDefaults = array('pairing' => 'Yes', 'buffer_seconds' => '2', 'volume_mode' => 'software');
+$qobuzDefaults = array('pairing' => 'Yes', 'buffer_seconds' => '2', 'volume_mode' => 'auto',
+	'output_mode' => 'auto', 'stream_first' => 'Yes', 'track_cache' => 'No',
+	'quality_fallback' => 'fallback');
 foreach ($qobuzDefaults as $param => $default) {
 	if (!isset($cfgQobuz[$param])) {
 		sqlInsert('cfg_qobuz', $dbh, "'" . $param . "', '" . $default . "'");
 		$cfgQobuz[$param] = $default;
 	}
+}
+
+// One control-API read for everything on this screen that needs the daemon.
+$qbzStatus = array();
+if ($_SESSION['qobuzsvc'] == '1') {
+	$result = sysCmd('curl -s --max-time 2 http://127.0.0.1:8182/api/status');
+	$decoded = json_decode(implode('', $result), true);
+	if (is_array($decoded)) {
+		$qbzStatus = $decoded;
+	}
+}
+
+// What Output routing actually resolves to on this box. Shown because "Auto"
+// is otherwise unanswerable without reading ALSA configs by hand, and the
+// reason is the useful half when it does not resolve to Direct.
+$routing = qobuzDirectRouting();
+$_qobuz_routing_resolves = $routing['direct'] ?
+	'Direct (' . $routing['device'] . ')' :
+	'Software' . ($routing['reason'] == '' ? '' : ' &mdash; ' . $routing['reason']);
+
+// Hardware volume needs both a direct handoff and a DAC that has a volume
+// control; say which one is missing rather than hiding the option.
+$hwVolumeReason = '';
+if (!$routing['direct']) {
+	$hwVolumeReason = 'n/a &mdash; using Software routing';
+} else if (qobuzSess('alsavolume', 'none') == 'none') {
+	$hwVolumeReason = 'n/a &mdash; this DAC has no hardware volume control';
 }
 
 // Local pairing supplies the account (the casting app hands over its own
@@ -78,24 +108,53 @@ $_select['quality'] .= "<option value=\"hires\" " . (($cfgQobuz['quality'] == 'h
 $_select['quality'] .= "<option value=\"hires_plus\" " . (($cfgQobuz['quality'] == 'hires_plus') ? "selected" : "") . ">Hi-Res 24 bit / 192 kHz (Default)</option>\n";
 $_select['pairing'] .= "<option value=\"Yes\" " . (($cfgQobuz['pairing'] == 'Yes') ? "selected" : "") . ">Yes (Default)</option>\n";
 $_select['pairing'] .= "<option value=\"No\" "  . (($cfgQobuz['pairing'] == 'No')  ? "selected" : "") . ">No</option>\n";
-$_select['gapless'] .= "<option value=\"Yes\" " . (($cfgQobuz['gapless'] == 'Yes') ? "selected" : "") . ">Yes (Default)</option>\n";
-$_select['gapless'] .= "<option value=\"No\" "  . (($cfgQobuz['gapless'] == 'No')  ? "selected" : "") . ">No</option>\n";
+// The gapless prefetch is a no-op in streaming-only mode, so with caching off
+// gapless cannot happen at all. Lock the control and show the value actually in
+// force rather than leaving a stored "Yes" on screen that does nothing. A
+// disabled select posts nothing, so the stored preference survives untouched
+// and comes back as soon as caching is turned on again.
+$_gapless_disabled = $cfgQobuz['track_cache'] == 'Yes' ? '' : 'disabled';
+$_gapless_hint = '';
+if ($_gapless_disabled == '') {
+	$_select['gapless'] .= "<option value=\"Yes\" " . (($cfgQobuz['gapless'] == 'Yes') ? "selected" : "") . ">Yes (Default)</option>\n";
+	$_select['gapless'] .= "<option value=\"No\" "  . (($cfgQobuz['gapless'] == 'No')  ? "selected" : "") . ">No</option>\n";
+} else {
+	$_select['gapless'] .= "<option value=\"No\" selected>No</option>\n";
+	$_gapless_hint = '<span class="config-help-static">Not available: Track cache is set to ' .
+		'stream only, and gapless needs the next track cached ahead of time.</span>';
+}
 $_select['normalize_volume'] .= "<option value=\"Yes\" " . (($cfgQobuz['normalize_volume'] == 'Yes') ? "selected" : "") . ">Yes</option>\n";
 $_select['normalize_volume'] .= "<option value=\"No\" "  . (($cfgQobuz['normalize_volume'] == 'No')  ? "selected" : "") . ">No (Default)</option>\n";
 foreach (array('2' => '2 seconds (Default)', '5' => '5 seconds', '10' => '10 seconds') as $secs => $label) {
 	$_select['buffer_seconds'] .= "<option value=\"" . $secs . "\" " .
 		(($cfgQobuz['buffer_seconds'] == $secs) ? "selected" : "") . ">" . $label . "</option>\n";
 }
-$_select['volume_mode'] .= "<option value=\"software\" " . (($cfgQobuz['volume_mode'] == 'software') ? "selected" : "") . ">Software (Default)</option>\n";
+$_select['output_mode'] .= "<option value=\"auto\" "     . (($cfgQobuz['output_mode'] == 'auto')     ? "selected" : "") . ">ALSA output mode (Auto) (Default)</option>\n";
+$_select['output_mode'] .= "<option value=\"software\" " . (($cfgQobuz['output_mode'] == 'software') ? "selected" : "") . ">Software</option>\n";
+$_select['output_mode'] .= "<option value=\"direct\" "   . (($cfgQobuz['output_mode'] == 'direct')   ? "selected" : "") . ">Direct</option>\n";
+
+$_select['volume_mode'] .= "<option value=\"auto\" " . (($cfgQobuz['volume_mode'] == 'auto') ? "selected" : "") . ">Auto (Default)</option>\n";
+$_select['volume_mode'] .= "<option value=\"hardware\" " . (($cfgQobuz['volume_mode'] == 'hardware') ? "selected" : "") .
+	($hwVolumeReason == '' ? "" : " disabled") . ">DAC hardware volume" .
+	($hwVolumeReason == '' ? "" : " (" . $hwVolumeReason . ")") . "</option>\n";
+$_select['volume_mode'] .= "<option value=\"software\" " . (($cfgQobuz['volume_mode'] == 'software') ? "selected" : "") . ">Software</option>\n";
 $_select['volume_mode'] .= "<option value=\"locked\" "   . (($cfgQobuz['volume_mode'] == 'locked')   ? "selected" : "") . ">Locked at 100%</option>\n";
+
+$_select['stream_first'] .= "<option value=\"Yes\" " . (($cfgQobuz['stream_first'] == 'Yes') ? "selected" : "") . ">As soon as buffered (Default)</option>\n";
+$_select['stream_first'] .= "<option value=\"No\" "  . (($cfgQobuz['stream_first'] == 'No')  ? "selected" : "") . ">After the full track downloads</option>\n";
+
+$_select['track_cache'] .= "<option value=\"No\" "  . (($cfgQobuz['track_cache'] == 'No')  ? "selected" : "") . ">Stream only, do not cache (Default)</option>\n";
+$_select['track_cache'] .= "<option value=\"Yes\" " . (($cfgQobuz['track_cache'] == 'Yes') ? "selected" : "") . ">Cache tracks on disk</option>\n";
+
+$_select['quality_fallback'] .= "<option value=\"fallback\" " . (($cfgQobuz['quality_fallback'] == 'fallback') ? "selected" : "") . ">Play at a lower quality (Default)</option>\n";
+$_select['quality_fallback'] .= "<option value=\"skip\" "     . (($cfgQobuz['quality_fallback'] == 'skip')     ? "selected" : "") . ">Skip the track</option>\n";
 
 // Account: login status is read from the qbzd control API (only available when the service is on)
 $_qobuz_login_hide = 'hide';
 $_qobuz_logout_hide = 'hide';
 $_qobuz_login_url_msg = '';
 if ($_SESSION['qobuzsvc'] == '1') {
-	$result = sysCmd('curl -s --max-time 2 http://127.0.0.1:8182/api/status');
-	$status = json_decode(implode('', $result), true);
+	$status = $qbzStatus;
 	if (isset($status['auth']['state']) && $status['auth']['state'] != 'needs_auth') {
 		$_qobuz_logout_hide = '';
 		$_qobuz_account_status = 'Logged in' .

--- a/www/qbz-config.php
+++ b/www/qbz-config.php
@@ -55,7 +55,7 @@ foreach ($result as $row) {
 // Self-heal a cfg_qobuz that predates a param: without the row, the generic
 // UPDATE in the save handler would silently no-op.
 $qobuzDefaults = array('pairing' => 'Yes', 'buffer_seconds' => '2', 'volume_mode' => 'auto',
-	'output_mode' => 'auto', 'stream_first' => 'Yes', 'track_cache' => 'No',
+	'output_mode' => 'auto', 'stream_first' => 'Yes', 'track_cache' => 'Yes',
 	'quality_fallback' => 'fallback');
 foreach ($qobuzDefaults as $param => $default) {
 	if (!isset($cfgQobuz[$param])) {
@@ -143,8 +143,8 @@ $_select['volume_mode'] .= "<option value=\"locked\" "   . (($cfgQobuz['volume_m
 $_select['stream_first'] .= "<option value=\"Yes\" " . (($cfgQobuz['stream_first'] == 'Yes') ? "selected" : "") . ">As soon as buffered (Default)</option>\n";
 $_select['stream_first'] .= "<option value=\"No\" "  . (($cfgQobuz['stream_first'] == 'No')  ? "selected" : "") . ">After the full track downloads</option>\n";
 
-$_select['track_cache'] .= "<option value=\"No\" "  . (($cfgQobuz['track_cache'] == 'No')  ? "selected" : "") . ">Stream only, do not cache (Default)</option>\n";
-$_select['track_cache'] .= "<option value=\"Yes\" " . (($cfgQobuz['track_cache'] == 'Yes') ? "selected" : "") . ">Cache tracks on disk</option>\n";
+$_select['track_cache'] .= "<option value=\"Yes\" " . (($cfgQobuz['track_cache'] == 'Yes') ? "selected" : "") . ">Cache tracks on disk (Default)</option>\n";
+$_select['track_cache'] .= "<option value=\"No\" "  . (($cfgQobuz['track_cache'] == 'No')  ? "selected" : "") . ">Stream only, do not cache</option>\n";
 
 $_select['quality_fallback'] .= "<option value=\"fallback\" " . (($cfgQobuz['quality_fallback'] == 'fallback') ? "selected" : "") . ">Play at a lower quality (Default)</option>\n";
 $_select['quality_fallback'] .= "<option value=\"skip\" "     . (($cfgQobuz['quality_fallback'] == 'skip')     ? "selected" : "") . ">Skip the track</option>\n";

--- a/www/qbz-config.php
+++ b/www/qbz-config.php
@@ -51,11 +51,14 @@ $cfgQobuz = array();
 foreach ($result as $row) {
 	$cfgQobuz[$row['param']] = $row['value'];
 }
-// Self-heal a cfg_qobuz that predates the pairing param: without the row,
-// the generic UPDATE in the save handler would silently no-op.
-if (!isset($cfgQobuz['pairing'])) {
-	sqlInsert('cfg_qobuz', $dbh, "'pairing', 'Yes'");
-	$cfgQobuz['pairing'] = 'Yes';
+// Self-heal a cfg_qobuz that predates a param: without the row, the generic
+// UPDATE in the save handler would silently no-op.
+$qobuzDefaults = array('pairing' => 'Yes', 'buffer_seconds' => '2', 'volume_mode' => 'software');
+foreach ($qobuzDefaults as $param => $default) {
+	if (!isset($cfgQobuz[$param])) {
+		sqlInsert('cfg_qobuz', $dbh, "'" . $param . "', '" . $default . "'");
+		$cfgQobuz[$param] = $default;
+	}
 }
 
 // Local pairing supplies the account (the casting app hands over its own
@@ -79,6 +82,12 @@ $_select['gapless'] .= "<option value=\"Yes\" " . (($cfgQobuz['gapless'] == 'Yes
 $_select['gapless'] .= "<option value=\"No\" "  . (($cfgQobuz['gapless'] == 'No')  ? "selected" : "") . ">No</option>\n";
 $_select['normalize_volume'] .= "<option value=\"Yes\" " . (($cfgQobuz['normalize_volume'] == 'Yes') ? "selected" : "") . ">Yes</option>\n";
 $_select['normalize_volume'] .= "<option value=\"No\" "  . (($cfgQobuz['normalize_volume'] == 'No')  ? "selected" : "") . ">No (Default)</option>\n";
+foreach (array('2' => '2 seconds (Default)', '5' => '5 seconds', '10' => '10 seconds') as $secs => $label) {
+	$_select['buffer_seconds'] .= "<option value=\"" . $secs . "\" " .
+		(($cfgQobuz['buffer_seconds'] == $secs) ? "selected" : "") . ">" . $label . "</option>\n";
+}
+$_select['volume_mode'] .= "<option value=\"software\" " . (($cfgQobuz['volume_mode'] == 'software') ? "selected" : "") . ">Software (Default)</option>\n";
+$_select['volume_mode'] .= "<option value=\"locked\" "   . (($cfgQobuz['volume_mode'] == 'locked')   ? "selected" : "") . ">Locked at 100%</option>\n";
 
 // Account: login status is read from the qbzd control API (only available when the service is on)
 $_qobuz_login_hide = 'hide';

--- a/www/relnotes.txt
+++ b/www/relnotes.txt
@@ -17,6 +17,7 @@
 
 New features:
 - NEW: Wide layout for AirPlay and Spotify Connect metadata display
+- NEW: Qobuz Connect renderer with metadata and cover art (qbzd)
 
 Updates:
 - UPD: Improve Radio Browser notification messages, reduce messages

--- a/www/ren-config.php
+++ b/www/ren-config.php
@@ -141,6 +141,31 @@ if (isset($_POST['deezerrestart']) && $_POST['deezerrestart'] == 1 && $_SESSION[
 	submitJob('deezersvc', '', NOTIFY_TITLE_INFO, NAME_DEEZER . NOTIFY_MSG_SVC_MANUAL_RESTART);
 }
 
+// Qobuz Connect
+if (isset($_POST['install_qobuz'])) {
+	submitJob('install_qobuz');
+	header('location: ren-status.php');
+}
+if (isset($_POST['update_qobuz_settings'])) {
+	if (isset($_POST['qobuzname']) && $_POST['qobuzname'] != $_SESSION['qobuzname']) {
+		$update = true;
+		phpSession('write', 'qobuzname', $_POST['qobuzname']);
+	}
+	if (isset($_POST['qobuzsvc']) && $_POST['qobuzsvc'] != $_SESSION['qobuzsvc']) {
+		$update = true;
+		phpSession('write', 'qobuzsvc', $_POST['qobuzsvc']);
+	}
+	if (isset($update)) {
+		submitJob('qobuzsvc');
+	}
+}
+if (isset($_POST['update_rsmafterqbz'])) {
+	phpSession('write', 'rsmafterqbz', $_POST['rsmafterqbz']);
+}
+if (isset($_POST['qobuzrestart']) && $_POST['qobuzrestart'] == 1 && $_SESSION['qobuzsvc'] == '1') {
+	submitJob('qobuzsvc', '', NOTIFY_TITLE_INFO, NAME_QOBUZ . NOTIFY_MSG_SVC_MANUAL_RESTART);
+}
+
 // UPnP client for MPD
 if (isset($_POST['update_upnp_settings'])) {
 	$currentUpnpName = $_SESSION['upnpname'];
@@ -342,6 +367,39 @@ $_select['deezername'] = $_SESSION['deezername'];
 $autoClick = " onchange=\"autoClick('#btn-set-rsmafterdeez');\" " . $_deezer_btn_disable;
 $_select['rsmafterdeez_on'] .= "<input type=\"radio\" name=\"rsmafterdeez\" id=\"toggle-rsmafterdeez-1\" value=\"Yes\" " . (($_SESSION['rsmafterdeez'] == 'Yes') ? "checked=\"checked\"" : "") . $autoClick . ">\n";
 $_select['rsmafterdeez_off']  .= "<input type=\"radio\" name=\"rsmafterdeez\" id=\"toggle-rsmafterdeez-2\" value=\"No\" " . (($_SESSION['rsmafterdeez'] == 'No') ? "checked=\"checked\"" : "") . $autoClick . ">\n";
+
+// Qobuz Connect
+$_feat_qobuz = $_SESSION['feat_bitmask'] & FEAT_QOBUZ ? '' : 'hide';
+if (isQobuzInstalled() === true) {
+	$_install_qobuz_hide = 'hide';
+	$_qobuz_version_hide = '';
+	$_qobuz_installed_version = 'Version: ' . sysCmd('qbzd --version | awk \'{print $2}\'')[0];
+	$_qobuz_svcbtn_disable = '';
+	$_qobuz_editlink_disable = '';
+} else {
+	$_install_qobuz_hide = '';
+	$_qobuz_version_hide = 'hide';
+	$_qobuz_installed_version = '';
+	$_qobuz_svcbtn_disable = 'disabled';
+	$_qobuz_editlink_disable = 'onclick="return false;"';
+}
+if ($_SESSION['qobuzsvc'] == '1') {
+	$result = sysCmd('curl -s --max-time 2 http://127.0.0.1:8182/api/status');
+	$status = json_decode(implode('', $result), true);
+	$_qobuz_login_msg = (isset($status['auth']['state']) && $status['auth']['state'] == 'needs_auth') ?
+		'<span class="config-help-static"><em>Not logged in to Qobuz yet &mdash; use the Edit screen to log in</em></span>' : '';
+} else {
+	$_qobuz_login_msg = '';
+}
+$_SESSION['qobuzsvc'] == '1' ? $_qobuz_btn_disable = '' : $_qobuz_btn_disable = 'disabled';
+$_SESSION['qobuzsvc'] == '1' ? $_qobuz_link_disable = '' : $_qobuz_link_disable = 'onclick="return false;"';
+$autoClick = " onchange=\"autoClick('#btn-set-qobuzsvc');\" " . $_qobuz_svcbtn_disable;
+$_select['qobuzsvc_on']  .= "<input type=\"radio\" name=\"qobuzsvc\" id=\"toggle-qobuzsvc-1\" value=\"1\" " . (($_SESSION['qobuzsvc'] == '1') ? "checked=\"checked\"" : "") . $autoClick . ">\n";
+$_select['qobuzsvc_off'] .= "<input type=\"radio\" name=\"qobuzsvc\" id=\"toggle-qobuzsvc-2\" value=\"0\" " . (($_SESSION['qobuzsvc'] == '0') ? "checked=\"checked\"" : "") . $autoClick . ">\n";
+$_select['qobuzname'] = $_SESSION['qobuzname'];
+$autoClick = " onchange=\"autoClick('#btn-set-rsmafterqbz');\" " . $_qobuz_btn_disable;
+$_select['rsmafterqbz_on'] .= "<input type=\"radio\" name=\"rsmafterqbz\" id=\"toggle-rsmafterqbz-1\" value=\"Yes\" " . (($_SESSION['rsmafterqbz'] == 'Yes') ? "checked=\"checked\"" : "") . $autoClick . ">\n";
+$_select['rsmafterqbz_off']  .= "<input type=\"radio\" name=\"rsmafterqbz\" id=\"toggle-rsmafterqbz-2\" value=\"No\" " . (($_SESSION['rsmafterqbz'] == 'No') ? "checked=\"checked\"" : "") . $autoClick . ">\n";
 
 // UPnP client for MPD
 $_feat_upmpdcli = $_SESSION['feat_bitmask'] & FEAT_UPMPDCLI ? '' : 'hide';

--- a/www/ren-config.php
+++ b/www/ren-config.php
@@ -165,6 +165,9 @@ if (isset($_POST['update_rsmafterqbz'])) {
 if (isset($_POST['qobuzrestart']) && $_POST['qobuzrestart'] == 1 && $_SESSION['qobuzsvc'] == '1') {
 	submitJob('qobuzsvc', '', NOTIFY_TITLE_INFO, NAME_QOBUZ . NOTIFY_MSG_SVC_MANUAL_RESTART);
 }
+if (isset($_POST['qobuz_clear_credentials']) && $_POST['qobuz_clear_credentials'] == 1) {
+	submitJob('qobuz_clear_credentials', '', NOTIFY_TITLE_INFO, 'Stored Qobuz credentials cleared');
+}
 
 // UPnP client for MPD
 if (isset($_POST['update_upnp_settings'])) {
@@ -390,13 +393,20 @@ if (isQobuzInstalled() === true) {
 	$_qobuz_svcbtn_disable = 'disabled';
 	$_qobuz_editlink_disable = 'onclick="return false;"';
 }
+$_qobuz_login_msg = '';
 if ($_SESSION['qobuzsvc'] == '1') {
 	$result = sysCmd('curl -s --max-time 2 http://127.0.0.1:8182/api/status');
 	$status = json_decode(implode('', $result), true);
-	$_qobuz_login_msg = (isset($status['auth']['state']) && $status['auth']['state'] == 'needs_auth') ?
-		'<span class="config-help-static"><em>Not logged in to Qobuz yet &mdash; use the Edit screen to log in</em></span>' : '';
-} else {
-	$_qobuz_login_msg = '';
+	// "Not logged in" is the NORMAL state with Local pairing on: the casting
+	// Qobuz app hands the player its own session, so nagging about a login
+	// would be telling the user to fix something that is not broken. Only a
+	// fixed-account setup (pairing off) actually needs one.
+	$pairingOn = !isset($status['qconnect']['pairing']) || $status['qconnect']['pairing'] === true;
+	$needsAuth = isset($status['auth']['state']) && $status['auth']['state'] == 'needs_auth';
+	if ($needsAuth && !$pairingOn) {
+		$_qobuz_login_msg = '<span class="config-help-static"><em>Not logged in to Qobuz ' .
+			'&mdash; Local pairing is off, so use the Edit screen to log in</em></span>';
+	}
 }
 $_SESSION['qobuzsvc'] == '1' ? $_qobuz_btn_disable = '' : $_qobuz_btn_disable = 'disabled';
 $_SESSION['qobuzsvc'] == '1' ? $_qobuz_link_disable = '' : $_qobuz_link_disable = 'onclick="return false;"';

--- a/www/ren-config.php
+++ b/www/ren-config.php
@@ -373,13 +373,20 @@ $_feat_qobuz = $_SESSION['feat_bitmask'] & FEAT_QOBUZ ? '' : 'hide';
 if (isQobuzInstalled() === true) {
 	$_install_qobuz_hide = 'hide';
 	$_qobuz_version_hide = '';
-	$_qobuz_installed_version = 'Version: ' . sysCmd('qbzd --version | awk \'{print $2}\'')[0];
+	$_qobuz_installed_version = 'Version: ' . qbzdVersion();
+	// Point at the exact source of a fork build so the installed bits are
+	// traceable — these are pre-release builds of unmerged work.
+	$_qobuz_source_link = isQbzdForkBuild() ?
+		'<br><a class="target-blank-link" href="' . QBZD_FORK_URL . '" target="_blank">' .
+			'Qobuz Connect pairing branch (fork build)</a>' :
+		'';
 	$_qobuz_svcbtn_disable = '';
 	$_qobuz_editlink_disable = '';
 } else {
 	$_install_qobuz_hide = '';
 	$_qobuz_version_hide = 'hide';
 	$_qobuz_installed_version = '';
+	$_qobuz_source_link = '';
 	$_qobuz_svcbtn_disable = 'disabled';
 	$_qobuz_editlink_disable = 'onclick="return false;"';
 }

--- a/www/setup_renderers.txt
+++ b/www/setup_renderers.txt
@@ -34,6 +34,8 @@ from the client and whether CamillaDSP is supported in the playback chain.
 +--------------------------------------------------------------------------------
 | Spotify Connect      | Spotify app (Desktop/Smartphone) | Yes      | Yes
 +--------------------------------------------------------------------------------
+| Qobuz Connect        | Qobuz app (Desktop/Smartphone)   | Yes      | Yes
++--------------------------------------------------------------------------------
 | Squeezelite          | Lyrion Media Server (LMS)        | No       | Yes
 +--------------------------------------------------------------------------------
 | UPnP Client for MPD  | Any UPnP Control Point app       | Yes      | Yes
@@ -54,6 +56,7 @@ another renderer.
 - Bluetooth
 - AirPlay
 - Spotify Connect
+- Qobuz Connect
 - Squeezelite (providing -c <timeout> option is specified)
 - UPnP Client for MPD
 
@@ -83,13 +86,28 @@ Session Based
 The other renderers use Session based protocols that run over existing
 Ethernet or WiFi networks. Since these networks are already present this type
 of renderer operates by establishing a playback session. moOde detects the
-session and displays cover art and track metadata for AirPlay and Spotify
-Connect, or the "Renderer Active" screen for Squeezelite, Plexamp and 
-RoonBridge renderers.
+session and displays cover art and track metadata for AirPlay, Spotify
+Connect and Qobuz Connect, or the "Renderer Active" screen for Squeezelite,
+Plexamp and RoonBridge renderers.
 
 AirPlay and Squeezelite renderers can automatically end their session and
 release the audio output after playback ends based on a configurable timeout
 value.
+
+QOBUZ CONNECT AND ACCOUNTS
+
+Qobuz Connect works differently from the other Session based renderers. There
+is no account stored on the player by default: when a device is selected in the
+Qobuz app's output picker, the app hands the player its own session, so any
+Qobuz account on the network can play to it. This is the "Local pairing"
+setting in Qobuz Config and it is on by default. The most recent client to
+select the player takes over from the previous one, in the same way as Spotify
+Connect.
+
+Turning Local pairing off makes the player use one fixed account instead. In
+that mode the LOGIN button in Qobuz Config is used to sign in via a browser,
+and only that account can play to the player. The CLEAR button in Renderer
+Config removes stored account credentials at any time.
 
 RECEIVE-ONLY RENDERERS
 

--- a/www/templates/qbz-config.html
+++ b/www/templates/qbz-config.html
@@ -19,7 +19,7 @@
 
 			<div class="config-horiz-rule">General</div>
 
-			<label class="control-label" for="quality">Audio quality</label>
+			<label class="control-label" for="quality">Stream quality</label>
 			<div class="controls">
 				<select id="quality" class="config-select-large" name="config[quality]">
 					$_select[quality]
@@ -28,17 +28,6 @@
 				<span id="info-quality" class="config-help-info">
 					Maximum streaming quality. Tracks not available at the selected quality are streamed at the highest quality available for your subscription.
                 </span>
-			</div>
-
-			<label class="control-label" for="gapless">Gapless playback</label>
-			<div class="controls">
-				<select id="gapless" class="config-select-large" name="config[gapless]">
-					$_select[gapless]
-				</select>
-				<a aria-label="Help" class="config-info-toggle" data-cmd="info-gapless" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
-				<span id="info-gapless" class="config-help-info">
-					Play consecutive tracks without a gap of silence between them.
-				</span>
 			</div>
 
 			<label class="control-label" for="buffer-seconds">Buffer</label>
@@ -54,6 +43,33 @@
 				</span>
 			</div>
 
+			<div class="config-horiz-rule">Output</div>
+
+			<label class="control-label" for="output-mode">Output routing</label>
+			<div class="controls">
+				<select id="output-mode" class="config-select-large" name="config[output_mode]">
+					$_select[output_mode]
+				</select>
+				<a aria-label="Help" class="config-info-toggle" data-cmd="info-output-mode" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
+				<span id="info-output-mode" class="config-help-info">
+					Where Qobuz playback sends audio:
+					<br>&bull; <b>ALSA output mode (Auto)</b> &mdash; picks Direct whenever Audio Config
+					has Output mode set to Direct and no DSP is enabled, in other words whenever moOde's
+					own output chain has nothing in it to lose. Falls back to Software otherwise.
+					<br>&bull; <b>Software</b> &mdash; goes through the same output chain as MPD, so your
+					EQ, crossfeed and CamillaDSP settings apply. The stream is converted to whatever rate
+					that chain is running at, which is usually not the rate of the track.
+					<br>&bull; <b>Direct</b> &mdash; hands the DAC the track's own rate untouched, for
+					bit-perfect playback. moOde's DSP is bypassed and the DAC is reserved for as long as
+					a Qobuz session is active, so nothing else can play through it.
+				</span>
+			</div>
+
+			<label class="control-label">Resolves to</label>
+			<div class="controls">
+				<span class="config-help-static">$_qobuz_routing_resolves</span>
+			</div>
+
 			<label class="control-label" for="volume-mode">Volume control</label>
 			<div class="controls">
 				<select id="volume-mode" class="config-select-large" name="config[volume_mode]">
@@ -61,9 +77,17 @@
 				</select>
 				<a aria-label="Help" class="config-info-toggle" data-cmd="info-volume-mode" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
 				<span id="info-volume-mode" class="config-help-info">
-					Software lets the Qobuz app's volume slider attenuate the stream. Locked keeps the
-					stream at full scale for bit-perfect output, so the app's slider does nothing and
-					volume must come from your amplifier or DAC.
+					How the Qobuz app's volume slider is applied:
+					<br>&bull; <b>Auto</b> &mdash; uses the DAC's own volume control when that is possible,
+					otherwise software.
+					<br>&bull; <b>DAC hardware volume</b> &mdash; sends the slider to the DAC's volume
+					control, so the audio stays bit-perfect. Needs Direct routing and a DAC that has a
+					hardware volume control. This is the same control moOde's volume uses, so a change
+					made from the Qobuz app persists and affects moOde playback afterwards.
+					<br>&bull; <b>Software</b> &mdash; scales the samples instead. Works with any output,
+					but the audio is no longer bit-perfect.
+					<br>&bull; <b>Locked at 100%</b> &mdash; keeps the stream at full scale and ignores
+					the app's slider, so volume must come from your amplifier or DAC.
 				</span>
 			</div>
 
@@ -75,6 +99,70 @@
 				<a aria-label="Help" class="config-info-toggle" data-cmd="info-normalize-volume" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
 				<span id="info-normalize-volume" class="config-help-info">
 					Adjusts the volume of all songs played so that they sound as though they are of equal loudness.
+				</span>
+			</div>
+
+			<div class="config-horiz-rule">Playback</div>
+
+			<label class="control-label" for="stream-first">Start playback</label>
+			<div class="controls">
+				<select id="stream-first" class="config-select-large" name="config[stream_first]">
+					$_select[stream_first]
+				</select>
+				<a aria-label="Help" class="config-info-toggle" data-cmd="info-stream-first" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
+				<span id="info-stream-first" class="config-help-info">
+					Whether a track that is not already cached starts as soon as enough of it has
+					arrived, or waits for the whole file:
+					<br>&bull; <b>As soon as buffered</b> &mdash; playback starts in a second or two
+					instead of tens of seconds.
+					<br>&bull; <b>After the full track downloads</b> &mdash; steadier on an unreliable
+					connection, at the cost of a long pause before every new track.
+				</span>
+			</div>
+
+			<label class="control-label" for="track-cache">Track cache</label>
+			<div class="controls">
+				<select id="track-cache" class="config-select-large" name="config[track_cache]">
+					$_select[track_cache]
+				</select>
+				<a aria-label="Help" class="config-info-toggle" data-cmd="info-track-cache" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
+				<span id="info-track-cache" class="config-help-info">
+					Whether finished tracks are kept on disk for instant replay:
+					<br>&bull; <b>Stream only, do not cache</b> &mdash; writes nothing to the SD card.
+					A hi-res track is 60&ndash;80 MB, so this spares the card over a long listening
+					session. Gapless playback is not possible without the cache.
+					<br>&bull; <b>Cache tracks on disk</b> &mdash; replaying a track is instant, and
+					gapless playback works because the next track can be loaded ahead of time.
+				</span>
+			</div>
+
+			<label class="control-label" for="gapless">Gapless playback</label>
+			<div class="controls">
+				<select id="gapless" class="config-select-large" name="config[gapless]" $_gapless_disabled>
+					$_select[gapless]
+				</select>
+				<a aria-label="Help" class="config-info-toggle" data-cmd="info-gapless" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
+				<span id="info-gapless" class="config-help-info">
+					Play consecutive tracks without a gap of silence between them. Needs Track cache
+					set to keep tracks on disk: the next track has to be loaded ahead of time, which
+					is not possible when nothing is cached.
+				</span>
+				$_gapless_hint
+			</div>
+
+			<label class="control-label" for="quality-fallback">If the quality is unavailable</label>
+			<div class="controls">
+				<select id="quality-fallback" class="config-select-large" name="config[quality_fallback]">
+					$_select[quality_fallback]
+				</select>
+				<a aria-label="Help" class="config-info-toggle" data-cmd="info-quality-fallback" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
+				<span id="info-quality-fallback" class="config-help-info">
+					What to do when a track cannot be played at the selected quality, either because
+					your subscription does not include it or because your DAC cannot do that rate:
+					<br>&bull; <b>Play at a lower quality</b> &mdash; the track still plays.
+					<br>&bull; <b>Skip the track</b> &mdash; quality stays guaranteed, at the cost of
+					silent gaps in an album. This matters more with Direct routing, where there is no
+					conversion step to fall back on.
 				</span>
 			</div>
 

--- a/www/templates/qbz-config.html
+++ b/www/templates/qbz-config.html
@@ -1,0 +1,79 @@
+<!--
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright 2014 The moOde audio player project / Tim Curtis
+*/
+-->
+<div id="container">
+<div class="container">
+	<h1 class="ren-config">Qobuz Connect</h1>
+
+	<!-- TEMPLATE -->
+
+    <form class="form-horizontal" action="" method="post">
+    	<legend>Settings
+			<button class="legend-config btn btn-medium btn-primary btn-submit" type="submit" name="save" value="1">Save</button>
+		</legend>
+
+		<div class="control-group">
+
+			<div class="config-horiz-rule">General</div>
+
+			<label class="control-label" for="quality">Audio quality</label>
+			<div class="controls">
+				<select id="quality" class="config-select-large" name="config[quality]">
+					$_select[quality]
+				</select>
+				<a aria-label="Help" class="config-info-toggle" data-cmd="info-quality" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
+				<span id="info-quality" class="config-help-info">
+					Maximum streaming quality. Tracks not available at the selected quality are streamed at the highest quality available for your subscription.
+                </span>
+			</div>
+
+			<label class="control-label" for="gapless">Gapless playback</label>
+			<div class="controls">
+				<select id="gapless" class="config-select-large" name="config[gapless]">
+					$_select[gapless]
+				</select>
+				<a aria-label="Help" class="config-info-toggle" data-cmd="info-gapless" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
+				<span id="info-gapless" class="config-help-info">
+					Play consecutive tracks without a gap of silence between them.
+				</span>
+			</div>
+
+			<label class="control-label" for="normalize-volume">Normalize volume</label>
+			<div class="controls">
+				<select id="normalize-volume" class="config-select-large" name="config[normalize_volume]">
+					$_select[normalize_volume]
+				</select>
+				<a aria-label="Help" class="config-info-toggle" data-cmd="info-normalize-volume" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
+				<span id="info-normalize-volume" class="config-help-info">
+					Adjusts the volume of all songs played so that they sound as though they are of equal loudness.
+				</span>
+			</div>
+
+			<div class="config-horiz-rule">Account</div>
+
+			<label class="control-label">Status</label>
+			<div class="controls">
+				<span class="config-help-static">$_qobuz_account_status</span>
+			</div>
+
+			<div class="$_qobuz_login_hide">
+				<div class="controls">
+					<button class="btn btn-medium btn-primary config-btn btn-submit" type="submit" name="qobuz_login" value="1">Login</button>
+					<span class="config-btn-after">Qobuz account</span>
+					$_qobuz_login_url_msg
+				</div>
+			</div>
+
+			<div class="$_qobuz_logout_hide">
+				<div class="controls">
+					<button class="btn btn-medium btn-primary config-btn btn-submit" type="submit" name="qobuz_logout" value="1">Logout</button>
+					<span class="config-btn-after">Qobuz account</span>
+				</div>
+			</div>
+		</div>
+	</form>
+</div>
+</div>

--- a/www/templates/qbz-config.html
+++ b/www/templates/qbz-config.html
@@ -41,6 +41,32 @@
 				</span>
 			</div>
 
+			<label class="control-label" for="buffer-seconds">Buffer</label>
+			<div class="controls">
+				<select id="buffer-seconds" class="config-select-large" name="config[buffer_seconds]">
+					$_select[buffer_seconds]
+				</select>
+				<a aria-label="Help" class="config-info-toggle" data-cmd="info-buffer-seconds" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
+				<span id="info-buffer-seconds" class="config-help-info">
+					How much audio to buffer before playback starts. A larger buffer rides out network
+					hiccups on a slow or wireless connection at the cost of a longer wait when starting
+					a track or switching output to this player.
+				</span>
+			</div>
+
+			<label class="control-label" for="volume-mode">Volume control</label>
+			<div class="controls">
+				<select id="volume-mode" class="config-select-large" name="config[volume_mode]">
+					$_select[volume_mode]
+				</select>
+				<a aria-label="Help" class="config-info-toggle" data-cmd="info-volume-mode" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
+				<span id="info-volume-mode" class="config-help-info">
+					Software lets the Qobuz app's volume slider attenuate the stream. Locked keeps the
+					stream at full scale for bit-perfect output, so the app's slider does nothing and
+					volume must come from your amplifier or DAC.
+				</span>
+			</div>
+
 			<label class="control-label" for="normalize-volume">Normalize volume</label>
 			<div class="controls">
 				<select id="normalize-volume" class="config-select-large" name="config[normalize_volume]">

--- a/www/templates/qbz-config.html
+++ b/www/templates/qbz-config.html
@@ -30,19 +30,6 @@
                 </span>
 			</div>
 
-			<label class="control-label" for="pairing">Local pairing</label>
-			<div class="controls">
-				<select id="pairing" class="config-select-large" name="config[pairing]">
-					$_select[pairing]
-				</select>
-				<a aria-label="Help" class="config-info-toggle" data-cmd="info-pairing" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
-				<span id="info-pairing" class="config-help-info">
-					Advertise this player on the network so any Qobuz app can cast to it without
-					logging in below. The app hands the player its own session when a device is
-					selected; the most recent cast takes over, like Spotify Connect.
-				</span>
-			</div>
-
 			<label class="control-label" for="gapless">Gapless playback</label>
 			<div class="controls">
 				<select id="gapless" class="config-select-large" name="config[gapless]">
@@ -67,6 +54,20 @@
 
 			<div class="config-horiz-rule">Account</div>
 
+			<label class="control-label" for="pairing">Local pairing</label>
+			<div class="controls">
+				<select id="pairing" class="config-select-large" name="config[pairing]">
+					$_select[pairing]
+				</select>
+				<a aria-label="Help" class="config-info-toggle" data-cmd="info-pairing" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
+				<span id="info-pairing" class="config-help-info">
+					Advertise this player on the network so any Qobuz app can cast to it without
+					a login. The app hands the player its own session when a device is selected;
+					the most recent cast takes over, like Spotify Connect. Turn this off to log
+					the player into a fixed Qobuz account instead.
+				</span>
+			</div>
+
 			<label class="control-label">Status</label>
 			<div class="controls">
 				<span class="config-help-static">$_qobuz_account_status</span>
@@ -74,8 +75,9 @@
 
 			<div class="$_qobuz_login_hide">
 				<div class="controls">
-					<button class="btn btn-medium btn-primary config-btn btn-submit" type="submit" name="qobuz_login" value="1">Login</button>
+					<button class="btn btn-medium btn-primary config-btn btn-submit" type="submit" name="qobuz_login" value="1" $_qobuz_login_disabled>Login</button>
 					<span class="config-btn-after">Qobuz account</span>
+					$_qobuz_login_hint
 					$_qobuz_login_url_msg
 				</div>
 			</div>

--- a/www/templates/qbz-config.html
+++ b/www/templates/qbz-config.html
@@ -30,6 +30,19 @@
                 </span>
 			</div>
 
+			<label class="control-label" for="pairing">Local pairing</label>
+			<div class="controls">
+				<select id="pairing" class="config-select-large" name="config[pairing]">
+					$_select[pairing]
+				</select>
+				<a aria-label="Help" class="config-info-toggle" data-cmd="info-pairing" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
+				<span id="info-pairing" class="config-help-info">
+					Advertise this player on the network so any Qobuz app can cast to it without
+					logging in below. The app hands the player its own session when a device is
+					selected; the most recent cast takes over, like Spotify Connect.
+				</span>
+			</div>
+
 			<label class="control-label" for="gapless">Gapless playback</label>
 			<div class="controls">
 				<select id="gapless" class="config-select-large" name="config[gapless]">

--- a/www/templates/ren-config.html
+++ b/www/templates/ren-config.html
@@ -307,7 +307,7 @@
 			<div class="$_qobuz_version_hide">
 				<label class="control-label">Qbzd</label>
 				<div class="controls">
-					<span class="config-help-static">$_qobuz_installed_version</span>
+					<span class="config-help-static">$_qobuz_installed_version$_qobuz_source_link</span>
 				</div>
 			</div>
 

--- a/www/templates/ren-config.html
+++ b/www/templates/ren-config.html
@@ -290,6 +290,70 @@
 				$_deezer_credentials_msg
 			</div>
 		</div>
+
+		<div class="control-group $_feat_qobuz">
+			<legend>Qobuz Connect</legend>
+
+			<div class="$_install_qobuz_hide">
+				<label class="control-label">Qbzd</label>
+				<div class="controls">
+					<button class="btn btn-primary btn-small config-btn set-button btn-submit" type="submit" name="install_qobuz" value="1">Install</button>
+					<span class="config-help-static">
+						This renderer is not installed. View the <a href="./install_renderers.txt" class="target-blank-link" target="_blank">Installation guide</a> for more information.
+					</span>
+				</div>
+			</div>
+
+			<div class="$_qobuz_version_hide">
+				<label class="control-label">Qbzd</label>
+				<div class="controls">
+					<span class="config-help-static">$_qobuz_installed_version</span>
+				</div>
+			</div>
+
+			<label class="control-label">Service</label>
+			<div class="controls">
+				<div class="toggle">
+					<label class="toggle-radio toggle-qobuzsvc" for="toggle-qobuzsvc-2">ON </label>$_select[qobuzsvc_on]
+					<label class="toggle-radio toggle-qobuzsvc" for="toggle-qobuzsvc-1">OFF</label>$_select[qobuzsvc_off]
+				</div>
+				<button id="btn-set-qobuzsvc" class="hide btn btn-primary btn-small config-btn-set btn-submit" type="submit" name="update_qobuz_settings" value="novalue"><i class="fa fa-solid fa-sharp fa-arrow-turn-down-left"></i></button>
+				<a aria-label="Help" class="config-info-toggle" data-cmd="info-qobuzsvc" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
+				<span id="info-qobuzsvc" class="config-help-info">
+					qbzd by vicrodh.
+                </span>
+			</div>
+
+			<label class="control-label" for="qobuzname">Name</label>
+			<div class="controls">
+				<input class="config-input-large" type="text" id="qobuzname" name="qobuzname" value="$_select[qobuzname]" required>
+				<button class="btn btn-primary btn-small config-btn-set btn-submit" type="submit" name="update_qobuz_settings" value="novalue" $_qobuz_svcbtn_disable><i class="fa fa-solid fa-sharp fa-arrow-turn-down-left"></i></button>
+			</div>
+
+			<label class="control-label">Resume MPD</label>
+			<div class="controls">
+				<div class="toggle">
+					<label class="toggle-radio toggle-rsmafterqbz" for="toggle-rsmafterqbz-2">ON </label>$_select[rsmafterqbz_on]
+					<label class="toggle-radio toggle-rsmafterqbz" for="toggle-rsmafterqbz-1">OFF</label>$_select[rsmafterqbz_off]
+				</div>
+				<button id="btn-set-rsmafterqbz" class="hide btn btn-primary btn-small config-btn-set btn-submit" type="submit" name="update_rsmafterqbz" value="novalue" $_qobuz_btn_disable><i class="fa fa-solid fa-sharp fa-arrow-turn-down-left"></i></button>
+				<a aria-label="Help" class="config-info-toggle" data-cmd="info-rsmafterqbz" href="#notarget"><i class="fa-regular fa-sharp fa-info-circle"></i></a>
+				<span id="info-rsmafterqbz" class="config-help-info">
+					Resume MPD playback after Qobuz client stops playing or disconnects.
+                </span>
+			</div>
+
+			<div class="controls">
+				<a data-toggle="modal" href="#qobuz-restart" $_qobuz_link_disable><button class="btn btn-medium btn-primary config-btn" $_qobuz_btn_disable>Restart</button></a>
+				<span class="config-btn-after">Qobuz Connect</span>
+			</div>
+
+			<div class="controls">
+				<a href="qbz-config.php" $_qobuz_editlink_disable><button class="btn btn-medium btn-primary config-btn" $_qobuz_svcbtn_disable>Edit</button></a>
+				<span class="config-btn-after">Qobuz Connect settings</span>
+				$_qobuz_login_msg
+			</div>
+		</div>
 		<div class="control-group $_feat_upmpdcli">
 			<legend>UPnP Client for MPD</legend>
 			<p class="sub-legend">This service functions as a UPnP media renderer that uses MPD for playback.</p>
@@ -549,6 +613,19 @@
 		<div class="modal-footer">
 			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="deezerrestart" value="1">Yes</button>
+		</div>
+	</div>
+</form>
+
+<form class="form-horizontal" method="post">
+	<div id="qobuz-restart" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="qobuz-restart-label" aria-hidden="true">
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
+			<h3>Restart Qobuz connect renderer?</h3>
+		</div>
+		<div class="modal-body"></div>
+		<div class="modal-footer">
+			<button class="btn" data-dismiss="modal">Cancel</button>
+			<button class="btn btn-primary btn-submit" type="submit" name="qobuzrestart" value="1">Yes</button>
 		</div>
 	</div>
 </form>

--- a/www/templates/ren-config.html
+++ b/www/templates/ren-config.html
@@ -353,6 +353,11 @@
 				<span class="config-btn-after">Qobuz Connect settings</span>
 				$_qobuz_login_msg
 			</div>
+
+			<div class="controls">
+				<a data-toggle="modal" href="#qobuz-clear-credentials" $_qobuz_link_disable><button class="btn btn-medium btn-primary config-btn" $_qobuz_btn_disable>Clear</button></a>
+				<span class="config-btn-after">Stored account credentials</span>
+			</div>
 		</div>
 		<div class="control-group $_feat_upmpdcli">
 			<legend>UPnP Client for MPD</legend>
@@ -600,6 +605,20 @@
 		<div class="modal-footer">
 			<button class="btn" data-dismiss="modal">Cancel</button>
 			<button class="btn btn-primary btn-submit" type="submit" name="spotify_clear_credentials" value="1">Yes</button>
+		</div>
+	</div>
+
+	<div id="qobuz-clear-credentials" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="qobuz-clear-credentials-label" aria-hidden="true">
+		<div class="modal-header"><button aria-label="Close" type="button" class="close" data-dismiss="modal">&times;</button>
+			<h3>Clear stored Qobuz credentials?</h3>
+		</div>
+		<div class="modal-body">
+			<span class="config-help-static">Removes the saved account login. Local pairing does not need one &mdash;
+			the Qobuz app hands this player its own session when casting.</span>
+		</div>
+		<div class="modal-footer">
+			<button class="btn" data-dismiss="modal">Cancel</button>
+			<button class="btn btn-primary btn-submit" type="submit" name="qobuz_clear_credentials" value="1">Yes</button>
 		</div>
 	</div>
 </form>

--- a/www/templates/sys-config.html
+++ b/www/templates/sys-config.html
@@ -643,6 +643,8 @@
 						<tr><td>Auto-config</td><td>/var/log/moode_update.log</td></tr>
 						<tr><td>Spotify</td><td>/var/log/moode_librespot.log</td></tr>
 						<tr><td>AirPlay</td><td>/var/log/moode_shairport-sync.log</td></tr>
+						<tr><td>Qobuz</td><td>/var/log/moode_qbzd.log</td></tr>
+						<tr><td>Qobuz login</td><td>/var/log/moode_qobuz_login.log</td></tr>
 						<tr><td>Squeezelite event</td><td>/var/log/moode_slpower.log</td></tr>
 						<tr><td>Spotify event</td><td>/var/log/moode_spotevent.log</td></tr>
 						<tr><td>AirPlay event</td><td>/var/log/moode_spsevent.log</td></tr>

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -16,7 +16,7 @@
 # The `.moodeN` suffix marks a moOde build of upstream 2.0.2: the binary reports
 # only its Cargo version, so the suffix is recorded in QBZD_BUILD_FILE for the
 # Renderer Config screen to display.
-QBZD_VERSION="2.0.2.moode16"
+QBZD_VERSION="2.0.2.moode17"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 QBZD_BUILD_FILE="/var/local/www/qbzd-build"

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -16,7 +16,7 @@
 # The `.moodeN` suffix marks a moOde build of upstream 2.0.2: the binary reports
 # only its Cargo version, so the suffix is recorded in QBZD_BUILD_FILE for the
 # Renderer Config screen to display.
-QBZD_VERSION="2.0.2.moode15"
+QBZD_VERSION="2.0.2.moode16"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 QBZD_BUILD_FILE="/var/local/www/qbzd-build"

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -16,7 +16,7 @@
 # The `.moodeN` suffix marks a moOde build of upstream 2.0.2: the binary reports
 # only its Cargo version, so the suffix is recorded in QBZD_BUILD_FILE for the
 # Renderer Config screen to display.
-QBZD_VERSION="2.0.2.moode10"
+QBZD_VERSION="2.0.2.moode11"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 QBZD_BUILD_FILE="/var/local/www/qbzd-build"

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -13,7 +13,7 @@
 # Pairing test builds come from the fork's standalone qbzd releases
 # (fork-qbzd-release.yml, tags qbzd-v<version>) until the pairing work is
 # upstream — then revert to vicrodh/qbz and the v<version> tag scheme.
-QBZD_VERSION="2.0.2-pairing.5"
+QBZD_VERSION="2.0.2-pairing.6"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -13,7 +13,7 @@
 # Pairing test builds come from the fork's standalone qbzd releases
 # (fork-qbzd-release.yml, tags qbzd-v<version>) until the pairing work is
 # upstream — then revert to vicrodh/qbz and the v<version> tag scheme.
-QBZD_VERSION="2.0.2-pairing.6"
+QBZD_VERSION="2.0.2-pairing.7"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -16,7 +16,7 @@
 # The `.moodeN` suffix marks a moOde build of upstream 2.0.2: the binary reports
 # only its Cargo version, so the suffix is recorded in QBZD_BUILD_FILE for the
 # Renderer Config screen to display.
-QBZD_VERSION="2.0.2.moode20"
+QBZD_VERSION="2.0.2.moode21"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 QBZD_BUILD_FILE="/var/local/www/qbzd-build"

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -16,7 +16,7 @@
 # The `.moodeN` suffix marks a moOde build of upstream 2.0.2: the binary reports
 # only its Cargo version, so the suffix is recorded in QBZD_BUILD_FILE for the
 # Renderer Config screen to display.
-QBZD_VERSION="2.0.2.moode13"
+QBZD_VERSION="2.0.2.moode14"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 QBZD_BUILD_FILE="/var/local/www/qbzd-build"

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright 2014 The moOde audio player project / Tim Curtis
+#
+# Install the qbzd Qobuz Connect renderer (https://github.com/vicrodh/qbz)
+#
+# Unlike AirPlay/Spotify which are built from source via the pkgbuild repo,
+# qbzd ships prebuilt static binaries so this installer downloads the release
+# for the current architecture, verifies it and installs binary + service.
+#
+
+QBZD_VERSION="2.0.2"
+QBZD_REPO="https://github.com/vicrodh/qbz"
+
+# Initialize the step counter
+STEP=0
+TOTAL_STEPS=4
+
+# Log files
+MOODE_LOG="/var/log/moode.log"
+PLUGIN_LOG="/var/log/moode_plugin.log"
+
+cancel_update () {
+	if [ $# -gt 0 ] ; then
+		message_log "$1"
+	fi
+	message_log "** Exiting install"
+	exit 1
+}
+
+message_log () {
+	echo "$1"
+	TIME=$(date +'%Y%m%d %H%M%S')
+	echo "$TIME updater: $1" >> $MOODE_LOG
+	echo "$TIME updater: $1" >> $PLUGIN_LOG
+}
+
+WD=$(mktemp -d)
+cd $WD || cancel_update "** Unable to create work directory"
+truncate $PLUGIN_LOG --size 0
+message_log "Start install for Qobuz Connect (qbzd $QBZD_VERSION)"
+
+# 1 - Determine architecture
+STEP=$((STEP + 1))
+message_log "** Step $STEP-$TOTAL_STEPS: Determine architecture"
+case "$(uname -m)" in
+	aarch64) ARCH="aarch64";;
+	x86_64) ARCH="amd64";;
+	*) cancel_update "** Unsupported architecture $(uname -m) (qbzd requires 64-bit)";;
+esac
+TARBALL="qbzd-$QBZD_VERSION-linux-$ARCH.tar.gz"
+
+# 2 - Download release
+STEP=$((STEP + 1))
+message_log "** Step $STEP-$TOTAL_STEPS: Download $TARBALL"
+wget -q "$QBZD_REPO/releases/download/v$QBZD_VERSION/$TARBALL" -O "$TARBALL"
+if [ $? -ne 0 ]; then
+	cancel_update "** Download failed"
+fi
+tar -zxf "$TARBALL"
+if [ $? -ne 0 ]; then
+	cancel_update "** Unpack failed"
+fi
+
+# 3 - Install binary
+STEP=$((STEP + 1))
+message_log "** Step $STEP-$TOTAL_STEPS: Install qbzd binary"
+install -Dm755 "qbzd-$QBZD_VERSION-linux-$ARCH/qbzd" /usr/local/bin/qbzd
+if [ $? -ne 0 ]; then
+	cancel_update "** Install failed"
+fi
+
+# 4 - Finish up
+STEP=$((STEP + 1))
+message_log "** Step $STEP-$TOTAL_STEPS: Finish up"
+cd /
+rm -rf $WD
+systemctl daemon-reload
+message_log "** Installed qbzd $(/usr/local/bin/qbzd --version | awk '{print $2}')"
+message_log "Install complete: turn the renderer on in Renderer Config"
+exit 0

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -16,7 +16,7 @@
 # The `.moodeN` suffix marks a moOde build of upstream 2.0.2: the binary reports
 # only its Cargo version, so the suffix is recorded in QBZD_BUILD_FILE for the
 # Renderer Config screen to display.
-QBZD_VERSION="2.0.2.moode8"
+QBZD_VERSION="2.0.2.moode9"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 QBZD_BUILD_FILE="/var/local/www/qbzd-build"

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -16,7 +16,7 @@
 # The `.moodeN` suffix marks a moOde build of upstream 2.0.2: the binary reports
 # only its Cargo version, so the suffix is recorded in QBZD_BUILD_FILE for the
 # Renderer Config screen to display.
-QBZD_VERSION="2.0.2.moode17"
+QBZD_VERSION="2.0.2.moode18"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 QBZD_BUILD_FILE="/var/local/www/qbzd-build"

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -13,7 +13,7 @@
 # Pairing test builds come from the fork's standalone qbzd releases
 # (fork-qbzd-release.yml, tags qbzd-v<version>) until the pairing work is
 # upstream — then revert to vicrodh/qbz and the v<version> tag scheme.
-QBZD_VERSION="2.0.2-pairing.2"
+QBZD_VERSION="2.0.2-pairing.3"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -16,7 +16,7 @@
 # The `.moodeN` suffix marks a moOde build of upstream 2.0.2: the binary reports
 # only its Cargo version, so the suffix is recorded in QBZD_BUILD_FILE for the
 # Renderer Config screen to display.
-QBZD_VERSION="2.0.2.moode9"
+QBZD_VERSION="2.0.2.moode10"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 QBZD_BUILD_FILE="/var/local/www/qbzd-build"

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -13,7 +13,7 @@
 # Pairing test builds come from the fork's standalone qbzd releases
 # (fork-qbzd-release.yml, tags qbzd-v<version>) until the pairing work is
 # upstream — then revert to vicrodh/qbz and the v<version> tag scheme.
-QBZD_VERSION="2.0.2-pairing.4"
+QBZD_VERSION="2.0.2-pairing.5"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -16,7 +16,7 @@
 # The `.moodeN` suffix marks a moOde build of upstream 2.0.2: the binary reports
 # only its Cargo version, so the suffix is recorded in QBZD_BUILD_FILE for the
 # Renderer Config screen to display.
-QBZD_VERSION="2.0.2.moode7"
+QBZD_VERSION="2.0.2.moode8"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 QBZD_BUILD_FILE="/var/local/www/qbzd-build"

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -16,7 +16,7 @@
 # The `.moodeN` suffix marks a moOde build of upstream 2.0.2: the binary reports
 # only its Cargo version, so the suffix is recorded in QBZD_BUILD_FILE for the
 # Renderer Config screen to display.
-QBZD_VERSION="2.0.2.moode18"
+QBZD_VERSION="2.0.2.moode19"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 QBZD_BUILD_FILE="/var/local/www/qbzd-build"

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -10,12 +10,16 @@
 # for the current architecture, verifies it and installs binary + service.
 #
 
-# Pairing test builds come from the fork's standalone qbzd releases
-# (fork-qbzd-release.yml, tags qbzd-v<version>) until the pairing work is
-# upstream — then revert to vicrodh/qbz and the v<version> tag scheme.
-QBZD_VERSION="2.0.2-pairing.7"
+# moOde builds come from the fork's standalone qbzd releases
+# (fork-qbzd-release.yml, tags qbzd-v<version>) while Qobuz Connect pairing is
+# unmerged — then revert to vicrodh/qbz and the plain v<version> tag scheme.
+# The `.moodeN` suffix marks a moOde build of upstream 2.0.2: the binary reports
+# only its Cargo version, so the suffix is recorded in QBZD_BUILD_FILE for the
+# Renderer Config screen to display.
+QBZD_VERSION="2.0.2.moode7"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
+QBZD_BUILD_FILE="/var/local/www/qbzd-build"
 
 # Initialize the step counter
 STEP=0
@@ -74,6 +78,9 @@ install -Dm755 "qbzd-$QBZD_VERSION-linux-$ARCH/qbzd" /usr/local/bin/qbzd
 if [ $? -ne 0 ]; then
 	cancel_update "** Install failed"
 fi
+# Record what was installed: `qbzd --version` reports the Cargo version only,
+# so without this a moOde build is indistinguishable from upstream 2.0.2.
+echo "$QBZD_VERSION" > $QBZD_BUILD_FILE
 
 # 4 - Finish up
 STEP=$((STEP + 1))
@@ -93,6 +100,6 @@ if systemctl list-unit-files qbzd.service > /dev/null 2>&1; then
 	fi
 fi
 systemctl daemon-reload
-message_log "** Installed qbzd $(/usr/local/bin/qbzd --version | awk '{print $2}')"
+message_log "** Installed qbzd $QBZD_VERSION (binary reports $(/usr/local/bin/qbzd --version | awk '{print $2}'))"
 message_log "Install complete: turn the renderer on in Renderer Config"
 exit 0

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -16,7 +16,7 @@
 # The `.moodeN` suffix marks a moOde build of upstream 2.0.2: the binary reports
 # only its Cargo version, so the suffix is recorded in QBZD_BUILD_FILE for the
 # Renderer Config screen to display.
-QBZD_VERSION="2.0.2.moode14"
+QBZD_VERSION="2.0.2.moode15"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 QBZD_BUILD_FILE="/var/local/www/qbzd-build"

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -16,7 +16,7 @@
 # The `.moodeN` suffix marks a moOde build of upstream 2.0.2: the binary reports
 # only its Cargo version, so the suffix is recorded in QBZD_BUILD_FILE for the
 # Renderer Config screen to display.
-QBZD_VERSION="2.0.2.moode12"
+QBZD_VERSION="2.0.2.moode13"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 QBZD_BUILD_FILE="/var/local/www/qbzd-build"

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -80,6 +80,18 @@ STEP=$((STEP + 1))
 message_log "** Step $STEP-$TOTAL_STEPS: Finish up"
 cd /
 rm -rf $WD
+# The standalone qbzd tarball ships a systemd unit for running the daemon on
+# its own. Under moOde the worker owns the daemon lifecycle (startQobuz), so an
+# enabled unit is a second instance competing for the audio device — and its
+# ExecStartPre clears cfg_system.qbzactive, which blanks the Renderer Active
+# overlay every restart attempt. Leave the unit file in place, just disabled.
+if systemctl list-unit-files qbzd.service > /dev/null 2>&1; then
+	if [ "$(systemctl is-enabled qbzd.service 2>/dev/null)" = "enabled" ] || \
+	   [ "$(systemctl is-active qbzd.service 2>/dev/null)" = "active" ]; then
+		message_log "** Disabling qbzd.service (moOde manages the daemon itself)"
+		systemctl disable --now qbzd.service > /dev/null 2>&1
+	fi
+fi
 systemctl daemon-reload
 message_log "** Installed qbzd $(/usr/local/bin/qbzd --version | awk '{print $2}')"
 message_log "Install complete: turn the renderer on in Renderer Config"

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -16,7 +16,7 @@
 # The `.moodeN` suffix marks a moOde build of upstream 2.0.2: the binary reports
 # only its Cargo version, so the suffix is recorded in QBZD_BUILD_FILE for the
 # Renderer Config screen to display.
-QBZD_VERSION="2.0.2.moode11"
+QBZD_VERSION="2.0.2.moode12"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 QBZD_BUILD_FILE="/var/local/www/qbzd-build"

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -16,7 +16,7 @@
 # The `.moodeN` suffix marks a moOde build of upstream 2.0.2: the binary reports
 # only its Cargo version, so the suffix is recorded in QBZD_BUILD_FILE for the
 # Renderer Config screen to display.
-QBZD_VERSION="2.0.2.moode21"
+QBZD_VERSION="2.0.2.moode26"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 QBZD_BUILD_FILE="/var/local/www/qbzd-build"

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -10,8 +10,12 @@
 # for the current architecture, verifies it and installs binary + service.
 #
 
-QBZD_VERSION="2.0.2"
-QBZD_REPO="https://github.com/vicrodh/qbz"
+# Pairing test builds come from the fork's standalone qbzd releases
+# (fork-qbzd-release.yml, tags qbzd-v<version>) until the pairing work is
+# upstream — then revert to vicrodh/qbz and the v<version> tag scheme.
+QBZD_VERSION="2.0.2-pairing.1"
+QBZD_REPO="https://github.com/PhilipVinc/qbz"
+QBZD_TAG="qbzd-v$QBZD_VERSION"
 
 # Initialize the step counter
 STEP=0
@@ -54,7 +58,7 @@ TARBALL="qbzd-$QBZD_VERSION-linux-$ARCH.tar.gz"
 # 2 - Download release
 STEP=$((STEP + 1))
 message_log "** Step $STEP-$TOTAL_STEPS: Download $TARBALL"
-wget -q "$QBZD_REPO/releases/download/v$QBZD_VERSION/$TARBALL" -O "$TARBALL"
+wget -q "$QBZD_REPO/releases/download/$QBZD_TAG/$TARBALL" -O "$TARBALL"
 if [ $? -ne 0 ]; then
 	cancel_update "** Download failed"
 fi

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -16,7 +16,7 @@
 # The `.moodeN` suffix marks a moOde build of upstream 2.0.2: the binary reports
 # only its Cargo version, so the suffix is recorded in QBZD_BUILD_FILE for the
 # Renderer Config screen to display.
-QBZD_VERSION="2.0.2.moode19"
+QBZD_VERSION="2.0.2.moode20"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 QBZD_BUILD_FILE="/var/local/www/qbzd-build"

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -13,7 +13,7 @@
 # Pairing test builds come from the fork's standalone qbzd releases
 # (fork-qbzd-release.yml, tags qbzd-v<version>) until the pairing work is
 # upstream — then revert to vicrodh/qbz and the v<version> tag scheme.
-QBZD_VERSION="2.0.2-pairing.1"
+QBZD_VERSION="2.0.2-pairing.2"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 

--- a/www/util/qobuz-installer.sh
+++ b/www/util/qobuz-installer.sh
@@ -13,7 +13,7 @@
 # Pairing test builds come from the fork's standalone qbzd releases
 # (fork-qbzd-release.yml, tags qbzd-v<version>) until the pairing work is
 # upstream — then revert to vicrodh/qbz and the v<version> tag scheme.
-QBZD_VERSION="2.0.2-pairing.3"
+QBZD_VERSION="2.0.2-pairing.4"
 QBZD_REPO="https://github.com/PhilipVinc/qbz"
 QBZD_TAG="qbzd-v$QBZD_VERSION"
 

--- a/www/util/renderer-onoff.php
+++ b/www/util/renderer-onoff.php
@@ -31,6 +31,9 @@ switch ($option) {
 	case '--deezer':
 		onoffDeezer($onoff);
 		break;
+	case '--qobuz':
+		onoffQobuz($onoff);
+		break;
 	case '--squeezelite':
 		onoffSqueezelite($onoff);
 		break;
@@ -48,16 +51,17 @@ switch ($option) {
 			fwrite(STDERR, "This command requires sudo to print the help\n");
 			return;
 		}
-		//[--bluetooth | --airplay | --spotify | --deezer | --upnp | --squeezelite | --plexamp | --roonbridge]
+		//[--bluetooth | --airplay | --spotify | --deezer | --qobuz | --upnp | --squeezelite | --plexamp | --roonbridge]
 		$btArg = $_SESSION['feat_bitmask'] & FEAT_BLUETOOTH ? "--bluetooth\tTurn Bluetooth On/Off\n" : "";
 		$apArg = $_SESSION['feat_bitmask'] & FEAT_AIRPLAY ? " --airplay\tTurn AirPlay On/Off\n" : "";
 		$spArg = $_SESSION['feat_bitmask'] & FEAT_SPOTIFY ? " --spotify\tTurn Spotify Connect On/Off\n" : "";
 		$dzArg = $_SESSION['feat_bitmask'] & FEAT_DEEZER ? " --deezer\tTurn Deezer ConnectOn/Off\n" : "";
+		$qbArg = $_SESSION['feat_bitmask'] & FEAT_QOBUZ ? " --qobuz\tTurn Qobuz Connect On/Off\n" : "";
 		$upArg = $_SESSION['feat_bitmask'] & FEAT_UPMPDCLI ? " --upnp\t\tTurn UPnP On/Off\n" : "";
 		$slArg = $_SESSION['feat_bitmask'] & FEAT_SQUEEZELITE ? " --squeezelite\tTurn Squeezelite On/Off\n" : "";
 		$paArg = $_SESSION['feat_bitmask'] & FEAT_PLEXAMP ? " --plexamp\tTurn Plexamp On/Off\n" : "";
 		$rbArg = $_SESSION['feat_bitmask'] & FEAT_ROONBRIDGE ? " --roonbridge\tTurn RoonBridge On/Off\n" : "";
-		$rendererList = ' '. $btArg . $apArg . $spArg . $dzArg . $upArg . $slArg . $paArg . $rbArg .
+		$rendererList = ' '. $btArg . $apArg . $spArg . $dzArg . $qbArg . $upArg . $slArg . $paArg . $rbArg .
 		" --help\t\tPrint this help text\n";
 		echo
 "Usage: renderer-onoff [OPTION] [on|off]
@@ -120,6 +124,16 @@ function onoffDeezer($onoff) {
 	} else if ($onoff == 'off' && $_SESSION['deezersvc'] == '1') {
 		phpSession('write', 'deezersvc', '0');
 		stopDeezer();
+	}
+}
+
+function onoffQobuz($onoff) {
+	if ($onoff == 'on' && $_SESSION['qobuzsvc'] == '0') {
+		phpSession('write', 'qobuzsvc', '1');
+		startQobuz();
+	} else if ($onoff == 'off' && $_SESSION['qobuzsvc'] == '1') {
+		phpSession('write', 'qobuzsvc', '0');
+		stopQobuz();
 	}
 }
 

--- a/www/util/restart-renderer.php
+++ b/www/util/restart-renderer.php
@@ -33,6 +33,9 @@ switch ($option) {
 	case '--deezer':
 		restartDeezer($stopOnly);
 		break;
+	case '--qobuz':
+		restartQobuz($stopOnly);
+		break;
 	case '--squeezelite':
 		restartSqueezelite($stopOnly);
 		break;
@@ -50,16 +53,17 @@ switch ($option) {
 			fwrite(STDERR, "This command requires sudo to print the help\n");
 			return;
 		}
-		//[--bluetooth | --airplay | --spotify | --deezer | --upnp | --squeezelite | --plexamp | --roonbridge]
+		//[--bluetooth | --airplay | --spotify | --deezer | --qobuz | --upnp | --squeezelite | --plexamp | --roonbridge]
 		$btArg = $_SESSION['feat_bitmask'] & FEAT_BLUETOOTH ? "--bluetooth\tRestart Bluetooth\n" : "";
 		$apArg = $_SESSION['feat_bitmask'] & FEAT_AIRPLAY ? " --airplay\tRestart AirPlay\n" : "";
 		$spArg = $_SESSION['feat_bitmask'] & FEAT_SPOTIFY ? " --spotify\tRestart Spotify Connect\n" : "";
 		$dzArg = $_SESSION['feat_bitmask'] & FEAT_DEEZER ? " --deezer\tRestart Deezer Connect\n" : "";
+		$qbArg = $_SESSION['feat_bitmask'] & FEAT_QOBUZ ? " --qobuz\tRestart Qobuz Connect\n" : "";
 		$upArg = $_SESSION['feat_bitmask'] & FEAT_UPMPDCLI ? " --upnp\t\tRestart UPnP\n" : "";
 		$slArg = $_SESSION['feat_bitmask'] & FEAT_SQUEEZELITE ? " --squeezelite\tRestart Squeezelite\n" : "";
 		$paArg = $_SESSION['feat_bitmask'] & FEAT_PLEXAMP ? " --plexamp\tRestart Plexamp\n" : "";
 		$rbArg = $_SESSION['feat_bitmask'] & FEAT_ROONBRIDGE ? " --roonbridge\tRestart RoonBridge\n" : "";
-		$rendererList = ' '. $btArg . $apArg . $spArg . $dzArg . $upArg . $slArg . $paArg . $rbArg .
+		$rendererList = ' '. $btArg . $apArg . $spArg . $dzArg . $qbArg . $upArg . $slArg . $paArg . $rbArg .
 		" --help\t\tPrint this help text\n";
 		echo
 "Usage: restart-renderer [OPTION] [--stop]
@@ -110,6 +114,13 @@ function restartDeezer($stopOnly) {
 	stopDeezer();
 	if ($stopOnly === false) {
 		startDeezer();
+	}
+}
+
+function restartQobuz($stopOnly) {
+	stopQobuz();
+	if ($stopOnly === false) {
+		startQobuz();
 	}
 }
 

--- a/www/util/send-fecmd.php
+++ b/www/util/send-fecmd.php
@@ -17,7 +17,7 @@ if ($option == '') {
 "Usage: send-fecmd.php [command]
 Send a command to the front-end\n";
 } else {
-	if (str_contains($argv[1], 'update_deezmeta') || str_contains($argv[1], 'update_spotmeta')) {
+	if (str_contains($argv[1], 'update_deezmeta') || str_contains($argv[1], 'update_qbzmeta') || str_contains($argv[1], 'update_spotmeta')) {
 		// Special handling for certain commands
 		$cmd = htmlspecialchars($argv[1], ENT_NOQUOTES);
 		sendFECmd($cmd);

--- a/www/util/sysinfo.sh
+++ b/www/util/sysinfo.sh
@@ -126,6 +126,9 @@ AUDIO_PARAMETERS() {
 	if [ $(($feat_bitmask & $FEAT_DEEZER)) -ne 0 ]; then
 		echo -e "\nDeezer Connect\t\t= $deezersvc\c"
 	fi
+	if [ $(($feat_bitmask & $FEAT_QOBUZ)) -ne 0 ]; then
+		echo -e "\nQobuz Connect\t\t= $qobuzsvc\c"
+	fi
 	if [ $(($feat_bitmask & $FEAT_SQUEEZELITE)) -ne 0 ]; then
 		echo -e "\nSqueezelite\t\t= $slsvc\c"
 	fi
@@ -375,6 +378,14 @@ RENDERER_SETTINGS() {
 		echo -e "\nResume MPD\t\t= $rsmafterdeez\n"
 	fi
 
+	if [ $(($feat_bitmask & $FEAT_QOBUZ)) -ne 0 ]; then
+		QBZVER="$(qbzd --version | awk -F" " '{print $2}')"
+		echo -e "Q O B U Z   C O N N E C T"
+		echo -e "\nVersion\t\t\t= $QBZVER\c"
+		echo -e "\nFriendly name\t\t= $qobuzname\c"
+		echo -e "\nResume MPD\t\t= $rsmafterqbz\n"
+	fi
+
 	if [ $(($feat_bitmask & $FEAT_SQUEEZELITE)) -ne 0 ]; then
 		SL=$(squeezelite -? | grep "Squeezelite" | awk '{print $2}' | cut -d "," -f1)
 		squeezelite -? | grep "\-Z" >/dev/null && SLT="\"DSD/SRC enabled\"" || SLT="\"DSD/SRC disabled\""
@@ -471,6 +482,7 @@ FEAT_PLEXAMP=8192
 FEAT_BLUETOOTH=16384
 FEAT_MULTIROOM=65536
 FEAT_PEPPYDISPLAY=131072
+FEAT_QOBUZ=262144
 
 # Selective resampling bitmask
 SOX_UPSAMPLE_ALL=3			# Upsample if source < target rate
@@ -941,6 +953,10 @@ library_onetouch_pl=${arr[171]}
 scnsaver_mode=${arr[172]}
 scnsaver_layout=${arr[173]}
 scnsaver_xmeta=${arr[174]}
+rsmafterqbz=${arr[175]}
+qbzactive=${arr[176]}
+[[ "${arr[177]}" = "1" ]] && qobuzsvc="On" || qobuzsvc="Off"
+qobuzname=${arr[178]}
 # Session only vars
 timezone=$(moodeutl -d -gv timezone)
 value=$(moodeutl -d -gv rotaryenc)

--- a/www/util/sysutil.sh
+++ b/www/util/sysutil.sh
@@ -148,6 +148,8 @@ if [[ $1 = "clear-syslogs" ]]; then
 	truncate /var/log/samba/log.smbd --size 0
 	truncate /var/log/moode_shairport-sync.log --size 0
 	truncate /var/log/moode_librespot.log --size 0
+	truncate /var/log/moode_qbzd.log --size 0
+	truncate /var/log/moode_qobuz_login.log --size 0
 	truncate /var/log/moode_mountmon.log --size 0
 	truncate /var/log/moode_spotevent.log --size 0
 	truncate /var/log/moode_spsevent.log --size 0


### PR DESCRIPTION
Hello, 

With the help of Claude I spent the last 2 days trying to get qbzd working as a renderer inside of Moode.
To make it work in the same way as Spotify connect (no login on the moode side), and to fix several issues in how qbzd reports it's state (Buffering, loading, etc) I had to do a lot of changes to qbzd. 

I will eventually try to upstream those, but as that would require a bit more time which I won't have over the next few weeks, so it's more of a longer term plan. 
Moreover, there's still a few issues I'd like to address, so the code for now lives at https://github.com/PhilipVinc/qbz/tree/feature/external/qbzd-connect-pairing and I'm tagging releases at https://github.com/PhilipVinc/qbz/releases .

This PR is the moode side of things. Also claude-generated largely, with a lot of steering and manual testing to identify issues. 
The implementation basically follows the same hook system as the other renderers. There's nothing fancy there (note that I did not try the multi receiver implementation).

Would you be willing to accept this PR, assuming I clean it up to standards, and assuming that I will be venturing my own fork of qbzd until I manage to upstream the changes, or that would not be acceptable to you?